### PR TITLE
Use standard struct timespec on vs2015 and above

### DIFF
--- a/libusb/os/threads_windows.h
+++ b/libusb/os/threads_windows.h
@@ -43,11 +43,15 @@ typedef struct usbi_cond_t_ usbi_cond_t;
 // We *were* getting timespec from pthread.h:
 #if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED))
 #define HAVE_STRUCT_TIMESPEC 1
+#if _MSC_VER >= 1900
+#include <time.h>
+#else
 #define _TIMESPEC_DEFINED 1
 struct timespec {
 		long tv_sec;
 		long tv_nsec;
 };
+#endif
 #endif /* HAVE_STRUCT_TIMESPEC | _TIMESPEC_DEFINED */
 
 // We *were* getting ETIMEDOUT from pthread.h:


### PR DESCRIPTION
Currently libusb will fail to compile with vs2015, so it should be updated before vs2015 is released, hopefully...