### PR TITLE
linux_get_parent_info: Check for NULL priv->sysfs_dir before strcmp

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1034,9 +1034,11 @@ retry:
 	usbi_mutex_lock(&ctx->usb_devs_lock);
 	list_for_each_entry(it, &ctx->usb_devs, list, struct libusb_device) {
 		struct linux_device_priv *priv = _device_priv(it);
-		if (0 == strcmp (priv->sysfs_dir, parent_sysfs_dir)) {
-			dev->parent_dev = libusb_ref_device(it);
-			break;
+		if (priv->sysfs_dir) {
+			if (0 == strcmp (priv->sysfs_dir, parent_sysfs_dir)) {
+				dev->parent_dev = libusb_ref_device(it);
+				break;
+			}
 		}
 	}
 	usbi_mutex_unlock(&ctx->usb_devs_lock);


### PR DESCRIPTION
This is a quick fix for a crash seen when a usb ups disconnects and reconnects while Network UPS Tools is monitoring it.  Here is the valgrind output:
==2383== Process terminating with default action of signal 11 (SIGSEGV)
==2383==  Access not within mapped region at address 0x0
==2383==    at 0x4C2F341: strcmp (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==2383==    by 0x561800B: linux_enumerate_device (linux_usbfs.c:1037)
==2383==    by 0x5618CB8: linux_hotplug_enumerate (linux_usbfs.c:1113)
==2383==    by 0x561A192: linux_netlink_read_message (linux_netlink.c:322)
==2383==    by 0x561A724: linux_netlink_hotplug_poll (linux_netlink.c:366)
==2383==    by 0x560D168: libusb_get_device_list (core.c:807)
==2383==    by 0x4E383DF: usb_find_busses (in /lib64/libusb-0.1.so.4.4.4)
==2383==    by 0x120D55: libusb_open (libusb.c:164)
==2383==    by 0x11EE09: upsdrv_updateinfo (usbhid-ups.c:1355)
==2383==    by 0x11D016: main (main.c:708)
