### PR TITLE
windows: relax HCD root hub enumeration errors

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -925,15 +925,15 @@ static int enumerate_hcd_root_hub(struct libusb_context *ctx, const char *dev_id
 	DEVINST child_devinst;
 
 	if (CM_Get_Child(&child_devinst, devinst, 0) != CR_SUCCESS) {
-		usbi_err(ctx, "could not get child devinst for '%s'", dev_id);
-		return LIBUSB_ERROR_OTHER;
+		usbi_warn(ctx, "could not get child devinst for '%s'", dev_id);
+		return LIBUSB_SUCCESS;
 	}
 
 	session_id = (unsigned long)child_devinst;
 	dev = usbi_get_device_by_session_id(ctx, session_id);
 	if (dev == NULL) {
-		usbi_err(ctx, "program assertion failed - HCD '%s' child not found", dev_id);
-		return LIBUSB_ERROR_NO_DEVICE;
+		usbi_warn(ctx, "program assertion failed - HCD '%s' child not found", dev_id);
+		return LIBUSB_SUCCESS;
 	}
 
 	if (dev->bus_number == 0) {


### PR DESCRIPTION
windows: relax HCD root hub enumeration errors

Enumeration errors happen on one HCD root hub should not prevent enumerating other hubs. This will fix an issue seen on some Windows 7 hosts with USB 3.0 host controller.

Closes #441