### PR TITLE
Fixed incorrect error message in fxload.

### DIFF
--- a/examples/fxload.c
+++ b/examples/fxload.c
@@ -147,7 +147,7 @@ int main(int argc, char*argv[])
 		return print_usage(-1);
 	}
 	if ((device_id != NULL) && (device_path != NULL)) {
-		logerror("only one of -d or -a can be specified\n");
+		logerror("only one of -d or -p can be specified\n");
 		return print_usage(-1);
 	}
 


### PR DESCRIPTION
```
fprintf(stderr, "  -d <vid:pid>    -- Target device, as an USB VID:PID\n");
fprintf(stderr, "  -p <bus,addr>   -- Target device, as a libusbx bus number and device address path\n");
```
