### PR TITLE
Fix typo in exit() function signature

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -614,7 +614,7 @@ struct usbi_os_backend {
 	 *
 	 * This function is called when the user deinitializes the library.
 	 */
-	void (*exit)(struct libusb_contex *ctx);
+	void (*exit)(struct libusb_context *ctx);
 
 	/* Set a backend-specific option. Optional.
 	 *


### PR DESCRIPTION
This typo caused a bunch of compile warnings about incompatible pointer types.