### PR TITLE
Remove unnecessary \n from log messages

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2307,8 +2307,8 @@ void usbi_log_v(struct libusb_context *ctx, enum libusb_log_level level,
 	usbi_gettimeofday(&now, NULL);
 	if ((global_debug) && (!has_debug_header_been_displayed)) {
 		has_debug_header_been_displayed = 1;
-		usbi_log_str(ctx, LIBUSB_LOG_LEVEL_DEBUG, "[timestamp] [threadID] facility level [function call] <message>\n");
-		usbi_log_str(ctx, LIBUSB_LOG_LEVEL_DEBUG, "--------------------------------------------------------------------------------\n");
+		usbi_log_str(ctx, LIBUSB_LOG_LEVEL_DEBUG, "[timestamp] [threadID] facility level [function call] <message>" USBI_LOG_LINE_END);
+		usbi_log_str(ctx, LIBUSB_LOG_LEVEL_DEBUG, "--------------------------------------------------------------------------------" USBI_LOG_LINE_END);
 	}
 	if (now.tv_usec < timestamp_origin.tv_usec) {
 		now.tv_sec--;

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -455,7 +455,7 @@ static int parse_configuration(struct libusb_context *ctx,
 					(header.bDescriptorType == LIBUSB_DT_DEVICE))
 				break;
 
-			usbi_dbg("skipping descriptor 0x%x\n", header.bDescriptorType);
+			usbi_dbg("skipping descriptor 0x%x", header.bDescriptorType);
 			buffer += header.bLength;
 			size -= header.bLength;
 		}

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2109,7 +2109,7 @@ redo_poll:
 	else if (r == -1 && errno == EINTR)
 		return LIBUSB_ERROR_INTERRUPTED;
 	else if (r < 0) {
-		usbi_err(ctx, "poll failed %d err=%d\n", r, errno);
+		usbi_err(ctx, "poll failed %d err=%d", r, errno);
 		return LIBUSB_ERROR_IO;
 	}
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -246,7 +246,7 @@ static usb_device_t **darwin_device_from_service (io_service_t service)
                                              &score);
 
   if (kIOReturnSuccess != result || !plugInInterface) {
-    usbi_dbg ("could not set up plugin for service: %s\n", darwin_error_str (result));
+    usbi_dbg ("could not set up plugin for service: %s", darwin_error_str (result));
     return NULL;
   }
 
@@ -998,7 +998,7 @@ static void darwin_close (struct libusb_device_handle *dev_handle) {
 
   if (dpriv->open_count == 0) {
     /* something is probably very wrong if this is the case */
-    usbi_err (HANDLE_CTX (dev_handle), "Close called on a device that was not open!\n");
+    usbi_err (HANDLE_CTX (dev_handle), "Close called on a device that was not open!");
     return;
   }
 

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -198,7 +198,7 @@ static int _get_usbfs_fd(struct libusb_device *dev, mode_t mode, int silent)
 
 	if (errno == ENOENT) {
 		if (!silent) 
-			usbi_err(ctx, "File doesn't exist, wait %d ms and try again\n", delay/1000);
+			usbi_err(ctx, "File doesn't exist, wait %d ms and try again", delay/1000);
    
 		/* Wait 10ms for USB device path creation.*/
 		usleep(delay);
@@ -2583,7 +2583,7 @@ static int op_handle_events(struct libusb_context *ctx,
 		}
 
 		if (!hpriv || hpriv->fd != pollfd->fd) {
-			usbi_err(ctx, "cannot find handle for fd %d\n",
+			usbi_err(ctx, "cannot find handle for fd %d",
 				 pollfd->fd);
 			continue;
 		}

--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -333,7 +333,7 @@ struct winfd usbi_create_fd(HANDLE handle, int access_mode, struct usbi_transfer
 	wfd.cancel_fn = cancel_fn;
 
 	if ((access_mode != RW_READ) && (access_mode != RW_WRITE)) {
-		usbi_warn(NULL, "only one of RW_READ or RW_WRITE are supported.\n"
+		usbi_warn(NULL, "only one of RW_READ or RW_WRITE are supported. "
 			"If you want to poll for R/W simultaneously, create multiple fds from the same handle.");
 		return INVALID_WINFD;
 	}

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -1555,7 +1555,7 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 //#define ENUM_DEBUG
 #ifdef ENUM_DEBUG
 		const char *passname[] = { "HCD", "HUB", "GEN", "DEV", "HID", "EXT" };
-		usbi_dbg("\n#### PROCESSING %ss %s", passname[(pass<=HID_PASS)?pass:HID_PASS+1],
+		usbi_dbg("#### PROCESSING %ss %s", passname[(pass<=HID_PASS)?pass:HID_PASS+1],
 			(pass!=GEN_PASS)?guid_to_string(guid[pass]):"");
 #endif
 		for (i = 0; ; i++) {
@@ -2698,7 +2698,7 @@ static int winusbx_init(int sub_api, struct libusb_context *ctx)
 		if (h == NULL) {
 			h = LoadLibraryA("WinUSB");
 		}		if (h == NULL) {
-			usbi_warn(ctx, "WinUSB DLL is not available either,\n"
+			usbi_warn(ctx, "WinUSB DLL is not available either, "
 				"you will not be able to access devices outside of enumeration");
 			return LIBUSB_ERROR_NOT_FOUND;
 		}


### PR DESCRIPTION
The final end-of-line marker is added in usbi_log_v() using the
USBI_LOG_LINE_END define.

Also don't mix hardcoded \n and USBI_LOG_LINE_END in usbi_log_v().