### PR TITLE
Windows: cache_config_descriptors doesn't return error code

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -981,7 +981,7 @@ static int cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handle
 			LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
 		memcpy(priv->config_descriptor[i], cd_data, cd_data->wTotalLength);
 	}
-	return LIBUSB_SUCCESS;
+	return r;
 }
 
 /*


### PR DESCRIPTION
currently always returning `LIBUSB_SUCCESS` even if error was found

this can cause all sorts of trouble, including the root cause behind https://github.com/libusb/libusb/pull/183