### PR TITLE
Propose travis automatic build support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+compiler: gcc
+os: linux
+
+before_install: sudo apt-get update -qq
+install: sudo apt-get install -qq udev
+
+script: ./autogen.sh && ./configure && make


### PR DESCRIPTION
Travis is continuous integration & automatic build system
It is supported on Github. I have enabled/configured travis for libusb.
After adding this file, travis build will be triggered when a new pull request is there.
It will automatically check if build is success or not & eliminate manual efforts.