### PR TITLE
Added libusb_hotplug_get_user_data

### DIFF
--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -356,6 +356,31 @@ void API_EXPORTED libusb_hotplug_deregister_callback(struct libusb_context *ctx,
 	}
 }
 
+void* API_EXPORTED libusb_hotplug_get_user_data(struct libusb_context *ctx,
+	libusb_hotplug_callback_handle callback_handle){
+	struct libusb_hotplug_callback *hotplug_cb;
+	void* user_data = NULL;
+
+	/* check for hotplug support */
+	if(!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)){
+		return NULL;
+	}
+
+	USBI_GET_CONTEXT(ctx);
+
+	usbi_dbg("get hotplug user data %d", callback_handle);
+
+	usbi_mutex_lock(&ctx->hotplug_cbs_lock);
+	list_for_each_entry(hotplug_cb, &ctx->hotplug_cbs, list, struct libusb_hotplug_callback){
+		if(callback_handle == hotplug_cb->handle){
+			user_data = hotplug_cb->user_data;
+		}
+	}
+	usbi_mutex_unlock(&ctx->hotplug_cbs_lock);
+
+	return user_data;
+}
+
 void usbi_hotplug_deregister(struct libusb_context *ctx, int forced)
 {
 	struct libusb_hotplug_callback *hotplug_cb, *next;

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1993,6 +1993,17 @@ int LIBUSB_CALL libusb_hotplug_register_callback(libusb_context *ctx,
 void LIBUSB_CALL libusb_hotplug_deregister_callback(libusb_context *ctx,
 						libusb_hotplug_callback_handle callback_handle);
 
+/** \ingroup libusb_hotplug
+ * Gets the user_data associated with a hotplug callback.
+ *
+ * Since version v1.0.23 \ref LIBUSB_API_VERSION >= 0x01000103
+ *
+ * \param[in] ctx context this callback is registered with
+ * \param[in] callback_handle the handle of the callback to get the user_data of
+ */
+void* LIBUSB_CALL libusb_hotplug_get_user_data(struct libusb_context *ctx,
+						libusb_hotplug_callback_handle callback_handle);
+
 /** \ingroup libusb_lib
  * Available option values for libusb_set_option().
  */


### PR DESCRIPTION
I have a project that needs to be able to fetch `user_data` from a registered libusb callback, this patch adds `libusb_hotplug_get_user_data`.