### PR TITLE
configure: remove AM_MAINTAINER_MODE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,6 @@ lt_age="1"
 LTLDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age}"
 
 AM_INIT_AUTOMAKE
-AM_MAINTAINER_MODE
 
 AC_CONFIG_SRCDIR([libusb/core.c])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
AM_MAINTAINER_MODE, contrary to it's name, disables the rebuild rules unless you enable them explicitly.  There are very few situations where this is desirable and can lead to unpredictable or broken builds.  In fact even the creator of AM_MAINTAINER_MODE now recommends against using it.

http://www.gnu.org/software/automake/manual/html_node/maintainer_002dmode.html has more analysis.
