### PR TITLE
Break out of event handling when attempt to cancel fails

### DIFF
--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -54,7 +54,8 @@ static void sync_transfer_wait_for_completion(struct libusb_transfer *transfer)
 				continue;
 			usbi_err(ctx, "libusb_handle_events failed: %s, cancelling transfer and retrying",
 				 libusb_error_name(r));
-			libusb_cancel_transfer(transfer);
+			if (libusb_cancel_transfer(transfer))
+				break;
 			continue;
 		}
 	}


### PR DESCRIPTION
Fixes #369 

This is a very basic attempt to prevent infinite loop which seems to happen when `libusb_cancel_transfer` fails. I am new to this codebase so please enlighten me if there is more sophisticated teardown that should happen in this situation.