### PR TITLE
examples: Fix format-truncation on debug

### DIFF
--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -169,7 +169,7 @@ static int print_device(libusb_device *dev, int level)
 {
 	struct libusb_device_descriptor desc;
 	libusb_device_handle *handle = NULL;
-	char description[256];
+	char description[260];
 	char string[256];
 	int ret;
 	uint8_t i;


### PR DESCRIPTION
As description is used only for debug, we can extend it to be sure to
fit 256 from string variable plus 3 chars from " - " as described in
gcc warning below

 | testlibusb.c: In function ‘print_device.constprop’:
 | testlibusb.c:188:51: warning: ‘ - ’ directive output may be truncated writing 3 bytes into a region of size between 1 and 256 [-Wformat-truncation=]
 |      snprintf(description, sizeof(description), "%s - ", string);
 |                                                    ^~~
 | testlibusb.c:188:5: note: ‘snprintf’ output between 4 and 259 bytes into a destination of size 256
 |      snprintf(description, sizeof(description), "%s - ", string);
 |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Victor Toso <victortoso@redhat.com>