### PR TITLE
Remove -c flag. Erroneous output caused on android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,9 +121,6 @@ linux)
 
 case $is_backend_android in
 yes)
-	dnl some pthread functions is in libc
-	THREAD_CFLAGS="-c"
-	LIBS="${LIBS} -c"
 	dnl there are gettimeofday function but configure doesn't seem to be able to find it.
 	AC_DEFINE([HAVE_GETTIMEOFDAY], [1], [Define if you have gettimeofday])
 	;;


### PR DESCRIPTION
While cross-building for android, the -c flag was causing errors.
This -c option ends up in Libs.private of libusb-1.0.pc file.
On its usage, it is interpreted as "Compile and assemble, but do not link"
option of gcc. Usage of -c in this way might be unintended.
Hence, removing this option.

Signed-off-by: Venkatesh Shukla <venkatesh.shukla.eee11@iitbhu.ac.in>