### PR TITLE
darwin: Replace bzero() with memset()

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1742,7 +1742,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) {
 
   IOReturn               kresult;
 
-  bzero(&tpriv->req, sizeof(tpriv->req));
+  memset(&tpriv->req, 0, sizeof(tpriv->req));
 
   /* IOUSBDeviceInterface expects the request in cpu endianness */
   tpriv->req.bmRequestType     = setup->bmRequestType;


### PR DESCRIPTION
The bzero() function is a deprecated BSD function that can be replaced
by the standard C89 memset() function.  When compiling for POSIX 2008,
the bzero() function is undefined on the OS X platform.