### PR TITLE
configure: add support for sub-project builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ autom4te.cache
 install-sh
 depcomp
 configure
+configure.gnu
 aclocal.m4
 compile
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,8 +14,10 @@ if BUILD_TESTS
 SUBDIRS += tests
 endif
 
+if !BUILD_SUBPROJECT
 pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_DATA=libusb-1.0.pc
+endif
 
 .PHONY: dist-up
 

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,13 @@ AC_ARG_ENABLE([tests-build], [AS_HELP_STRING([--enable-tests-build],
 	[build_tests='no'])
 AM_CONDITIONAL([BUILD_TESTS], [test "x$build_tests" != "xno"])
 
+# Subproject build
+AC_ARG_ENABLE([subproject-build], [AS_HELP_STRING([--enable-subproject-build],
+	[build as sub-project [default=no]])],
+	[build_subproject=$enableval],
+	[build_subproject='no'])
+AM_CONDITIONAL([BUILD_SUBPROJECT], [test "x$build_subproject" != "xno"])
+
 # check for -fvisibility=hidden compiler support (GCC >= 3.4)
 saved_cflags="$CFLAGS"
 # -Werror required for cygwin

--- a/libusb/Makefile.am
+++ b/libusb/Makefile.am
@@ -2,7 +2,11 @@ all: libusb-1.0.la libusb-1.0.dll
 
 AUTOMAKE_OPTIONS = subdir-objects
 
+if BUILD_SUBPROJECT
+noinst_LTLIBRARIES = libusb-1.0.la
+else
 lib_LTLIBRARIES = libusb-1.0.la
+endif
 
 POSIX_POLL_SRC = os/poll_posix.h os/poll_posix.c
 POSIX_THREADS_SRC = os/threads_posix.h os/threads_posix.c
@@ -95,5 +99,9 @@ libusb_1_0_la_SOURCES = libusbi.h libusb.h version.h version_nano.h \
 	core.c descriptor.c hotplug.h hotplug.c io.c strerror.c sync.c \
 	$(POLL_SRC) $(THREADS_SRC) $(OS_SRC)
 
+if BUILD_SUBPROJECT
+noinst_HEADERS = libusb.h
+else
 hdrdir = $(includedir)/libusb-1.0
 hdr_HEADERS = libusb.h
+endif


### PR DESCRIPTION
This patch allows libusb to be built as a subproject to other
autotools-based projects. This behavior is disabled by default, but can
be enabled by passing the --enable-subproject-build flag to configure.

Signed-off-by: Steven Stallion <stallion@squareup.com>