### PR TITLE
Replaced __android_log_write by __android_log_print

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2261,7 +2261,7 @@ static void usbi_log_str(struct libusb_context *ctx,
 	case LIBUSB_LOG_LEVEL_ERROR: priority = ANDROID_LOG_ERROR; break;
 	case LIBUSB_LOG_LEVEL_DEBUG: priority = ANDROID_LOG_DEBUG; break;
 	}
-	__android_log_write(priority, "libusb", str);
+	__android_log_print(priority, "libusb", "%s", str);
 #elif defined(HAVE_SYSLOG_FUNC)
 	int syslog_level = LOG_INFO;
 	switch (level) {


### PR DESCRIPTION
The use of __android_log_write causes problems in execution time.