### PR TITLE
libusb.h: use __linux__ instead of __linux

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -54,7 +54,7 @@ typedef unsigned __int32  uint32_t;
 #include <sys/types.h>
 #endif
 
-#if defined(__linux) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__HAIKU__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__HAIKU__)
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
The check was added since sys/time.h is not available on Windows,
but breaks on PowerPC where __linux is not defined by GCC in strict
standards modes.

Signed-off-by: Adrian Bunk <bunk@debian.org>
Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>