### PR TITLE
Spelling fixes

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -137,7 +137,7 @@ struct list_head active_contexts_list;
  * libusb_set_debug(), or the setting of the environmental variable
  * LIBUSB_DEBUG outside of the application, can result in logging being
  * produced. Your application should therefore not close stderr, but instead
- * direct it to the null device if its output is undesireable.
+ * direct it to the null device if its output is undesirable.
  *
  * The libusb_set_debug() function can be used to enable logging of certain
  * messages. Under standard configuration, libusb doesn't really log much

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1101,7 +1101,7 @@ printf("completed!\n");
  * (without implementing the rules and locking semantics documented above)
  * and another trying to send a synchronous USB transfer, you will end up with
  * two threads monitoring the same descriptors, and the above-described
- * undesirable behaviour occuring. The solution is for your polling thread to
+ * undesirable behaviour occurring. The solution is for your polling thread to
  * play by the rules; the synchronous I/O functions do so, and this will result
  * in them getting along in perfect harmony.
  *

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -700,7 +700,7 @@ struct libusb_ss_endpoint_companion_descriptor {
 
 
 	/** The maximum number of packets the endpoint can send or
-	 *  recieve as part of a burst. */
+	 *  receive as part of a burst. */
 	uint8_t  bMaxBurst;
 
 	/** In bulk EP:	bits 4:0 represents the	maximum	number of

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1619,7 +1619,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) {
 
   bzero(&tpriv->req, sizeof(tpriv->req));
 
-  /* IOUSBDeviceInterface expects the request in cpu endianess */
+  /* IOUSBDeviceInterface expects the request in cpu endianness */
   tpriv->req.bmRequestType     = setup->bmRequestType;
   tpriv->req.bRequest          = setup->bRequest;
   /* these values should be in bus order from libusb_fill_control_setup */

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -308,7 +308,7 @@ static int linux_netlink_read_message(void)
 	len = recvmsg(linux_netlink_socket, &meh, 0);
 	if (len < 32) {
 		if (errno != EAGAIN)
-			usbi_dbg("error recieving message from netlink");
+			usbi_dbg("error receiving message from netlink");
 		return -1;
 	}
 

--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -54,7 +54,7 @@
 #define poll_dbg usbi_dbg
 #else
 // MSVC++ < 2005 cannot use a variadic argument and non MSVC
-// compilers produce warnings if parenthesis are ommitted.
+// compilers produce warnings if parenthesis are omitted.
 #if defined(_MSC_VER) && (_MSC_VER < 1400)
 #define poll_dbg
 #else

--- a/libusb/os/wince_usb.c
+++ b/libusb/os/wince_usb.c
@@ -101,7 +101,7 @@ static int translate_driver_error(int error)
 			return LIBUSB_ERROR_BUSY;
 
 		// Error codes that are either unexpected, or have
-		// no suitable LIBUSB_ERROR equivilant.
+		// no suitable LIBUSB_ERROR equivalent.
 		case ERROR_CANCELLED:
 		case ERROR_INTERNAL_ERROR:
 		default:

--- a/libusb/os/windows_usb.c
+++ b/libusb/os/windows_usb.c
@@ -2758,7 +2758,7 @@ static int winusbx_open(int sub_api, struct libusb_device_handle *dev_handle)
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
-	// WinUSB requires a seperate handle for each interface
+	// WinUSB requires a separate handle for each interface
 	for (i = 0; i < USB_MAXINTERFACES; i++) {
 		if ( (priv->usb_interface[i].path != NULL)
 		  && (priv->usb_interface[i].apib->id == USB_API_WINUSBX) ) {

--- a/libusb/os/windows_usb.h
+++ b/libusb/os/windows_usb.h
@@ -304,7 +304,7 @@ struct windows_transfer_priv {
 // used to match a device driver (including filter drivers) against a supported API
 struct driver_lookup {
 	char list[MAX_KEY_LENGTH+1];// REG_MULTI_SZ list of services (driver) names
-	const DWORD reg_prop;		// SPDRP registry key to use to retreive list
+	const DWORD reg_prop;		// SPDRP registry key to use to retrieve list
 	const char* designation;	// internal designation (for debug output)
 };
 


### PR DESCRIPTION
Fix spelling errors found by codespell, some of them in API
documentation and user visible messages.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>