### PR TITLE
Windows: Fix race condition between submit and handle events on windows

### DIFF
--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -149,8 +149,7 @@ static int check_pollfds(struct pollfd *fds, unsigned int nfds,
 			continue;
 		}
 
-		// The following macro only works if overlapped I/O was reported pending
-		if (HasOverlappedIoCompleted(&fd->overlapped)) {
+		if (WaitForSingleObject(fd->overlapped.hEvent, 0) == WAIT_OBJECT_0) {
 			fds[n].revents = fds[n].events;
 			nready++;
 		} else if (wait_handles != NULL) {


### PR DESCRIPTION
Check the event object for completion in poll instead of using HasOverlappedIoCompleted
When we submit a transfer on windows the fd is added to the poll list before the read/write begins, so HasOverlappedIoCompleted can be called before overlapped.Internal is set to ERROR_IO_PENDING if events are being being handled concurrently, so the fd will be marked as completed before it has actually started.