### PR TITLE
Windows: Fix possible false error message during device enumeration

### DIFF
--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -201,7 +201,6 @@ struct windows_device_priv {
 	uint8_t depth; // distance to HCD
 	uint8_t port;  // port number on the hub
 	uint8_t active_config;
-	struct libusb_device *parent_dev; // access to parent is required for usermode ops
 	struct windows_usb_api_backend const *apib;
 	char *path;  // device interface path
 	int sub_api; // for WinUSB-like APIs
@@ -231,7 +230,6 @@ static inline struct windows_device_priv *windows_device_priv_init(struct libusb
 
 	p->depth = 0;
 	p->port = 0;
-	p->parent_dev = NULL;
 	p->path = NULL;
 	p->apib = &usb_api_backend[USB_API_UNSUPPORTED];
 	p->sub_api = SUB_API_NOTSET;


### PR DESCRIPTION
During early phases of enumeration, it is possible for a device to be
enumerated before its parent. When this occurs, the device assigned as
the parent will actually be a grandparent. During later phases of
enumeration, the parent device will in fact exist but will not match
what has already been assigned to the device.

This commit adds code to check for and update the parent device when
this situation occurs.

Closes #206

Signed-off-by: Chris Dickens <christopher.a.dickens@gmail.com>