### PR TITLE
usbi_dbg() uses backend's clock_gettime(), break recursion in sunos b…

### DIFF
--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -1503,8 +1503,6 @@ sunos_handle_transfer_completion(struct usbi_transfer *itransfer)
 int
 sunos_clock_gettime(int clkid, struct timespec *tp)
 {
-	usbi_dbg("clock %d", clkid);
-
 	if (clkid == USBI_CLOCK_REALTIME)
 		return clock_gettime(CLOCK_REALTIME, tp);
 


### PR DESCRIPTION
…ackend