### PR TITLE
configure: bump autoconf version and remove obsolete AM_MAINTAINER_MODE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+# Require trusty for now as it has a more recent version of autoconf
 sudo: required
+dist: trusty
 language: c
 
 compiler:

--- a/configure.ac
+++ b/configure.ac
@@ -27,14 +27,13 @@ lt_age="1"
 LTLDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age}"
 
 AM_INIT_AUTOMAKE
-AM_MAINTAINER_MODE
 
 AC_CONFIG_SRCDIR([libusb/core.c])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
-AC_PREREQ([2.50])
+AC_PREREQ([2.69])
 AC_PROG_CC
 AC_PROG_CXX
 LT_INIT

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11102
+#define LIBUSB_NANO 11105


### PR DESCRIPTION
This commit bumps the minimum autoconf version to 2.69. This only
affects maintainers and will ensure libusb tarballs have up-to-date
configure scripts. At the same time we are removing the
AM_MAINTAINER_MODE macro as even its creator recommends against
using it.

Closes #122

Signed-off-by: Nathan Hjelm <hjelmn@me.com>