### PR TITLE
Fix for Apple devices not showing in normal mode

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -528,7 +528,6 @@ static void darwin_check_version (void) {
   errno = 0;
   version = strtol (version_string, NULL, 10);
   if (0 == errno && version >= 15) {
-    darwin_device_class = "IOUSBHostDevice";
   }
 }
 
@@ -894,7 +893,7 @@ static int get_device_parent_sessionID(io_service_t service, UInt64 *parent_sess
 
   /* Walk up the tree in the IOService plane until we find a parent that has a sessionID */
   parent = service;
-  while((result = IORegistryEntryGetParentEntry (parent, kIOServicePlane, &parent)) == kIOReturnSuccess) {
+  while((result = IORegistryEntryGetParentEntry (parent, kIOUSBPlane, &parent)) == kIOReturnSuccess) {
     if (get_ioregistry_value_number (parent, CFSTR("sessionID"), kCFNumberSInt64Type, parent_sessionID)) {
         /* Success */
         return 1;


### PR DESCRIPTION
Hey there, here is a fix for Apple devices not showing in normal mode (device is detected in Recovery/DFU mode).

People were talking about this patch in #290 but has not been submitted yet