### PR TITLE
Windows: Fixes for corner case leaks when reusing device references

### DIFF
--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -1735,6 +1735,13 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 				} else {
 					usbi_dbg("found existing device for session [%X] (%d.%d)",
 						session_id, dev->bus_number, dev->device_address);
+					if(_device_priv(dev)->parent_dev != parent_dev)
+						usbi_err(ctx,"program assertion failed - existing device should share parent");
+					else {
+						/* we hold a reference to parent_dev instance, but this device already
+						   has a parent_dev reference (only one per child) */
+						libusb_unref_device(parent_dev);
+					}
 				}
 				// Keep track of devices that need unref
 				unref_list[unref_cur++] = dev;


### PR DESCRIPTION
I noticed my libusb-based program was leaking memory under Windows and tracked it down to leaks that occur when libusb_get_device_list() reuses existing device references.

A test program that demonstrates the problem is here:
https://gist.github.com/projectgus/c9e29f90397202dbba38

* When run on Windows with current libusb the debug output includes "some libusb_devices were leaked" near the end, even though all instances are released. (related to 0cbb891)
* When run under drmemory leaks are reported on close. (related to f6b348f)
* If run with the RUN_INFINITE variable changed to 1 then the memory usage will climb indefinitely.

The three commits in this PR fix these problems for me.

I've been cross-compiling with mingw and testing on Windows 7 and XP 32-bit. But I don't think those details are relevant.

BTW, thanks very much to everyone who works on libusb. It's marvellous being able to write cross-platform code for something as complex as USB, and have it run everywhere. I am even more admiring of libusb after today, having now become more familiar with the actual Windows USB stack. ;)