### PR TITLE
Use locally defined MIN macro instead of min which is (possibly) defi…

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -39,7 +39,7 @@
 
 #define safe_free(p) do {if (p != NULL) {free((void*)p); p = NULL;}} while(0)
 #define safe_closehandle(h) do {if (h != INVALID_HANDLE_VALUE) {CloseHandle(h); h = INVALID_HANDLE_VALUE;}} while(0)
-#define safe_min(a, b) min((size_t)(a), (size_t)(b))
+#define safe_min(a, b) MIN((size_t)(a), (size_t)(b))
 #define safe_strcp(dst, dst_max, src, count) do {memcpy(dst, src, safe_min(count, dst_max)); \
 	((char*)dst)[safe_min(count, dst_max)-1] = 0;} while(0)
 #define safe_strcpy(dst, dst_max, src) safe_strcp(dst, dst_max, src, safe_strlen(src)+1)

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -1929,7 +1929,7 @@ static int windows_get_config_descriptor(struct libusb_device *dev, uint8_t conf
 
 	config_header = (PUSB_CONFIGURATION_DESCRIPTOR)priv->config_descriptor[config_index];
 
-	size = min(config_header->wTotalLength, len);
+	size = MIN(config_header->wTotalLength, len);
 	memcpy(buffer, priv->config_descriptor[config_index], size);
 	*host_endian = 0;
 


### PR DESCRIPTION
…ned in windows.h

Some users have to define NOMINMAX which means that windows.h doesn't define min() or max(). Instead of relying on it it is better to use a locally defined function / macro. Fortunately libusbi.h already defines MIN and MAX so we can just use those.