### PR TITLE
darwin: use clock_gettime() on 10.12+

### DIFF
--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11192
+#define LIBUSB_NANO 11193


### PR DESCRIPTION
Apple implemented the POSIX.2 clock_gettime () call in macOS
10.12. This commit updates the darwin backend to not use the mach
clock if clock_gettime() is available.

Signed-off-by: Nathan Hjelm <hjelmn@mac.com>