### PR TITLE
Fix linux builds (<2.6.23 not supporting O_CLOEXEC)

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -27,6 +27,10 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+/* Older builds: O_CLOEXEC requires min. Linux 2.6.23 */
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
 #include <fcntl.h>
 #include <poll.h>
 #include <stdio.h>


### PR DESCRIPTION
Fix for older linux builds (<2.6.23) because of used flag O_CLOEXEC introduced with commit aa73b2ecb81f1fe4f503d3ac693679632587ad50.
