### PR TITLE
Replace obsolete usleep with nanosleep DO NOT MERGE

### DIFF
--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -29,8 +29,8 @@
 #if defined(_WIN32)
 #define msleep(msecs) Sleep(msecs)
 #else
-#include <unistd.h>
-#define msleep(msecs) usleep(1000*msecs)
+#include <time.h>
+#define msleep(msecs) nanosleep(&(struct timespec){delay / 1000, (delay * 1000000) % 1000000000UL}, NULL);
 #endif
 
 #if defined(_MSC_VER)

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -30,7 +30,7 @@
 #define msleep(msecs) Sleep(msecs)
 #else
 #include <time.h>
-#define msleep(msecs) nanosleep(&(struct timespec){delay / 1000, (delay * 1000000) % 1000000000UL}, NULL);
+#define msleep(msecs) nanosleep(&(struct timespec){msecs / 1000, (msecs * 1000000) % 1000000000UL}, NULL);
 #endif
 
 #if defined(_MSC_VER)

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -94,6 +94,7 @@
 \code
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <libusb.h>
 
 static int count = 0;
@@ -142,7 +143,7 @@ int main (void) {
 
   while (count < 2) {
     libusb_handle_events_completed(NULL, NULL);
-    usleep(10000);
+    nanosleep(&(struct timespec){0, 10000000UL}, NULL);
   }
 
   libusb_hotplug_deregister_callback(NULL, callback_handle);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -19,6 +19,7 @@
  */
 
 #include "config.h"
+#include <time.h>
 #include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
@@ -764,7 +765,7 @@ static int darwin_cache_device_descriptor (struct libusb_context *ctx, struct da
     if (kIOReturnSuccess != ret) {
       usbi_dbg("kernel responded with code: 0x%08x. sleeping for %d ms before trying again", ret, delay/1000);
       /* sleep for a little while before trying again */
-      usleep (delay);
+      nanosleep(&(struct timespec){delay / 1000000, (delay * 1000) % 1000000000UL}, NULL);
     }
   } while (kIOReturnSuccess != ret && retries--);
 

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -36,7 +36,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
-#include <unistd.h>
+#include <time.h>
 
 #include "libusbi.h"
 #include "linux_usbfs.h"
@@ -202,7 +202,7 @@ static int _get_usbfs_fd(struct libusb_device *dev, mode_t mode, int silent)
 			usbi_err(ctx, "File doesn't exist, wait %d ms and try again", delay/1000);
    
 		/* Wait 10ms for USB device path creation.*/
-		usleep(delay);
+		nanosleep(&(struct timespec){delay / 1000000, (delay * 1000) % 1000000000UL}, NULL);
 
 		fd = open(path, mode);
 		if (fd != -1)

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11092
+#define LIBUSB_NANO 11091

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11089
+#define LIBUSB_NANO 11092


### PR DESCRIPTION
This fixes compiling libusb with uclibc.

Signed-off-by: Stefan Tauner <stefan.tauner@gmx.at>