### PR TITLE
Core: new API (libusb_set_log_cb) to redirect log messages.

### DIFF
--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -148,6 +148,8 @@ EXPORTS
   libusb_set_configuration@8 = libusb_set_configuration
   libusb_set_debug
   libusb_set_debug@8 = libusb_set_debug
+  libusb_set_log_cb
+  libusb_set_log_cb@12 = libusb_set_log_cb
   libusb_set_interface_alt_setting
   libusb_set_interface_alt_setting@12 = libusb_set_interface_alt_setting
   libusb_set_option

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1294,10 +1294,35 @@ enum libusb_log_level {
 	LIBUSB_LOG_LEVEL_DEBUG = 4,
 };
 
+/** \ingroup libusb_lib
+ *  Log callback mode.
+ * \see libusb_set_log_cb()
+ */
+enum libusb_log_cb_mode {
+
+	/** Callback function handling all log mesages. */
+	LIBUSB_LOG_CB_GLOBAL = 1 << 0,
+
+	/** Callback function handling context related log mesages. */
+	LIBUSB_LOG_CB_CONTEXT = 1 << 1
+};
+
+/** \ingroup libusb_lib
+ * Callback function for handling log messages.
+ * \param ctx the context which is related to the log message, or NULL if it
+ * is a global log message
+ * \param level the log level, see \ref libusb_log_level for a description
+ * \param str the log message
+ * \see libusb_set_log_cb()
+ */
+typedef void (LIBUSB_CALL *libusb_log_cb)(libusb_context *ctx,
+	enum libusb_log_level level, const char *str);
+
 int LIBUSB_CALL libusb_init(libusb_context **ctx);
 void LIBUSB_CALL libusb_exit(libusb_context *ctx);
 LIBUSB_DEPRECATED_FOR(libusb_set_option)
 void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
+void LIBUSB_CALL libusb_set_log_cb(libusb_context *ctx, libusb_log_cb cb, int mode);
 const struct libusb_version * LIBUSB_CALL libusb_get_version(void);
 int LIBUSB_CALL libusb_has_capability(uint32_t capability);
 const char * LIBUSB_CALL libusb_error_name(int errcode);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -293,6 +293,7 @@ struct libusb_context {
 #if defined(ENABLE_LOGGING) && !defined(ENABLE_DEBUG_LOGGING)
 	enum libusb_log_level debug;
 	int debug_fixed;
+	libusb_log_cb log_handler;
 #endif
 
 	/* internal event pipe, used for signalling occurrence of an internal event. */


### PR DESCRIPTION
The proposed API allows to redirect all log messages to a custom log handler function that can be useful in situations when libusb is used by the application with own centralized logging (which can log as to console, so to the file and etc.). These logs can be collected from the users of the application for the debugging purpose of some failures/problems and thus having possibility to redirect logs is very important for such case.

The implementation does not require ```libusb_init``` be called forehand and if callback is provided before the ```libusb_init``` then logs from the possible failure to initialize will also be forwarded to the callback function that can be useful in debugging the reason of the failure.

The usage example can be as such:
```c
void my_log_handler(enum libusb_log_level level, const char *str)
{
...
}

...

int r;

libusb_set_log_cb(my_log_handler);

if ((r = libusb_init(&context)) < 0)
{
    USBErrLog("libusb_init() failed with error: %d", r);
    return false;
}

...
```

It is a refactored log redirection proposal from this pull request:
http://github.com/libusb/libusb/pull/190