### PR TITLE
Allow set configuration control requests when using libusb0.sys

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2406,8 +2406,9 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 	transfer_priv->handle = winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 	overlapped = transfer_priv->pollable_fd.overlapped;
 
-	// Sending of set configuration control requests from WinUSB creates issues
-	if ((LIBUSB_REQ_TYPE(setup->RequestType) == LIBUSB_REQUEST_TYPE_STANDARD)
+	// Sending of set configuration control requests from WinUSB creates issues, except when using libusb0.sys
+	if (sub_api != SUB_API_LIBUSB0
+			&& (LIBUSB_REQ_TYPE(setup->RequestType) == LIBUSB_REQUEST_TYPE_STANDARD)
 			&& (setup->Request == LIBUSB_REQUEST_SET_CONFIGURATION)) {
 		if (setup->Value != priv->active_config) {
 			usbi_warn(ctx, "cannot set configuration other than the default one");


### PR DESCRIPTION
`libusb0.sys` supports setting the active configuration on Windows. (It is the only open source Windows driver I know of that does.)

This PR allows sending of the set configuration control request when using `libusb0.sys`.

This PR is intended to be used together with https://github.com/mcuee/libusbk/pull/15
