### PR TITLE
Fix the usage and usagePage value is not right 

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3177,9 +3177,9 @@ static int _hid_get_report_descriptor(struct hid_device_priv *dev, void *data, s
 	size_t i = 0;
 
 	/* usage page (0xFFA0 == vendor defined) */
-	d[i++] = 0x06; d[i++] = 0xA0; d[i++] = 0xFF;
+	d[i++] = 0x06; d[i++] = dev->usagePage & 0xff;d[i++] = dev->usagePage >> 8;
 	/* usage (vendor defined) */
-	d[i++] = 0x09; d[i++] = 0x01;
+	d[i++] = 0x09; d[i++] = (uint8_t)dev->usage;
 	/* start collection (application) */
 	d[i++] = 0xA1; d[i++] = 0x01;
 	/* input report */
@@ -3601,6 +3601,8 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 		priv->hid->input_report_size = capabilities.InputReportByteLength;
 		priv->hid->output_report_size = capabilities.OutputReportByteLength;
 		priv->hid->feature_report_size = capabilities.FeatureReportByteLength;
+		priv->hid->usage = capabilities.Usage;
+		priv->hid->usagePage = capabilities.UsagePage;
 
 		// Fetch string descriptors
 		priv->hid->string_index[0] = priv->dev_descriptor.iManufacturer;

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -193,6 +193,8 @@ struct hid_device_priv {
 	uint16_t input_report_size;
 	uint16_t output_report_size;
 	uint16_t feature_report_size;
+	uint16_t usage;
+	uint16_t usagePage;
 	WCHAR string[3][MAX_USB_STRING_LENGTH];
 	uint8_t string_index[3]; // man, prod, ser
 };


### PR DESCRIPTION
This patch can fix the issue #278.  We fill the hid report descriptor with the real value of usage and usagePage.