### PR TITLE
Fixed USB_CONFIGURATION_DESCRIPTOR struct alignment issue

### DIFF
--- a/libusb/os/windows_nt_common.h
+++ b/libusb/os/windows_nt_common.h
@@ -31,7 +31,7 @@
 #define FACILITY_SETUPAPI	15
 #endif
 
-#include <PSHPACK1.H>
+#include <pshpack1.h>
 
 typedef struct USB_CONFIGURATION_DESCRIPTOR {
   UCHAR  bLength;
@@ -44,7 +44,7 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
   UCHAR  MaxPower;
 } USB_CONFIGURATION_DESCRIPTOR, *PUSB_CONFIGURATION_DESCRIPTOR;
 
-#include <POPPACK.H>
+#include <poppack.h>
 
 typedef struct libusb_device_descriptor USB_DEVICE_DESCRIPTOR, *PUSB_DEVICE_DESCRIPTOR;
 

--- a/libusb/os/windows_nt_common.h
+++ b/libusb/os/windows_nt_common.h
@@ -31,6 +31,8 @@
 #define FACILITY_SETUPAPI	15
 #endif
 
+#include <PSHPACK1.H>
+
 typedef struct USB_CONFIGURATION_DESCRIPTOR {
   UCHAR  bLength;
   UCHAR  bDescriptorType;
@@ -41,6 +43,8 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
   UCHAR  bmAttributes;
   UCHAR  MaxPower;
 } USB_CONFIGURATION_DESCRIPTOR, *PUSB_CONFIGURATION_DESCRIPTOR;
+
+#include <POPPACK.H>
 
 typedef struct libusb_device_descriptor USB_DEVICE_DESCRIPTOR, *PUSB_DEVICE_DESCRIPTOR;
 


### PR DESCRIPTION
Fixed USB_CONFIGURATION_DESCRIPTOR struct alignment issue (10 bytes size instead of 9)