### PR TITLE
linux_udev: Retry poll() on EINTR

### DIFF
--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -172,7 +172,11 @@ static void *linux_udev_event_thread_main(void *arg)
 
 	usbi_dbg("udev event thread entering.");
 
-	while (poll(fds, 2, -1) >= 0) {
+	while ((r = poll(fds, 2, -1)) >= 0 || errno == EINTR) {
+		if (r < 0) {
+			// temporary failure
+			continue;
+		}
 		if (fds[0].revents & POLLIN) {
 			/* activity on control pipe, read the byte and exit */
 			r = usbi_read(udev_control_pipe[0], &dummy, sizeof(dummy));


### PR DESCRIPTION
The poll() syscall may temporarily fail when it is interrupted by a
signal; -1 is returned and errno is set to EINTR.

When this occurred, the udev event thread exited.

Instead, since this is a temporary failure, just try the call again.
https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html
