### PR TITLE
add detach/attach kernel driver support for solaris backend

### DIFF
--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -21,6 +21,7 @@
 
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/list.h>
 #include <sys/stat.h>
 #include <strings.h>
 #include <errno.h>
@@ -28,15 +29,28 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wait.h>
 #include <unistd.h>
 #include <aio.h>
 #include <libdevinfo.h>
+#include <sys/nvpair.h>
+#include <sys/devctl.h>
 #include <sys/usb/clients/ugen/usb_ugen.h>
+#include <errno.h>
 #include <sys/usb/usba.h>
 #include <sys/pci.h>
 
 #include "libusbi.h"
 #include "sunos_usb.h"
+
+#define	UPDATEDRV_PATH	"/usr/sbin/update_drv"
+#define	UPDATEDRV	"update_drv"
+
+typedef	list_t	string_list_t;
+typedef struct string_node {
+	char		*string;
+	list_node_t	link;
+} string_node_t;
 
 /*
  * Backend functions
@@ -67,6 +81,165 @@ static int sunos_cancel_transfer(struct usbi_transfer *);
 static void sunos_clear_transfer_priv(struct usbi_transfer *);
 static int sunos_handle_transfer_completion(struct usbi_transfer *);
 static int sunos_clock_gettime(int, struct timespec *);
+static int sunos_kernel_driver_active(struct libusb_device_handle *, int interface);
+static int sunos_detach_kernel_driver (struct libusb_device_handle *dev, int interface_number);
+static int sunos_attach_kernel_driver (struct libusb_device_handle *dev, int interface_number);
+static int sunos_usb_open_ep0(sunos_dev_handle_priv_t *hpriv, sunos_dev_priv_t *dpriv);
+static int sunos_usb_ioctl(struct libusb_device_handle *dev, int cmd);
+
+static struct devctl_iocdata iocdata;
+static int sunos_get_link(di_devlink_t devlink, void *arg)
+{
+	walk_link_t *larg = (walk_link_t *)arg;
+	const char *p;
+	const char *q;
+
+	if (larg->path) {
+		char *content = (char *)di_devlink_content(devlink);
+		char *start = strstr(content, "/devices/");
+		start += strlen("/devices");
+		usbi_dbg("%s", start);
+
+		/* line content must have minor node */
+		if (start == NULL ||
+		    strncmp(start, larg->path, larg->len) != 0 ||
+		    start[larg->len] != ':') {
+
+			return (DI_WALK_CONTINUE);
+		}
+	}
+
+	p = di_devlink_path(devlink);
+	q = strrchr(p, '/');
+	usbi_dbg("%s", q);
+
+	*(larg->linkpp) = strndup(p, strlen(p)-strlen(q));
+
+	return (DI_WALK_TERMINATE);
+}
+
+
+static int sunos_physpath_to_devlink(
+	const char *node_path, const char *match, char **link_path)
+{
+	walk_link_t larg;
+	di_devlink_handle_t hdl;
+
+	*link_path = NULL;
+	larg.linkpp = link_path;
+	if ((hdl = di_devlink_init(NULL, 0)) == NULL) {
+		usbi_dbg("di_devlink_init failure");
+
+		return (-1);
+	}
+
+	larg.len = strlen(node_path);
+	larg.path = (char *)node_path; 
+
+	(void) di_devlink_walk(hdl, match, NULL, DI_PRIMARY_LINK,
+	    (void *)&larg, sunos_get_link);
+
+	(void) di_devlink_fini(&hdl);
+
+	if (*link_path == NULL) {
+		usbi_dbg("there is no devlink for this path");
+
+		return (-1);
+	}
+
+	return 0;
+}
+
+static int sunos_usb_ioctl(struct libusb_device_handle *dev, int cmd)
+{
+	int		fd;
+	nvlist_t	*nvlist;
+	char		*end;
+	char		*phypath;
+	char		*hubpath;
+	char		path_arg[PATH_MAX]={0};
+	sunos_dev_priv_t *dpriv;
+	struct libusb_device	 *usbdev;
+	devctl_ap_state_t	devctl_ap_state;
+	
+	usbdev = (struct libusb_device  *)dev->dev;
+	dpriv = (sunos_dev_priv_t *)usbdev->os_priv;
+	phypath = dpriv->phypath;
+	nvlist_alloc(&nvlist,  NV_UNIQUE_NAME_TYPE, KM_NOSLEEP);
+	nvlist_add_int32(nvlist, "port", usbdev->port_number);
+	//find the hub path
+	end = strrchr(phypath, '/');
+	hubpath = strndup(phypath, end - phypath);
+	snprintf(path_arg, PATH_MAX, "/devices%s:hubd", hubpath);
+	usbi_dbg("ioctl hub path:%s", path_arg);
+	
+	end = strrchr(hubpath, '@');
+	if (end == NULL) {
+
+		return (-1);
+	}
+	end++;
+	usbi_dbg("unitaddr:%s", end);
+
+	(void) memset(&iocdata, 0, sizeof (struct devctl_iocdata));
+	(void) memset(&devctl_ap_state, 0, sizeof (struct devctl_ap_state));
+	
+	errno = 0; 
+	fd = open(path_arg, O_RDONLY);
+	if (fd < 0) {
+		usbi_dbg("open failed: %d (%s)\n", errno, strerror(errno));
+		
+		return -1;	
+	}
+
+	nvlist_pack(nvlist, (char **)&iocdata.nvl_user, &iocdata.nvl_usersz, NV_ENCODE_NATIVE, 0);
+	
+	iocdata.cmd = DEVCTL_AP_GETSTATE;
+	iocdata.flags = 0;
+	iocdata.c_nodename = "hub";
+	iocdata.c_unitaddr = end;
+	iocdata.cpyout_buf = &devctl_ap_state;
+	usbi_dbg("%p, %d\n", iocdata.nvl_user, iocdata.nvl_usersz);
+
+	errno = 0;
+	if (ioctl(fd, DEVCTL_AP_GETSTATE, &iocdata) == -1) {
+		usbi_dbg("ioctl failed: fd %d, cmd %x, errno %d (%s)\n",
+		    fd, DEVCTL_AP_GETSTATE, errno, strerror(errno));
+	} else {
+		usbi_dbg("dev rstate:%d",devctl_ap_state.ap_rstate);
+		usbi_dbg("dev ostate:%d",devctl_ap_state.ap_ostate);
+	}
+
+	errno = 0;
+	iocdata.cmd = cmd;
+	if (ioctl(fd, (int)cmd, &iocdata) != 0) {
+		usbi_dbg("ioctl failed: fd %d, cmd %x, errno %d (%s)\n",
+		    fd, cmd, errno, strerror(errno));
+		sleep(2);
+	}
+	
+	close(fd);
+	nvlist_free(nvlist);
+	free(hubpath);
+	free(iocdata.nvl_user);
+
+	return (-errno);
+}
+
+static int sunos_kernel_driver_active(struct libusb_device_handle *dev, int interface)
+{
+	sunos_dev_priv_t *dpriv;
+	dpriv = (sunos_dev_priv_t *)dev->dev->os_priv;
+	usbi_dbg("%s", dpriv->ugenpath);
+
+	if (dpriv->ugenpath) {
+
+		return 0;
+	} else {
+
+		return 1;
+	}
+}
 
 /*
  * Private functions
@@ -84,6 +257,196 @@ static void sunos_exit(void)
 	usbi_dbg("");
 }
 
+static void *
+sunos_new(size_t n)
+{
+	void	*m;
+	if ((m = calloc(1, n)) == NULL) {
+		usbi_dbg("can not alloc memory");
+
+		return 0;
+	}
+
+	return (m);
+}
+
+static char *
+sunos_newstring(char *s)
+{
+	size_t	n = strlen(s) + 1;
+	char	*ns = sunos_new(n);
+
+	return (memcpy(ns, s, n));
+}
+
+
+static string_list_t *
+sunos_new_string_list(void)
+{
+	string_list_t *list;
+
+	list = sunos_new(sizeof (string_list_t));
+	list_create(list, sizeof (string_node_t),
+	    offsetof(string_node_t, link));
+
+	return (list);
+}
+
+static void
+sunos_append_to_string_list(string_list_t *list, char *arg)
+{
+	string_node_t *np;
+
+	np = sunos_new(sizeof (*np));
+	np->string = sunos_newstring(arg);
+	list_insert_tail(list, np);
+}
+
+static void
+sunos_free_string_list(string_list_t *list)
+{
+	string_node_t *np;
+	while ((np = list_remove_head(list)) != NULL) {
+		free(np->string);
+		free(np);
+	}
+	free(list);
+}
+
+static char **
+sunos_build_argv_list(string_list_t *list)
+{
+	char **argv_list;
+	string_node_t *np;
+	int n;
+
+	for (n = 0, np = list_head(list);
+	    np != NULL; np = list_next(list, np)) {
+		n++;
+	}
+
+	if ((argv_list = calloc(n+1, sizeof (char *))) == NULL) {
+		usbi_dbg("alloc memory failure");
+
+		return 0;
+	}
+	for (n = 0, np = list_head(list);
+	    np != NULL; np = list_next(list, np)) {
+		argv_list[n++] = np->string;
+	}
+	argv_list[n] = NULL;
+
+	return (argv_list);
+}
+
+
+static int
+sunos_exec_command(char *path, string_list_t *list)
+{
+	pid_t pid;
+	uint_t stat_loc;
+	int waitstat;
+	int exit_status;
+	char **argv_list;
+
+	argv_list = sunos_build_argv_list(list);
+
+	/* child */
+	if ((pid = fork()) == 0) {
+		(void) execv(path, argv_list);
+		perror(NULL);
+		
+		return -1;
+	} else if (pid == -1) {
+		/* fork failed */
+		perror(NULL);
+		free(argv_list);
+
+		return -1;
+	} else {
+		/* parent */
+		free(argv_list);
+		do {
+			waitstat = waitpid(pid, (int *)&stat_loc, 0);
+
+		} while ((!WIFEXITED(stat_loc) &&
+		    !WIFSIGNALED(stat_loc)) || (waitstat == 0));
+
+		exit_status = WEXITSTATUS(stat_loc);
+
+		return (exit_status);
+	}
+}
+
+static int sunos_detach_kernel_driver (struct libusb_device_handle *dev, int interface_number)
+{
+	string_list_t *list;
+	char path_arg[PATH_MAX+1]={0};
+	sunos_dev_priv_t *dpriv;
+
+	dpriv = (sunos_dev_priv_t *)dev->dev->os_priv;
+	snprintf(path_arg, PATH_MAX, "\'\"%s\"\'", dpriv->phypath);
+	usbi_dbg("%s", path_arg);
+	list = sunos_new_string_list();
+	/* attach ugen driver */
+	sunos_append_to_string_list(list, UPDATEDRV);
+	sunos_append_to_string_list(list, "-a"); /* add rule */ 
+	sunos_append_to_string_list(list, "-i"); /* specific device */
+	sunos_append_to_string_list(list, path_arg); /* physical path */
+	sunos_append_to_string_list(list, "ugen");
+
+	sunos_exec_command(UPDATEDRV_PATH, list);
+	/* reconfigure the driver node */
+	sunos_usb_ioctl(dev, DEVCTL_AP_DISCONNECT);
+	sunos_usb_ioctl(dev, DEVCTL_AP_CONFIGURE);
+
+	sunos_free_string_list(list);
+	snprintf(path_arg, PATH_MAX, "^usb/%x.%x", dpriv->dev_descr.idVendor,
+	    dpriv->dev_descr.idProduct);
+	sunos_physpath_to_devlink(dpriv->phypath, path_arg, &dpriv->ugenpath); 
+
+	if(access(dpriv->ugenpath, F_OK) != -1 ) {
+		sunos_usb_open_ep0((sunos_dev_handle_priv_t *)dev->os_priv, dpriv);
+
+		return 0;
+	} else {
+		usbi_dbg("fail to detach kernel driver");
+
+		return (LIBUSB_ERROR_IO);
+	}
+
+}
+
+static int 
+sunos_attach_kernel_driver (struct libusb_device_handle *dev, int interface_number) 
+{
+	string_list_t *list;
+	char path_arg[PATH_MAX+1]={0};
+	sunos_dev_priv_t *dpriv;
+
+	/* we open the dev in detach driver, so we need close it first. */
+	sunos_close(dev);
+
+	dpriv = (sunos_dev_priv_t *)dev->dev->os_priv;
+	sprintf(path_arg, "\'\"%s\"\'", dpriv->phypath);
+	usbi_dbg("%s", path_arg);
+	list = sunos_new_string_list();
+	/* detach ugen driver */
+	sunos_append_to_string_list(list, UPDATEDRV);
+	sunos_append_to_string_list(list, "-d"); /* add rule */
+	sunos_append_to_string_list(list, "-i"); /* specific device */
+	sunos_append_to_string_list(list, path_arg); /* physical path */
+	sunos_append_to_string_list(list, "ugen");
+	sunos_exec_command(UPDATEDRV_PATH, list);
+
+	/* reconfigure the driver node */
+	sunos_usb_ioctl(dev, DEVCTL_AP_CONFIGURE);
+	sunos_usb_ioctl(dev, DEVCTL_AP_DISCONNECT);
+	sunos_usb_ioctl(dev, DEVCTL_AP_CONFIGURE);
+
+	return 0;
+}
+
 static int
 sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 {
@@ -93,6 +456,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	uint8_t	*rdata;
 	struct libusb_device_descriptor	*descr;
 	sunos_dev_priv_t	*dpriv = (sunos_dev_priv_t *)dev->os_priv;
+	char	match_str[PATH_MAX + 1]; 
 
 	/* Device descriptors */
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
@@ -108,7 +472,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	dpriv->dev_descr.idVendor = libusb_cpu_to_le16(descr->idVendor);
 	dpriv->dev_descr.idProduct = libusb_cpu_to_le16(descr->idProduct);
 	dpriv->dev_descr.bcdDevice = libusb_cpu_to_le16(descr->bcdDevice);
-
+	
 	/* Raw configuration descriptors */
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
 	    "usb-raw-cfg-descriptors", &rdata);
