### PR TITLE
 Updated netlink code for linux kernel 2.6.18

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -184,6 +184,7 @@ static int _get_usbfs_fd(struct libusb_device *dev, mode_t mode, int silent)
 	struct libusb_context *ctx = DEVICE_CTX(dev);
 	char path[PATH_MAX];
 	int fd;
+	int delay = 10000;
 
 	if (usbdev_names)
 		snprintf(path, PATH_MAX, "%s/usbdev%d.%d",
@@ -196,6 +197,18 @@ static int _get_usbfs_fd(struct libusb_device *dev, mode_t mode, int silent)
 	if (fd != -1)
 		return fd; /* Success */
 
+	if (errno == ENOENT) {
+		if (!silent) 
+			usbi_err(ctx, "File doesn't exist, wait %d ms and try again\n", delay/1000);
+   
+		/* Wait 10ms for USB device path creation.*/
+		usleep(delay);
+
+		fd = open(path, mode);
+		if (fd != -1)
+			return fd; /* Success */
+	}
+	
 	if (!silent) {
 		usbi_err(ctx, "libusb couldn't open USB device %s: %s",
 			 path, strerror(errno));


### PR DESCRIPTION
   Updated netlink code to parse events that do not contain BUSNUM and DEVNUM but do have a DEVICE parameter.

 These netlink events are now parsed:

 add@/devices/platform/brcm-ohci-0.0/usb3/3-2/3-2:1.0
 ACTION=add
 DEVPATH=/devices/platform/brcm-ohci-0.0/usb3/3-2/3-2:1.0
 SUBSYSTEM=usb
 SEQNUM=290
 PHYSDEVBUS=usb
 DEVICE=/proc/bus/usb/003/003
 PRODUCT=45e/28e/114
 TYPE=255/255/255
 INTERFACE=255/93/1

 Also added a retry when opening the device file to work around a race condition with the kernel
