### PR TITLE
Fix isochronous transfers in Linux 4.13.8

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2084,6 +2084,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		for (j = 0, k = packet_offset - urb_packet_offset;
 				k < packet_offset; k++, j++) {
 			packet_len = transfer->iso_packet_desc[k].length;
+			urb->buffer_length += packet_len;
 			urb->iso_frame_desc[j].length = packet_len;
 		}
 


### PR DESCRIPTION
Sometime between 4.13.0 and 4.13.8, a new check appeared in `USBDEVFS_SUBMITURB` ioctl code:

```
		for (totlen = u = 0; u < number_of_packets; u++) {
			/*
			 * arbitrary limit need for USB 3.0
			 * bMaxBurst (0~15 allowed, 1~16 packets)
			 * bmAttributes (bit 1:0, mult 0~2, 1~3 packets)
			 * sizemax: 1024 * 16 * 3 = 49152
			 */
			if (isopkt[u].length > 49152) {
				ret = -EINVAL;
				goto error;
			}
			totlen += isopkt[u].length;
		}
		u *= sizeof(struct usb_iso_packet_descriptor);
		if (totlen <= uurb->buffer_length)
			uurb->buffer_length = totlen;
		else
			WARN_ONCE(1, "uurb->buffer_length is too short %d vs %d",
				  totlen, uurb->buffer_length);
		break;
```

Since libusb is not setting `uurb->buffer_length` for isochronous transfers, they all end up with 0 bytes transferred and the `uurb->buffer_length is too short %d vs %d` warning is printed in the dmesg. This PR makes libusb set `buffer_length` to be the sum of all iso descriptor lengths.