### PR TITLE
configure.ac: fix detection of clock_gettime library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ case $backend in
 linux)
 	AC_DEFINE(OS_LINUX, 1, [Linux backend])
 	AC_SUBST(OS_LINUX)
-	AC_SEARCH_LIBS([clock_gettime2], [rt], [], [], [-pthread])
+	AC_SEARCH_LIBS([clock_gettime], [rt], [], [], [-pthread])
 	AC_ARG_ENABLE([udev],
 		[AC_HELP_STRING([--enable-udev], [use udev for device enumeration and hotplug support (recommended) [default=yes]])],
 		[], [enable_udev=yes])


### PR DESCRIPTION
glibc before 2.17 requires link with librt for clock_gettime(). The
AC_SEARCH_LIBS check in configure.ac should detect this dependency.
Unfortunately commit cb77a25e51 (configure.ac: Remove obsolete AC_ERROR
and make formatting consistent) inadvertently renamed to clock_gettime2,
thus breaking librt detection.

Restore the correct clock_gettime() name.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>