### PR TITLE
Added function to retreive context of a device. libusb_get_context()

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode:t ; c-basic-offset:8 -*- */
 /*
  * Core functions for libusb
+ * Copyright © 2015 Kuldeep Singh Dhaka <kuldeepdhaka9@gmail.com>
  * Copyright © 2012-2013 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2007-2008 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2001 Johannes Erdfelt <johannes@erdfelt.com>
@@ -1437,6 +1438,17 @@ DEFAULT_VISIBILITY
 libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle)
 {
 	return dev_handle->dev;
+}
+
+/** \ingroup dev
+ * Get the underlying context for a device.
+ * \param dev a device handle
+ * \returns the underlying context
+ */
+DEFAULT_VISIBILITY
+libusb_context * LIBUSB_CALL libusb_get_context(libusb_device *dev)
+{
+	return dev->ctx;
 }
 
 /** \ingroup dev

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -4,6 +4,7 @@
  * Copyright © 2007-2008 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2012 Pete Batard <pete@akeo.ie>
  * Copyright © 2012 Nathan Hjelm <hjelmn@cs.unm.edu>
+ * Copyright © 2015 Kuldeep Singh Dhaka <kuldeepdhaka9@gmail.com>
  * For more information, please visit: http://libusb.info
  *
  * This library is free software; you can redistribute it and/or
@@ -1369,6 +1370,7 @@ int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **handle);
 void LIBUSB_CALL libusb_close(libusb_device_handle *dev_handle);
 libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle);
+libusb_context * LIBUSB_CALL libusb_get_context(libusb_device *dev);
 
 int LIBUSB_CALL libusb_set_configuration(libusb_device_handle *dev,
 	int configuration);


### PR DESCRIPTION
This will allow application code to get device context.
earlier, it is not possible to get device context without hacking device data structure.