### PR TITLE
threads_posix: use backend clock_gettime()

### DIFF
--- a/libusb/os/threads_posix.c
+++ b/libusb/os/threads_posix.c
@@ -35,6 +35,7 @@
 #endif
 
 #include "threads_posix.h"
+#include "libusbi.h"
 
 int usbi_mutex_init_recursive(pthread_mutex_t *mutex)
 {
@@ -64,7 +65,7 @@ int usbi_cond_timedwait(pthread_cond_t *cond,
 	struct timespec timeout;
 	int r;
 
-	r = clock_gettime(CLOCK_REALTIME, &timeout);
+	r = usbi_backend->clock_gettime(USBI_CLOCK_REALTIME, &timeout);
 	if (r < 0)
 		return r;
 

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11065
+#define LIBUSB_NANO 11066


### PR DESCRIPTION
Some platforms do not implement the optional clock_gettime(). Need
to use the backend implementation instead.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>