### PR TITLE
bootstrap: use autoreconf

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,19 +1,6 @@
 #!/bin/sh
 
-set -e
-
-# use libtoolize if available, otherwise look for glibtoolize (darwin)
-if (libtoolize --version) < /dev/null > /dev/null 2>&1; then
-  LIBTOOLIZE=libtoolize
-elif (glibtoolize --version) < /dev/null > /dev/null 2>&1; then
-  LIBTOOLIZE=glibtoolize
-else
-  echo "libtoolize or glibtoolize was not found! Please install libtool." 1>&2
-  exit 1
+if ! test -d m4 ; then
+    mkdir m4
 fi
-
-$LIBTOOLIZE --copy --force || exit 1
-aclocal || exit 1
-autoheader || exit 1
-autoconf || exit 1
-automake -a -c || exit 1
+autoreconf -ivf || exit 1

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11075
+#define LIBUSB_NANO 11077


### PR DESCRIPTION
This PR cleans up the bootstrap script to use autoreconf. It has the same effect as the code it replaces.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>