### PR TITLE
Fix issue #144

### DIFF
--- a/libusb/os/threads_windows.h
+++ b/libusb/os/threads_windows.h
@@ -34,7 +34,7 @@ typedef struct usbi_cond {
 } usbi_cond_t;
 
 // We *were* getting timespec from pthread.h:
-#if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED))
+#if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED) && !defined(_INC_TIME))
 #define HAVE_STRUCT_TIMESPEC 1
 #define _TIMESPEC_DEFINED 1
 struct timespec {


### PR DESCRIPTION
Issue was claimed to be fixed, but still happens with Windows SDK 10.0.10240.0 and latest usb 1.2.0 (latest on npm).

The first definition is in time.h in the Windows SDK, which also does a #DEFINE _INC_TIME. Checking for this define allows us to skip redefining the struct and avoid this error.