### PR TITLE
Fix appveyor scripts for Cygwin and MinGW to build as intended

### DIFF
--- a/appveyor_cygwin.bat
+++ b/appveyor_cygwin.bat
@@ -1,14 +1,11 @@
 echo on
 SetLocal EnableDelayedExpansion
 
-if [%Configuration%] NEQ [Debug] goto releaseWin32
-
-:releaseWin32
-if [%Platform%] NEQ [Win32] exit 0
 if [%Configuration%] NEQ [Release] exit 0
-C:\cygwin\bin\bash -e -l -c "mkdir build-Win32-cygwin"
-C:\cygwin\bin\bash -e -l -c ./autogen.sh
-C:\cygwin\bin\bash -e -l -c "cd build-Win32-cygwin"
-C:\cygwin\bin\bash -e -l -c "build-Win32-cygwin/../configure"
-C:\cygwin\bin\bash -e -l -c "make -j4"
-C:\cygwin\bin\bash -e -l -c "make install"
+if [%Platform%] NEQ [Win32] exit 0
+
+C:\cygwin\bin\bash -e -l -c "./bootstrap.sh" || exit /B
+C:\cygwin\bin\bash -e -l -c "mkdir build-Win32-cygwin" || exit /B
+C:\cygwin\bin\bash -e -l -c "cd build-Win32-cygwin && ../configure --enable-examples-build --enable-tests-build" || exit /B
+C:\cygwin\bin\bash -e -l -c "cd build-Win32-cygwin && make -j4" || exit /B
+C:\cygwin\bin\bash -e -l -c "cd build-Win32-cygwin && make install" || exit /B

--- a/appveyor_minGW.bat
+++ b/appveyor_minGW.bat
@@ -1,24 +1,19 @@
 echo on
 SetLocal EnableDelayedExpansion
 
-if [%Configuration%] NEQ [Debug] goto releasex64
-
-:releasex64
-if [%Platform%] NEQ [x64] goto releaseWin32
 if [%Configuration%] NEQ [Release] exit 0
-C:\msys64\usr\bin\bash -e -l -c "mkdir build-x64"
-C:\msys64\usr\bin\bash -e -l -c ./autogen.sh
-C:\msys64\usr\bin\bash -e -l -c "cd build-x64"
-C:\msys64\usr\bin\bash -e -l -c "build-x64/../configure --prefix=/mingw64 --build=--build= --host=x86_64-w64-mingw32"
-C:\msys64\usr\bin\bash -e -l -c "make -j4"
-C:\msys64\usr\bin\bash -e -l -c "make install"
 
-:releaseWin32
+if [%Platform%] NEQ [x64] goto Win32
+C:\msys64\usr\bin\bash -e -l -c "./bootstrap.sh" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "mkdir build-x64" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-x64 && ../configure --prefix=/mingw64 --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-x64 && make -j4" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-x64 && make install" || exit /B
+
+:Win32
 if [%Platform%] NEQ [Win32] exit 0
-if [%Configuration%] NEQ [Release] exit 0
-C:\msys64\usr\bin\bash -e -l -c "mkdir build-Win32"
-C:\msys64\usr\bin\bash -e -l -c ./autogen.sh
-C:\msys64\usr\bin\bash -e -l -c "cd build-Win32"
-C:\msys64\usr\bin\bash -e -l -c "build-Win32/../configure --prefix=/mingw32 --build=i686-w64-mingw32 --host=i686-w64-mingw32"
-C:\msys64\usr\bin\bash -e -l -c "make -j4"
-C:\msys64\usr\bin\bash -e -l -c "make install"
+C:\msys64\usr\bin\bash -e -l -c "./bootstrap.sh" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "mkdir build-Win32" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-Win32 && ../configure --prefix=/mingw32 --build=i686-w64-mingw32 --host=i686-w64-mingw32" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-Win32 && make -j4" || exit /B
+C:\msys64\usr\bin\bash -e -l -c "cd build-Win32 && make install" || exit /B

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11285
+#define LIBUSB_NANO 11286

--- a/msvc/appveyor.bat
+++ b/msvc/appveyor.bat
@@ -7,22 +7,21 @@ if [%Configuration%] NEQ [Release] goto debugx64
 :debugx64
 if [%Platform%] NEQ [x64] goto debugWin32
 if [%Configuration%] NEQ [Debug] exit 0
-call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /Debug /x64
-msbuild %libusb_2010% /p:Configuration=Debug,Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /Debug /x64 || exit /B
+msbuild %libusb_2010% /p:Configuration=Debug,Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || exit /B
 
 :releasex64
 if [%Platform%] NEQ [x64] goto releaseWin32
 if [%Configuration%] NEQ [Release] exit 0
-call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /Release /x64
-msbuild %libusb_2010% /p:Configuration=Release,Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /Release /x64 || exit /B
+msbuild %libusb_2010% /p:Configuration=Release,Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || exit /B
 
 :debugWin32
 if [%Platform%] NEQ [Win32] exit 0
 if [%Configuration%] NEQ [Debug] exit 0
-msbuild %libusb_2010% /p:Configuration=Debug,Platform=Win32 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+msbuild %libusb_2010% /p:Configuration=Debug,Platform=Win32 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || exit /B
 
 :releaseWin32
 if [%Platform%] NEQ [Win32] exit 0
 if [%Configuration%] NEQ [Release] exit 0
-msbuild %libusb_2010% /p:Configuration=Release,Platform=Win32 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-
+msbuild %libusb_2010% /p:Configuration=Release,Platform=Win32 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || exit /B


### PR DESCRIPTION
The sub-directory created to store the generated files and build objects
was not being used as intended, because each invocation of the bash
shell inherits the current working directory. Fix this by making and
changing directories in the parent script.

Also replace the invocation of autogen.sh with bootstrap.sh, since using
autogen.sh calls ./configure and we weren't using the results of that
work. Instead we call configure directly from the sub-directory while
enabling the examples and test builds as autogen.sh would do.

Also fixes the invalid value for the --build option provided to the x64
build of MinGW.

Signed-off-by: Chris Dickens <christopher.a.dickens@gmail.com>