### PR TITLE
Windows: Allow HID reports up to 1024 + report id

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3358,11 +3358,13 @@ static int _hid_set_report(struct hid_device_priv *dev, HANDLE hid_handle, int i
 {
 	uint8_t *buf = NULL;
 	DWORD ioctl_code, write_size = (DWORD)*size;
+	// If an id is reported, we must allow MAX_HID_REPORT_SIZE + 1
+	unsigned int max_report_size = MAX_HID_REPORT_SIZE + id ? 1 : 0;
 
 	if (tp->hid_buffer != NULL)
 		usbi_dbg("program assertion failed: hid_buffer is not NULL");
 
-	if ((*size == 0) || (*size > MAX_HID_REPORT_SIZE)) {
+	if ((*size == 0) || (*size > max_report_size)) {
 		usbi_dbg("invalid size (%u)", *size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}


### PR DESCRIPTION
HID reports can contain up to 1024 bytes. When using a report id
the complete buffer will be 1025 bytes. Do not return an error
if the user supplies a report id and a buffer of 1025 bytes size.

Closes #222

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>

This avoids a warning about signed/unsigned compare and replaces my earlier pull.