### PR TITLE
fix timerfd initialization

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #endif
 #ifdef USBI_TIMERFD_AVAILABLE
+#include <fcntl.h>
 #include <sys/timerfd.h>
 #endif
 
@@ -1148,7 +1149,7 @@ int usbi_io_init(struct libusb_context *ctx)
 
 #ifdef USBI_TIMERFD_AVAILABLE
 	ctx->timerfd = timerfd_create(usbi_backend->get_timerfd_clockid(),
-		TFD_NONBLOCK);
+		O_NONBLOCK);
 	if (ctx->timerfd >= 0) {
 		usbi_dbg("using timerfd for timeouts");
 		r = usbi_add_pollfd(ctx, ctx->timerfd, POLLIN);


### PR DESCRIPTION
sys/timerfd.h defines TFD_NONBLOCK as 0x800 but in kernel TFD_NONBLOCK
is an alias for O_NONBLOCK which is defined in arch-specific fcntl.h.
While it's still 0x800 for most of archs but for mips it's 0x80. So
timerfd_create(..., TFD_NONBLOCK) returns -EINVAL because of that. Fix
this by using O_NONBLOCK instead.

Signed-off-by: Alexander Gordeev <lasaine@lvk.cs.msu.su>