### PR TITLE
Remove unused member add_iso_packet_size from struct usbi_os_backend

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1249,8 +1249,7 @@ struct libusb_transfer * LIBUSB_CALL libusb_alloc_transfer(
 	int iso_packets)
 {
 	struct libusb_transfer *transfer;
-	size_t os_alloc_size = usbi_backend->transfer_priv_size
-		+ (usbi_backend->add_iso_packet_size * iso_packets);
+	size_t os_alloc_size = usbi_backend->transfer_priv_size;
 	size_t alloc_size = sizeof(struct usbi_transfer)
 		+ sizeof(struct libusb_transfer)
 		+ (sizeof(struct libusb_iso_packet_descriptor) * iso_packets)

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1077,12 +1077,6 @@ struct usbi_os_backend {
 	 * usbi_transfer_get_os_priv() on the appropriate usbi_transfer instance.
 	 */
 	size_t transfer_priv_size;
-
-	/* Mumber of additional bytes for os_priv for each iso packet.
-	 * Can your backend use this? */
-	/* FIXME: linux can't use this any more. if other OS's cannot either,
-	 * then remove this */
-	size_t add_iso_packet_size;
 };
 
 extern const struct usbi_os_backend * const usbi_backend;

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1966,5 +1966,4 @@ const struct usbi_os_backend darwin_backend = {
         .device_priv_size = sizeof(struct darwin_device_priv),
         .device_handle_priv_size = sizeof(struct darwin_device_handle_priv),
         .transfer_priv_size = sizeof(struct darwin_transfer_priv),
-        .add_iso_packet_size = 0,
 };

--- a/libusb/os/haiku/haiku_usb_raw.cpp
+++ b/libusb/os/haiku/haiku_usb_raw.cpp
@@ -252,5 +252,4 @@ const struct usbi_os_backend haiku_usb_raw_backend = {
 	/*.device_priv_size =*/ sizeof(USBDevice*),
 	/*.device_handle_priv_size =*/ sizeof(USBDeviceHandle*),
 	/*.transfer_priv_size =*/ sizeof(USBTransfer*),
-	/*.add_iso_packet_size =*/ 0,
 };

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2683,5 +2683,4 @@ const struct usbi_os_backend linux_usbfs_backend = {
 	.device_priv_size = sizeof(struct linux_device_priv),
 	.device_handle_priv_size = sizeof(struct linux_device_handle_priv),
 	.transfer_priv_size = sizeof(struct linux_transfer_priv),
-	.add_iso_packet_size = 0,
 };

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -131,7 +131,6 @@ const struct usbi_os_backend netbsd_backend = {
 	sizeof(struct device_priv),
 	sizeof(struct handle_priv),
 	0,				/* transfer_priv_size */
-	0,				/* add_iso_packet_size */
 };
 
 int

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -134,7 +134,6 @@ const struct usbi_os_backend openbsd_backend = {
 	sizeof(struct device_priv),
 	sizeof(struct handle_priv),
 	0,				/* transfer_priv_size */
-	0,				/* add_iso_packet_size */
 };
 
 #define DEVPATH	"/dev/"

--- a/libusb/os/wince_usb.c
+++ b/libusb/os/wince_usb.c
@@ -866,5 +866,4 @@ const struct usbi_os_backend wince_backend = {
 	sizeof(struct wince_device_priv),
 	sizeof(struct wince_device_handle_priv),
 	sizeof(struct wince_transfer_priv),
-	0,
 };

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -2480,7 +2480,6 @@ const struct usbi_os_backend windows_backend = {
 	sizeof(struct windows_device_priv),
 	sizeof(struct windows_device_handle_priv),
 	sizeof(struct windows_transfer_priv),
-	0,
 };
 
 


### PR DESCRIPTION
The member add_iso_packet_size of struct usbi_os_backend is set to 0 in
all backends and thus has no actual use. This has been the case since
commit ad6e2b71 ("Linux: fire multiple URBs at once for split
transfers").

Also, the comment above the member actually states the fact that it is
unused and could potentially be removed, so remove it.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>