### PR TITLE
Fix doxygen comment for MaxPower field with respect to super-speed

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -666,7 +666,8 @@ struct libusb_config_descriptor {
 
 	/** Maximum power consumption of the USB device from this bus in this
 	 * configuration when the device is fully operation. Expressed in units
-	 * of 2 mA. */
+	 * of 2 mA when the device is operating in high-speed mode and in units
+	 * of 8 mA when the device is operating in super-speed mode. */
 	uint8_t  MaxPower;
 
 	/** Array of interfaces supported by this configuration. The length of


### PR DESCRIPTION
The MaxPower field of a configuration descriptor is in units of 8 mA
when the device is operating in super-speed mode according to the USB
3.0 specification, section 9.6.3, table 9-12:

  Maximum power consumption of the device from the
  bus in this specific configuration when the device is
  fully operational. Expressed in 2-mA units when the
  device is operating in high-speed mode and in 8-mA
  units when operating at Gen X speed.
  (i.e., 50 = 100 mA when operating at high-speed and
  50 = 400 mA when operating at Gen X speed).

Adjust the doxygen comment for the MaxPower member of struct
libusb_config_descriptor accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>