### PR TITLE
Fix HCD hubs Null-Pointer exception in windows_get_config_descriptor_…

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1731,6 +1731,8 @@ static int windows_get_config_descriptor_by_value(struct libusb_device *dev, uin
 
 	for (index = 0; index < dev->num_configurations; index++) {
 		config_header = (PUSB_CONFIGURATION_DESCRIPTOR)priv->config_descriptor[index];
+		if (config_header == NULL)
+			return LIBUSB_ERROR_NOT_FOUND;
 		if (config_header->bConfigurationValue == bConfigurationValue) {
 			*buffer = priv->config_descriptor[index];
 			return (int)config_header->wTotalLength;


### PR DESCRIPTION
…by_value.
As described on the libusb-devel list this Null-Pointer check will fix problems with HCD hubs.
This fix just adds the same check that were used in version 1.0.20 and are necessary for some HCD hubs regarding not cached config descriptors.