@@ -137,7 +501,11 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	phypath = di_devfs_path(node);
 	if (phypath) {
 		dpriv->phypath = strdup(phypath);
+		snprintf(match_str, PATH_MAX, "^usb/%x.%x", dpriv->dev_descr.idVendor, dpriv->dev_descr.idProduct);
+		usbi_dbg("match is %s", match_str);
+		sunos_physpath_to_devlink(dpriv->phypath, match_str,  &dpriv->ugenpath);
 		di_devfs_path_free(phypath);
+
 	} else {
 		free(dpriv->raw_cfgdescr);
 
@@ -170,112 +538,101 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	return (LIBUSB_SUCCESS);
 }
 
-
 static int
 sunos_add_devices(di_devlink_t link, void *arg)
 {
 	struct devlink_cbarg	*largs = (struct devlink_cbarg *)arg;
 	struct node_args	*nargs;
-	di_node_t		myself, pnode;
+	di_node_t		myself, dn;
 	uint64_t		session_id = 0;
-	uint16_t		bdf = 0;
+	uint64_t		sid = 0;
+	uint64_t		bdf = 0;
 	struct libusb_device	*dev;
 	sunos_dev_priv_t	*devpriv;
-	const char		*path, *newpath;
-	int			 n, i;
+	int			n;
+	int			i = 0;
 	int			*addr_prop;
 	uint8_t			bus_number = 0;
+	uint32_t * 		regbuf = NULL;
+	uint32_t		reg;
 
 	nargs = (struct node_args *)largs->nargs;
 	myself = largs->myself;
-	if (nargs->last_ugenpath) {
-		/* the same node's links */
-		return (DI_WALK_CONTINUE);
-	}
 
 	/*
 	 * Construct session ID.
-	 * session ID = ...parent hub addr|hub addr|dev addr.
+	 * session ID = dev_addr | hub addr |parent hub addr|...|root hub bdf
+	 * 		8 bits       8bits          8 bits               16bits
 	 */
-	pnode = myself;
-	i = 0;
-	while (pnode != DI_NODE_NIL) {
-		if (di_prop_exists(DDI_DEV_T_ANY, pnode, "root-hub") == 1) {
-			/* walk to root */
-			uint32_t *regbuf = NULL;
-			uint32_t reg;
+	if(myself == DI_NODE_NIL) {
+		return (DI_WALK_CONTINUE);
+	}
 
-			n = di_prop_lookup_ints(DDI_DEV_T_ANY, pnode, "reg",
-			    (int **)&regbuf);
-			reg = regbuf[0];
-			bdf = (PCI_REG_BUS_G(reg) << 8) |
-			    (PCI_REG_DEV_G(reg) << 3) | PCI_REG_FUNC_G(reg);
-			session_id |= (bdf << i * 8);
+	dn = myself;
+	/* find the root hub */
+	while(di_prop_exists(DDI_DEV_T_ANY, dn, "root-hub") != 1) {
+		usbi_dbg("find_root_hub:%s", di_devfs_path(dn));
+		n = di_prop_lookup_ints(DDI_DEV_T_ANY, dn,
+				"assigned-address", &addr_prop);
+		session_id |= ((addr_prop[0] & 0xff) << i++ * 8);
+		dn = di_parent_node(dn);
+	}
 
-			/* same as 'unit-address' property */
-			bus_number =
-			    (PCI_REG_DEV_G(reg) << 3) | PCI_REG_FUNC_G(reg);
+	/* dn is the root hub node */
+	n = di_prop_lookup_ints(DDI_DEV_T_ANY, dn, "reg", (int **)&regbuf);
+	reg = regbuf[0];
+	bdf = (PCI_REG_BUS_G(reg) << 8) | (PCI_REG_DEV_G(reg) << 3) | PCI_REG_FUNC_G(reg);
+	/* bdf must larger than i*8 bits */
+	session_id |= (bdf << i * 8); 
+	bus_number = (PCI_REG_DEV_G(reg) << 3) | PCI_REG_FUNC_G(reg);
 
-			usbi_dbg("device bus address=%s:%x",
-			    di_bus_addr(pnode), bus_number);
+	usbi_dbg("device bus address=%s:%x, name:%s",
+	    di_bus_addr(myself), bus_number, di_node_name(dn));
+	usbi_dbg("session id org:%lx", session_id);	
 
-			break;
+	/* dn is the usb device */
+	for (dn = di_child_node(myself); dn != DI_NODE_NIL; dn = di_sibling_node(dn)) {
+		usbi_dbg("device path:%s", di_devfs_path(dn));
+		/* skip hub devices, because its driver can not been unload */
+		if(di_prop_lookup_ints(DDI_DEV_T_ANY, dn, "usb-port-count", &addr_prop) != -1) {
+			continue;
 		}
-
 		/* usb_addr */
-		n = di_prop_lookup_ints(DDI_DEV_T_ANY, pnode,
+		n = di_prop_lookup_ints(DDI_DEV_T_ANY, dn,
 		    "assigned-address", &addr_prop);
 		if ((n != 1) || (addr_prop[0] == 0)) {
 			usbi_dbg("cannot get valid usb_addr");
-
-			return (DI_WALK_CONTINUE);
+			continue;
 		}
 
-		session_id |= ((addr_prop[0] & 0xff) << i * 8);
-		if (++i > 7)
-			break;
+		sid = (session_id << 8) | (addr_prop[0] & 0xff) ;
+		usbi_dbg("session id %lx", sid);	
 
-		pnode = di_parent_node(pnode);
-	}
-
-	path = di_devlink_path(link);
-	dev = usbi_get_device_by_session_id(nargs->ctx, session_id);
-	if (dev == NULL) {
-		dev = usbi_alloc_device(nargs->ctx, session_id);
+		dev = usbi_get_device_by_session_id(nargs->ctx, sid);
 		if (dev == NULL) {
-			usbi_dbg("can't alloc device");
-
-			return (DI_WALK_TERMINATE);
+			dev = usbi_alloc_device(nargs->ctx, sid);
+			if (dev == NULL) {
+				usbi_dbg("can't alloc device");
+				continue;	
+			}
+			devpriv = (sunos_dev_priv_t *)dev->os_priv;
+			dev->bus_number = bus_number;
+	
+			if (sunos_fill_in_dev_info(dn, dev) != LIBUSB_SUCCESS) {
+				libusb_unref_device(dev);
+				usbi_dbg("get infomation fail");
+				continue;
+			}
+			if (usbi_sanitize_device(dev) < 0) {
+				libusb_unref_device(dev);
+				usbi_dbg("sanatize failed: ");
+				return (DI_WALK_TERMINATE);
+			}
+		} else {
+			devpriv = (sunos_dev_priv_t *)dev->os_priv;
+			usbi_dbg("Dev %s exists", devpriv->ugenpath);
 		}
-		devpriv = (sunos_dev_priv_t *)dev->os_priv;
-		if ((newpath = strrchr(path, '/')) == NULL) {
-			libusb_unref_device(dev);
-
-			return (DI_WALK_TERMINATE);
-		}
-		devpriv->ugenpath = strndup(path, strlen(path) -
-		    strlen(newpath));
-		dev->bus_number = bus_number;
-
-		if (sunos_fill_in_dev_info(myself, dev) != LIBUSB_SUCCESS) {
-			libusb_unref_device(dev);
-
-			return (DI_WALK_TERMINATE);
-		}
-		if (usbi_sanitize_device(dev) < 0) {
-			libusb_unref_device(dev);
-			usbi_dbg("sanatize failed: ");
-			return (DI_WALK_TERMINATE);
-		}
-	} else {
-		usbi_dbg("Dev %s exists", path);
-	}
-
-	devpriv = (sunos_dev_priv_t *)dev->os_priv;
-	if (nargs->last_ugenpath == NULL) {
-		/* first device */
-		nargs->last_ugenpath = devpriv->ugenpath;
-
+	
 		if (discovered_devs_append(*(nargs->discdevs), dev) == NULL) {
 			usbi_dbg("cannot append device");
 		}
@@ -285,11 +642,11 @@ sunos_add_devices(di_devlink_t link, void *arg)
 		 * hereafter. Front end or app should take care of their ref.
 		 */
 		libusb_unref_device(dev);
+	
+		usbi_dbg("Device %s %s id=0x%llx, devcount:%d, bdf=%x",
+		    devpriv->ugenpath, di_devfs_path(dn), (uint64_t)sid,
+		    (*nargs->discdevs)->len, bdf);
 	}
-
-	usbi_dbg("Device %s %s id=0x%llx, devcount:%d, bdf=%x",
-	    devpriv->ugenpath, path, (uint64_t)session_id,
-	    (*nargs->discdevs)->len, bdf);
 
 	return (DI_WALK_CONTINUE);
 }
@@ -303,14 +660,14 @@ sunos_walk_minor_node_link(di_node_t node, void *args)
 	struct node_args *nargs = (struct node_args *)args;
 	di_devlink_handle_t devlink_hdl = nargs->dlink_hdl;
 
-	/* walk each minor to find ugen devices */
+	/* walk each minor to find usb devices */
         while ((minor = di_minor_next(node, minor)) != DI_MINOR_NIL) {
                 minor_path = di_devfs_minor_path(minor);
                 arg.nargs = args;
 		arg.myself = node;
                 arg.minor = minor;
                 (void) di_devlink_walk(devlink_hdl,
-		    "^usb/[0-9a-f]+[.][0-9a-f]+", minor_path,
+		    "^usb/hub[0-9]+", minor_path,
 		    DI_PRIMARY_LINK, (void *)&arg, sunos_add_devices);
                 di_devfs_path_free(minor_path);
         }
@@ -496,7 +853,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 		usbi_dbg("can't find interface for endpoint 0x%02x",
 		    ep_addr);
 
-		return (LIBUSB_ERROR_ACCESS);
+		return (EACCES);
 	}
 
 	/* create filename */
@@ -601,6 +958,11 @@ sunos_open(struct libusb_device_handle *handle)
 	for (i = 0; i < USB_MAXENDPOINTS; i++) {
 		hpriv->eps[i].datafd = -1;
 		hpriv->eps[i].statfd = -1;
+	}
+	
+	if (sunos_kernel_driver_active(handle, 0)) {
+		/* pretend we can open the device */
+		return (LIBUSB_SUCCESS);
 	}
 
 	if ((ret = sunos_usb_open_ep0(hpriv, dpriv)) != LIBUSB_SUCCESS) {
@@ -1010,9 +1372,7 @@ void
 sunos_destroy_device(struct libusb_device *dev)
 {
 	sunos_dev_priv_t *dpriv = (sunos_dev_priv_t *)dev->os_priv;
-
-	usbi_dbg("");
-
+	usbi_dbg("destroy everyting");
 	free(dpriv->raw_cfgdescr);
 	free(dpriv->ugenpath);
 	free(dpriv->phypath);
@@ -1276,9 +1636,9 @@ const struct usbi_os_backend sunos_backend = {
         .reset_device = sunos_reset_device, /* TODO */
         .alloc_streams = NULL,
         .free_streams = NULL,
-        .kernel_driver_active = NULL,
-        .detach_kernel_driver = NULL,
-        .attach_kernel_driver = NULL,
+        .kernel_driver_active = sunos_kernel_driver_active,
+        .detach_kernel_driver = sunos_detach_kernel_driver,
+        .attach_kernel_driver = sunos_attach_kernel_driver,
         .destroy_device = sunos_destroy_device,
         .submit_transfer = sunos_submit_transfer,
         .cancel_transfer = sunos_cancel_transfer,

--- a/libusb/os/sunos_usb.h
+++ b/libusb/os/sunos_usb.h
@@ -65,6 +65,12 @@ struct devlink_cbarg {
 	di_minor_t		minor;
 };
 
+typedef struct walk_link {
+	char *path;
+	int len;
+	char **linkpp;
+} walk_link_t;
+
 /* AIO callback args */
 struct aio_callback_args{
 	struct libusb_transfer *transfer;


### PR DESCRIPTION
I resolved two issues for Solaris libusb-1.0 backend.
1. PyUSB can not show all the usb devices when using libusb-1.0 backend.
2. Support detach/attach kernel driver APIs.