### PR TITLE
Fixed log message incorrect data format sent to MSVC if Unicode defined.

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2408,13 +2408,14 @@ int usbi_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 static void usbi_log_str(enum libusb_log_level level, const char *str)
 {
 #if defined(USE_SYSTEM_LOGGING_FACILITY)
-#if defined(OS_WINDOWS)
+#if defined(OS_WINDOWS) || defined(OS_WINCE)
+#if !defined(UNICODE)
 	OutputDebugStringA(str);
-#elif defined(OS_WINCE)
-	/* Windows CE only supports the Unicode version of OutputDebugString. */
+#else
 	WCHAR wbuf[USBI_MAX_LOG_LEN];
-	MultiByteToWideChar(CP_UTF8, 0, str, -1, wbuf, sizeof(wbuf));
-	OutputDebugStringW(wbuf);
+	if (MultiByteToWideChar(CP_UTF8, 0, str, -1, wbuf, sizeof(wbuf)) != 0)
+		OutputDebugStringW(wbuf);
+#endif
 #elif defined(__ANDROID__)
 	int priority = ANDROID_LOG_UNKNOWN;
 	switch (level) {

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2409,7 +2409,7 @@ static void usbi_log_str(enum libusb_log_level level, const char *str)
 {
 #if defined(USE_SYSTEM_LOGGING_FACILITY)
 #if defined(OS_WINDOWS)
-	OutputDebugString(str);
+	OutputDebugStringA(str);
 #elif defined(OS_WINCE)
 	/* Windows CE only supports the Unicode version of OutputDebugString. */
 	WCHAR wbuf[USBI_MAX_LOG_LEN];


### PR DESCRIPTION
If USE_SYSTEM_LOGGING_FACILITY is defined and Platform is Windows and thus OS_WINDOWS is defined and project is configured as Unicode then ```OutputDebugString``` macro is expanded to ```OutputDebugStringW```.

Log message variable ```str``` has ```const char *``` format while OutputDebugStringW expects ```const wchar_t *``` that will cause garbled output in the Output window of the Visual Studio and can also cause buffer overrun. While compiling Visual Studio gives such warning:

```` c
libusb\core.c(2412): warning C4133: 'function': incompatible types - from 'const char *' to 'LPCWSTR'
````

The proposed change is to force ```OutputDebugStringA``` which expects ```const char *```.

But, if libusb log messages may contain some non-Latin text then the ifdefed solution inside ```OS_WINCE``` would be more suitable and proposed implementation could be changed to it.