### PR TITLE
New libusb_fdopen(dev, fd, handle) API to provide ability to associate the file descriptor with a device handle.

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1280,7 +1280,6 @@ int API_EXPORTED libusb_open(libusb_device *dev,
  * This function allows to associate a device handle with the existing file 
  * descriptor.
  *
- *
  * \param dev the device to open
  * \param fd the file descriptor to associate with the device 
  * \param handle output location for the returned device handle pointer. Only

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1196,26 +1196,7 @@ int usbi_clear_event(struct libusb_context *ctx)
 	return 0;
 }
 
-/** \ingroup dev
- * Open a device and obtain a device handle. A handle allows you to perform
- * I/O on the device in question.
- *
- * Internally, this function adds a reference to the device and makes it
- * available to you through libusb_get_device(). This reference is removed
- * during libusb_close().
- *
- * This is a non-blocking function; no requests are sent over the bus.
- *
- * \param dev the device to open
- * \param handle output location for the returned device handle pointer. Only
- * populated when the return code is 0.
- * \returns 0 on success
- * \returns LIBUSB_ERROR_NO_MEM on memory allocation failure
- * \returns LIBUSB_ERROR_ACCESS if the user has insufficient permissions
- * \returns LIBUSB_ERROR_NO_DEVICE if the device has been disconnected
- * \returns another LIBUSB_ERROR code on other failure
- */
-int API_EXPORTED libusb_open(libusb_device *dev,
+static int do_open(libusb_device *dev, intptr_t fd,
 	libusb_device_handle **handle)
 {
 	struct libusb_context *ctx = DEVICE_CTX(dev);
@@ -1241,6 +1222,7 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 	_handle->dev = libusb_ref_device(dev);
 	_handle->auto_detach_kernel_driver = 0;
 	_handle->claimed_interfaces = 0;
+	_handle->associated_fd = fd;
 	memset(&_handle->os_priv, 0, priv_size);
 
 	r = usbi_backend->open(_handle);
@@ -1258,6 +1240,61 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 	*handle = _handle;
 
 	return 0;
+}
+
+/** \ingroup dev
+ * Open a device and obtain a device handle. A handle allows you to perform
+ * I/O on the device in question.
+ *
+ * Internally, this function adds a reference to the device and makes it
+ * available to you through libusb_get_device(). This reference is removed
+ * during libusb_close().
+ *
+ * This is a non-blocking function; no requests are sent over the bus.
+ *
+ * \param dev the device to open
+ * \param handle output location for the returned device handle pointer. Only
+ * populated when the return code is 0.
+ * \returns 0 on success
+ * \returns LIBUSB_ERROR_NO_MEM on memory allocation failure
+ * \returns LIBUSB_ERROR_ACCESS if the user has insufficient permissions
+ * \returns LIBUSB_ERROR_NO_DEVICE if the device has been disconnected
+ * \returns another LIBUSB_ERROR code on other failure
+ */
+int API_EXPORTED libusb_open(libusb_device *dev,
+	libusb_device_handle **handle)
+{
+	return do_open(dev, -1, handle);
+}
+
+ /** \ingroup dev
+ * Open a device and obtain a device handle. A handle allows you to perform
+ * I/O on the device in question.
+ *
+ * Internally, this function adds a reference to the device and makes it
+ * available to you through libusb_get_device(). This reference is removed
+ * during libusb_close().
+ *
+ * This is a non-blocking function; no requests are sent over the bus.
+ *
+ * This function allows to associate a device handle with the existing file 
+ * descriptor.
+ *
+ *
+ * \param dev the device to open
+ * \param fd the file descriptor to associate with the device 
+ * \param handle output location for the returned device handle pointer. Only
+ * populated when the return code is 0.
+ * \returns 0 on success
+ * \returns LIBUSB_ERROR_NO_MEM on memory allocation failure
+ * \returns LIBUSB_ERROR_ACCESS if the user has insufficient permissions
+ * \returns LIBUSB_ERROR_NO_DEVICE if the device has been disconnected
+ * \returns another LIBUSB_ERROR code on other failure
+ */
+int API_EXPORTED libusb_fdopen(libusb_device *dev, intptr_t fd,
+	libusb_device_handle **handle)
+{
+	return do_open(dev, fd, handle);
 }
 
 /** \ingroup dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -126,6 +126,8 @@ EXPORTS
   libusb_lock_events@4 = libusb_lock_events
   libusb_open
   libusb_open@8 = libusb_open
+  libusb_fdopen
+  libusb_fdopen@12 = libusb_fdopen  
   libusb_open_device_with_vid_pid
   libusb_open_device_with_vid_pid@12 = libusb_open_device_with_vid_pid
   libusb_pollfds_handle_timeouts

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1368,6 +1368,7 @@ int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **handle);
+int LIBUSB_CALL libusb_fdopen(libusb_device *dev, intptr_t fd, libusb_device_handle **handle);
 void LIBUSB_CALL libusb_close(libusb_device_handle *dev_handle);
 libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle);
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -67,6 +67,12 @@ typedef unsigned __int32  uint32_t;
  * As this can be problematic if you include windows.h after libusb.h
  * in your sources, we force windows.h to be included first. */
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(_WIN32_WCE)
+#ifdef _DEBUG
+	#ifndef _CRTDBG_MAP_ALLOC
+		#define _CRTDBG_MAP_ALLOC
+	#endif
+	#include <crtdbg.h>
+#endif
 #include <windows.h>
 #if defined(interface)
 #undef interface

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -364,6 +364,7 @@ struct libusb_device_handle {
 	struct list_head list;
 	struct libusb_device *dev;
 	int auto_detach_kernel_driver;
+	intptr_t associated_fd;
 	unsigned char os_priv
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 	[] /* valid C99 code */

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1290,7 +1290,7 @@ static int op_open(struct libusb_device_handle *handle)
 	struct linux_device_handle_priv *hpriv = _device_handle_priv(handle);
 	int r;
 
-	hpriv->fd = _get_usbfs_fd(handle->dev, O_RDWR, 0);
+	hpriv->fd = ((int)handle->associated_fd < 0 ? _get_usbfs_fd(handle->dev, O_RDWR, 0) : (int)handle->associated_fd);
 	if (hpriv->fd < 0) {
 		if (hpriv->fd == LIBUSB_ERROR_NO_DEVICE) {
 			/* device will still be marked as attached if hotplug monitor thread

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -60,6 +60,7 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 static int winusbx_release_interface(int sub_api, struct libusb_device_handle *dev_handle, int iface);
 static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *itransfer);
 static int winusbx_set_interface_altsetting(int sub_api, struct libusb_device_handle *dev_handle, int iface, int altsetting);
+static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itransfer);
 static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer);
 static int winusbx_clear_halt(int sub_api, struct libusb_device_handle *dev_handle, unsigned char endpoint);
 static int winusbx_abort_transfers(int sub_api, struct usbi_transfer *itransfer);
@@ -2094,6 +2095,10 @@ static void windows_clear_transfer_priv(struct usbi_transfer *itransfer)
 
 	usbi_free_fd(&transfer_priv->pollable_fd);
 	safe_free(transfer_priv->hid_buffer);
+
+	//TODO this should occur during windows_free_transfer instead
+	safe_free(transfer_priv->iso_context);
+
 	// When auto claim is in use, attempt to release the auto-claimed interface
 	auto_release(itransfer);
 }
@@ -2630,7 +2635,7 @@ const struct windows_usb_api_backend usb_api_backend[USB_API_MAX] = {
 		winusbx_clear_halt,
 		winusbx_reset_device,
 		winusbx_submit_bulk_transfer,
-		unsupported_submit_iso_transfer,
+		winusbx_submit_iso_transfer,
 		winusbx_submit_control_transfer,
 		winusbx_abort_control,
 		winusbx_abort_transfers,
@@ -2725,6 +2730,8 @@ static int winusbx_init(int sub_api, struct libusb_context *ctx)
 		WinUSBX_Set(SetPipePolicy);
 		WinUSBX_Set(SetPowerPolicy);
 		WinUSBX_Set(WritePipe);
+		WinUSBX_Set(IsoReadPipe);
+		WinUSBX_Set(IsoWritePipe);
 		if (!native_winusb) {
 			WinUSBX_Set(ResetDevice);
 		}
@@ -3146,6 +3153,99 @@ static int winusbx_set_interface_altsetting(int sub_api, struct libusb_device_ha
 	return LIBUSB_SUCCESS;
 }
 
+static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itransfer)
+{
+	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_context *ctx = DEVICE_CTX(transfer->dev_handle->dev);
+	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv*)usbi_transfer_get_os_priv(itransfer);
+	struct windows_device_handle_priv *handle_priv = _device_handle_priv(transfer->dev_handle);
+	struct windows_device_priv *priv = _device_priv(transfer->dev_handle->dev);
+	HANDLE winusb_handle;
+	bool ret;
+	int current_interface;
+	struct winfd wfd;
+	int i;
+	uint32_t offset;
+	size_t ctx_size;
+
+	CHECK_WINUSBX_AVAILABLE(sub_api);
+
+	if (sub_api != SUB_API_LIBUSBK && sub_api != SUB_API_LIBUSB0)
+	{
+		//iso only supported on libusbk-based backends
+		return unsupported_submit_iso_transfer(sub_api, itransfer);
+	};
+
+	transfer_priv->pollable_fd = INVALID_WINFD;
+
+	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
+	if (current_interface < 0) {
+		usbi_err(ctx, "unable to match endpoint to an open interface - cancelling transfer");
+		return LIBUSB_ERROR_NOT_FOUND;
+	}
+
+	usbi_dbg("matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+
+	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
+
+	wfd = usbi_create_fd(winusb_handle, IS_XFERIN(transfer) ? RW_READ : RW_WRITE, NULL, NULL);
+	// Always use the handle returned from usbi_create_fd (wfd.handle)
+	if (wfd.fd < 0) {
+		return LIBUSB_ERROR_NO_MEM;
+	}
+
+	ctx_size = sizeof(KISO_CONTEXT)+sizeof(KISO_PACKET)* transfer->num_iso_packets;
+	//Init the libusbk iso_context
+	if (!transfer_priv->iso_context)
+	{
+		transfer_priv->iso_context = (PKISO_CONTEXT)malloc(ctx_size);
+		if (!transfer_priv->iso_context)
+		{
+			//TODO does this return leak mem, or does the transfer get cleaned up?
+			return LIBUSB_ERROR_NO_MEM;
+		}
+	}
+	memset(transfer_priv->iso_context, 0, ctx_size);
+
+	//start ASAP
+	transfer_priv->iso_context->StartFrame = 0;
+	transfer_priv->iso_context->NumberOfPackets = transfer->num_iso_packets;
+
+	/* convert the transfer packet lengths to iso_packet offsets */
+	offset = 0;
+	for (i = 0; i < transfer->num_iso_packets; i++)
+	{
+		transfer_priv->iso_context->IsoPackets[i].offset = offset;
+		offset += transfer->iso_packet_desc[i].length;
+	}
+
+	if (IS_XFERIN(transfer)) {
+		usbi_dbg("reading %d iso packets", transfer->num_iso_packets);
+		ret = WinUSBX[sub_api].IsoReadPipe(wfd.handle, transfer->endpoint, transfer->buffer, transfer->length, wfd.overlapped, transfer_priv->iso_context);
+	}
+	else {
+		usbi_dbg("writing %d iso packets", transfer->num_iso_packets);
+		ret = WinUSBX[sub_api].IsoWritePipe(wfd.handle, transfer->endpoint, transfer->buffer, transfer->length, wfd.overlapped, transfer_priv->iso_context);
+	}
+
+	if (!ret) {
+		if (GetLastError() != ERROR_IO_PENDING) {
+			usbi_err(ctx, "IsoReadPipe/IsoWritePipe failed: %s", windows_error_str(0));
+			usbi_free_fd(&wfd);
+			return LIBUSB_ERROR_IO;
+		}
+	}
+	else {
+		wfd.overlapped->Internal = STATUS_COMPLETED_SYNCHRONOUSLY;
+		wfd.overlapped->InternalHigh = (DWORD)transfer->length;
+	}
+
+	transfer_priv->pollable_fd = wfd;
+	transfer_priv->interface_number = (uint8_t)current_interface;
+
+	return LIBUSB_SUCCESS;
+}
+
 static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
@@ -3334,7 +3434,38 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 
 static int winusbx_copy_transfer_data(int sub_api, struct usbi_transfer *itransfer, uint32_t io_size)
 {
+	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv*)usbi_transfer_get_os_priv(itransfer);
+	struct windows_device_priv *priv = _device_priv(transfer->dev_handle->dev);
+	int i;
+
+	CHECK_WINUSBX_AVAILABLE(sub_api);
+
+	if (transfer->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS)
+	{
+		//for isochronous, need to copy the individual iso packet actual_lengths and statuses
+		if (sub_api == SUB_API_LIBUSBK || sub_api == SUB_API_LIBUSB0)
+		{
+			//iso only supported on libusbk-based backends for now
+
+			for (i = 0; i < transfer->num_iso_packets; i++)
+			{
+				transfer->iso_packet_desc[i].actual_length = transfer_priv->iso_context->IsoPackets[i].actual_length;
+				if (transfer->iso_packet_desc[i].actual_length == 0)
+					transfer->iso_packet_desc[i].actual_length = transfer->iso_packet_desc[i].length;
+				//TODO translate USDB_STATUS codes http://msdn.microsoft.com/en-us/library/ff539136(VS.85).aspx to libusb_transfer_status
+				//transfer->iso_packet_desc[i].status = transfer_priv->iso_context->IsoPackets[i].status;
+			}
+		}
+		else
+		{
+			//This should only occur if backend is not set correctly or other backend isoc is partially implemented
+			return unsupported_copy_transfer_data(sub_api, itransfer, io_size);
+		}
+	}
+	
 	itransfer->transferred += io_size;
+
 	return LIBUSB_TRANSFER_COMPLETED;
 }
 

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -708,11 +708,13 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, int
 
 	if (if_desc->bNumEndpoints == 0) {
 		usbi_dbg("no endpoints found for interface %d", iface);
+		libusb_free_config_descriptor(conf_desc);
 		return LIBUSB_SUCCESS;
 	}
 
 	priv->usb_interface[iface].endpoint = (uint8_t*) malloc(if_desc->bNumEndpoints);
 	if (priv->usb_interface[iface].endpoint == NULL) {
+		libusb_free_config_descriptor(conf_desc);
 		return LIBUSB_ERROR_NO_MEM;
 	}
 

--- a/libusb/os/windows_usb.h
+++ b/libusb/os/windows_usb.h
@@ -166,6 +166,42 @@ struct libusb_hid_descriptor {
 #define LIBUSB_REQ_IN(request_type) ((request_type) & LIBUSB_ENDPOINT_IN)
 #define LIBUSB_REQ_OUT(request_type) (!LIBUSB_REQ_IN(request_type))
 
+
+/* start libusbk_shared.h definitions, must match libusbk_shared.h for isochronous support */
+
+//KISO_PACKET is equivalent of libusb_iso_packet_descriptor except uses absolute "offset" field instead of sequential Lengths
+typedef struct _KISO_PACKET
+{
+	UINT offset;
+	USHORT actual_length; //changed from libusbk_shared.h "Length" for clarity
+	USHORT status;
+
+} KISO_PACKET;
+
+typedef KISO_PACKET* PKISO_PACKET;
+
+typedef enum _KISO_FLAG
+{
+	KISO_FLAG_NONE = 0,
+	KISO_FLAG_SET_START_FRAME = 0x00000001,
+} KISO_FLAG;
+
+//KISO_CONTEXT is the conceptual equivalent of libusb_transfer except is isochronous-specific and must match libusbk's version
+typedef struct _KISO_CONTEXT
+{
+	KISO_FLAG Flags;
+	UINT StartFrame;
+	SHORT ErrorCount;
+	SHORT NumberOfPackets;
+	UINT UrbHdrStatus;
+	KISO_PACKET IsoPackets[0];
+
+} KISO_CONTEXT;
+
+typedef KISO_CONTEXT* PKISO_CONTEXT;
+
+/* end libusbk_shared.h definitions */
+
 // The following are used for HID reports IOCTLs
 #define HID_CTL_CODE(id) \
   CTL_CODE (FILE_DEVICE_KEYBOARD, (id), METHOD_NEITHER, FILE_ANY_ACCESS)
@@ -299,6 +335,8 @@ struct windows_transfer_priv {
 	uint8_t *hid_buffer; // 1 byte extended data buffer, required for HID
 	uint8_t *hid_dest;   // transfer buffer destination, required for HID
 	size_t hid_expected_size;
+	/* Isoc */
+	PKISO_CONTEXT iso_context;
 };
 
 // used to match a device driver (including filter drivers) against a supported API
@@ -795,6 +833,23 @@ typedef BOOL (WINAPI *WinUsb_ResetDevice_t)(
 	WINUSB_INTERFACE_HANDLE InterfaceHandle
 );
 
+typedef BOOL(WINAPI *WinUsb_IsoReadPipe_t)(
+	WINUSB_INTERFACE_HANDLE InterfaceHandle,
+	UCHAR PipeID,
+	PUCHAR Buffer,
+	ULONG BufferLength,
+	LPOVERLAPPED Overlapped,
+	PKISO_CONTEXT IsoContext
+	);
+typedef BOOL(WINAPI *WinUsb_IsoWritePipe_t)(
+	WINUSB_INTERFACE_HANDLE InterfaceHandle,
+	UCHAR PipeID,
+	PUCHAR Buffer,
+	ULONG BufferLength,
+	LPOVERLAPPED Overlapped,
+	PKISO_CONTEXT IsoContext
+	);
+
 /* /!\ These must match the ones from the official libusbk.h */
 typedef enum _KUSB_FNID
 {
@@ -876,6 +931,8 @@ struct winusb_interface {
 	WinUsb_SetPowerPolicy_t SetPowerPolicy;
 	WinUsb_WritePipe_t WritePipe;
 	WinUsb_ResetDevice_t ResetDevice;
+	WinUsb_IsoReadPipe_t IsoReadPipe;
+	WinUsb_IsoWritePipe_t IsoWritePipe;
 };
 
 /* hid.dll interface */


### PR DESCRIPTION
The proposed API would act by idea similar to fdopen(), e.g. it would be possible to associate a created device handle with the existing file descriptor which was obtained earlier for the USB device.

It would be helpful to handle device opening on Android OS for instance, where file descriptor is obtained when user granted the permission to access a USB device. That file descriptor could then be passed to libusb API via libusb_fdopen() call.

The Linux back-end was modified to handle libusb_fdopen() call and use supplied file descriptor instead of trying to call _get_usbfs_fd(). Potentially libusb_fdopen() could be used to provide external file handles to a Windows back-end too. For that case intptr_t type is used for the 'fd' parameter of libusb_fdopen() function in order to guarantee the sufficient parameter width for passing the raw pointer.