### PR TITLE
Fix Null-Pointer exception as described in the mailing list

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1734,6 +1734,8 @@ static int windows_get_config_descriptor_by_value(struct libusb_device *dev, uin
 
 	for (index = 0; index < dev->num_configurations; index++) {
 		config_header = (PUSB_CONFIGURATION_DESCRIPTOR)priv->config_descriptor[index];
+        if (config_header == NULL)
+			return LIBUSB_ERROR_NOT_FOUND;
 		if (config_header->bConfigurationValue == bConfigurationValue) {
 			*buffer = priv->config_descriptor[index];
 			return (int)config_header->wTotalLength;


### PR DESCRIPTION
Fix Null-Pointer exception for HCD hubs. Concerning
libusb_get_device_descriptor.