### PR TITLE
darwin: fix reporting of USB3 device speed when kIOUSBDeviceInterfaceID320 is used

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1027,7 +1027,7 @@ static int process_new_device (struct libusb_context *ctx, io_service_t service)
     case kUSBDeviceSpeedLow: dev->speed = LIBUSB_SPEED_LOW; break;
     case kUSBDeviceSpeedFull: dev->speed = LIBUSB_SPEED_FULL; break;
     case kUSBDeviceSpeedHigh: dev->speed = LIBUSB_SPEED_HIGH; break;
-#if DeviceVersion >= 500
+#if defined (kIOUSBDeviceInterfaceID500)
     case kUSBDeviceSpeedSuper: dev->speed = LIBUSB_SPEED_SUPER; break;
 #endif
     default:


### PR DESCRIPTION
Even when version 320 of IOUSBDeviceInterface is used new enough OS can report
kUSBDeviceSpeedSuper as device speed. Without this fix libusb will return
LIBUSB_SPEED_UNKNOWN in that case (e.g. when deployment target was set to 10.7).