### PR TITLE
macOS Sierra: Fix detection of parent devices.

### DIFF
--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11193
+#define LIBUSB_NANO 11194


### PR DESCRIPTION
This fixes the output of libusb_get_port_numbers(), where it used to merely return the port number of the device itself.
Now that libusb properly detects parent devices, we get the entire port path of the device.
For reference, here's the output of the 'listdevs' example before my changes:

tich-mbp:libusb-1.0.21 tich$ ./examples/listdevs
0409:005a (bus 29, device 6) path: 1
05ac:8509 (bus 26, device 2) path: 1
05ac:821d (bus 29, device 7) path: 3
05ac:0252 (bus 29, device 5) path: 3
05ac:8242 (bus 29, device 4) path: 2
0a5c:4500 (bus 29, device 3) path: 1
0424:2513 (bus 29, device 2) path: 8
8087:0024 (bus 29, device 1) path: 1
8087:0024 (bus 26, device 1) path: 1

And here's the output after my changes:

tich-mbp:libusb-1.0.21 tich$ ./examples/listdevs
0409:005a (bus 29, device 6) path: 1.1
05ac:8509 (bus 26, device 2) path: 1.1
05ac:821d (bus 29, device 7) path: 1.8.1.3
05ac:0252 (bus 29, device 5) path: 1.8.3
05ac:8242 (bus 29, device 4) path: 1.8.2
0a5c:4500 (bus 29, device 3) path: 1.8.1
0424:2513 (bus 29, device 2) path: 1.8
8087:0024 (bus 29, device 1) path: 1
8087:0024 (bus 26, device 1) path: 1

Since we're now using "IOUSBHostDevice" as the matching service (starting with El Capitan), we need to walk up the IOService plane to look for parents.
You can manually walk up the IOService plane by executing "ioreg -p IOService -l -w 0 -x | less" and looking for your device. Notice that the parent device is always a parent in the tree, but it's not always the _immediate_ parent of the device.

For reference, here's the output of "uname -a" on my machine:
Darwin tich-mbp 16.4.0 Darwin Kernel Version 16.4.0: Thu Dec 22 22:53:21 PST 2016; root:xnu-3789.41.3~3/RELEASE_X86_64 x86_64