### PR TITLE
Miscellaneous fixes

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -222,7 +222,6 @@ static int parse_interface(libusb_context *ctx,
 	int r;
 	int parsed = 0;
 	int interface_number = -1;
-	size_t tmp;
 	struct usb_descriptor_header header;
 	struct libusb_interface_descriptor *ifp;
 	unsigned char *begin;
@@ -323,15 +322,13 @@ static int parse_interface(libusb_context *ctx,
 
 		if (ifp->bNumEndpoints > 0) {
 			struct libusb_endpoint_descriptor *endpoint;
-			tmp = ifp->bNumEndpoints * sizeof(struct libusb_endpoint_descriptor);
-			endpoint = malloc(tmp);
+			endpoint = calloc(ifp->bNumEndpoints, sizeof(struct libusb_endpoint_descriptor));
 			ifp->endpoint = endpoint;
 			if (!endpoint) {
 				r = LIBUSB_ERROR_NO_MEM;
 				goto err;
 			}
 
-			memset(endpoint, 0, tmp);
 			for (i = 0; i < ifp->bNumEndpoints; i++) {
 				r = parse_endpoint(ctx, endpoint + i, buffer, size,
 					host_endian);
@@ -381,7 +378,6 @@ static int parse_configuration(struct libusb_context *ctx,
 {
 	int i;
 	int r;
-	size_t tmp;
 	struct usb_descriptor_header header;
 	struct libusb_interface *usb_interface;
 
@@ -411,13 +407,11 @@ static int parse_configuration(struct libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	tmp = config->bNumInterfaces * sizeof(struct libusb_interface);
-	usb_interface = malloc(tmp);
+	usb_interface = calloc(config->bNumInterfaces, sizeof(struct libusb_interface));
 	config->interface = usb_interface;
-	if (!config->interface)
+	if (!usb_interface)
 		return LIBUSB_ERROR_NO_MEM;
 
-	memset(usb_interface, 0, tmp);
 	buffer += config->bLength;
 	size -= config->bLength;
 

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1350,7 +1350,7 @@ disarm:
 #else
 static int arm_timerfd_for_next_timeout(struct libusb_context *ctx)
 {
-	(void)ctx;
+	UNUSED(ctx);
 	return 0;
 }
 #endif
@@ -2452,7 +2452,7 @@ int API_EXPORTED libusb_pollfds_handle_timeouts(libusb_context *ctx)
 	USBI_GET_CONTEXT(ctx);
 	return usbi_using_timerfd(ctx);
 #else
-	(void)ctx;
+	UNUSED(ctx);
 	return 0;
 #endif
 }

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1407,14 +1407,14 @@ static int darwin_kernel_driver_active(struct libusb_device_handle *dev_handle, 
 
 /* attaching/detaching kernel drivers is not currently supported (maybe in the future?) */
 static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle, int interface) {
-  (void)dev_handle;
-  (void)interface;
+  UNUSED(dev_handle);
+  UNUSED(interface);
   return LIBUSB_ERROR_NOT_SUPPORTED;
 }
 
 static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, int interface) {
-  (void)dev_handle;
-  (void)interface;
+  UNUSED(dev_handle);
+  UNUSED(interface);
   return LIBUSB_ERROR_NOT_SUPPORTED;
 }
 

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -317,7 +317,7 @@ static int linux_netlink_read_message(void)
 
 	/* signal device is available (or not) to all contexts */
 	if (detached)
-		linux_device_disconnected(busnum, devaddr, sys_name);
+		linux_device_disconnected(busnum, devaddr);
 	else
 		linux_hotplug_enumerate(busnum, devaddr, sys_name);
 

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -335,8 +335,7 @@ static void *linux_netlink_event_thread_main(void *arg)
 		  .events = POLLIN },
 	};
 
-	/* silence compiler warning */
-	(void) arg;
+	UNUSED(arg);
 
 	while (poll(fds, 2, -1) >= 0) {
 		if (fds[0].revents & POLLIN) {

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -63,28 +63,28 @@ static void *linux_netlink_event_thread_main(void *arg);
 
 static struct sockaddr_nl snl = { .nl_family=AF_NETLINK, .nl_groups=KERNEL };
 
-static int set_fd_cloexec_nb (int fd)
+static int set_fd_cloexec_nb(int fd)
 {
 	int flags;
 
 #if defined(FD_CLOEXEC)
-	flags = fcntl (linux_netlink_socket, F_GETFD);
+	flags = fcntl(fd, F_GETFD);
 	if (0 > flags) {
 		return -1;
 	}
 
 	if (!(flags & FD_CLOEXEC)) {
-		fcntl (linux_netlink_socket, F_SETFD, flags | FD_CLOEXEC);
+		fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
 	}
 #endif
 
-	flags = fcntl (linux_netlink_socket, F_GETFL);
+	flags = fcntl(fd, F_GETFL);
 	if (0 > flags) {
 		return -1;
 	}
 
 	if (!(flags & O_NONBLOCK)) {
-		fcntl (linux_netlink_socket, F_SETFL, flags | O_NONBLOCK);
+		fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 	}
 
 	return 0;

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -61,7 +61,7 @@ static pthread_t libusb_linux_event_thread;
 
 static void *linux_netlink_event_thread_main(void *arg);
 
-struct sockaddr_nl snl = { .nl_family=AF_NETLINK, .nl_groups=KERNEL };
+static struct sockaddr_nl snl = { .nl_family=AF_NETLINK, .nl_groups=KERNEL };
 
 static int set_fd_cloexec_nb (int fd)
 {

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -240,7 +240,7 @@ static void udev_hotplug_event(struct udev_device* udev_dev)
 		if (strncmp(udev_action, "add", 3) == 0) {
 			linux_hotplug_enumerate(busnum, devaddr, sys_name);
 		} else if (detached) {
-			linux_device_disconnected(busnum, devaddr, sys_name);
+			linux_device_disconnected(busnum, devaddr);
 		} else {
 			usbi_err(NULL, "ignoring udev action %s", udev_action);
 		}

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -121,7 +121,7 @@ static int sysfs_has_descriptors = -1;
 static int init_count = 0;
 
 /* Serialize hotplug start/stop */
-usbi_mutex_static_t linux_hotplug_startstop_lock = USBI_MUTEX_INITIALIZER;
+static usbi_mutex_static_t linux_hotplug_startstop_lock = USBI_MUTEX_INITIALIZER;
 /* Serialize scan-devices, event-thread, and poll */
 usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
 

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1103,7 +1103,7 @@ void linux_hotplug_enumerate(uint8_t busnum, uint8_t devaddr, const char *sys_na
 	usbi_mutex_static_unlock(&active_contexts_lock);
 }
 
-void linux_device_disconnected(uint8_t busnum, uint8_t devaddr, const char *sys_name)
+void linux_device_disconnected(uint8_t busnum, uint8_t devaddr)
 {
 	struct libusb_context *ctx;
 	struct libusb_device *dev;
@@ -1287,7 +1287,7 @@ static int op_open(struct libusb_device_handle *handle)
 			if (handle->dev->attached) {
 				usbi_dbg("open failed with no device, but device still attached");
 				linux_device_disconnected(handle->dev->bus_number,
-						handle->dev->device_address, NULL);
+						handle->dev->device_address);
 			}
 			usbi_mutex_static_unlock(&linux_hotplug_lock);
 		}
@@ -2595,7 +2595,7 @@ static int op_handle_events(struct libusb_context *ctx,
 			usbi_mutex_static_lock(&linux_hotplug_lock);
 			if (handle->dev->attached)
 				linux_device_disconnected(handle->dev->bus_number,
-						handle->dev->device_address, NULL);
+						handle->dev->device_address);
 			usbi_mutex_static_unlock(&linux_hotplug_lock);
 			continue;
 		}

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -874,10 +874,9 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 	dev->device_address = devaddr;
 
 	if (sysfs_dir) {
-		priv->sysfs_dir = malloc(strlen(sysfs_dir) + 1);
+		priv->sysfs_dir = strdup(sysfs_dir);
 		if (!priv->sysfs_dir)
 			return LIBUSB_ERROR_NO_MEM;
-		strcpy(priv->sysfs_dir, sysfs_dir);
 
 		/* Note speed can contain 1.5, in this case __read_sysfs_attr
 		   will stop parsing at the '.' and return 1 */

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -181,7 +181,7 @@ void linux_netlink_hotplug_poll(void);
 #endif
 
 void linux_hotplug_enumerate(uint8_t busnum, uint8_t devaddr, const char *sys_name);
-void linux_device_disconnected(uint8_t busnum, uint8_t devaddr, const char *sys_name);
+void linux_device_disconnected(uint8_t busnum, uint8_t devaddr);
 
 int linux_get_device_address (struct libusb_context *ctx, int detached,
 	uint8_t *busnum, uint8_t *devaddr, const char *dev_node,


### PR DESCRIPTION
- Replace open coded functions by the proper library function/header
- Remove unused function parameters or use them properly (instead of accessing globals)