### PR TITLE
windows: get usb device until usb configuration is set

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2146,6 +2146,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 	}
 	fds = ctx->pollfds;
 	nfds = ctx->pollfds_cnt;
+	usbi_inc_fds_ref(fds, nfds);
 	usbi_mutex_unlock(&ctx->event_data_lock);
 
 	timeout_ms = (int)(tv->tv_sec * 1000) + (tv->tv_usec / 1000);
@@ -2278,6 +2279,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 
 done:
 	usbi_end_event_handling(ctx);
+	usbi_dec_fds_ref(fds, nfds);
 	return r;
 }
 

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2082,9 +2082,16 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 
 	/* prevent attempts to recursively handle events (e.g. calling into
 	 * libusb_handle_events() from within a hotplug or transfer callback) */
+	usbi_mutex_lock(&ctx->event_data_lock);
+	r = 0;
 	if (usbi_handling_events(ctx))
-		return LIBUSB_ERROR_BUSY;
-	usbi_start_event_handling(ctx);
+		r = LIBUSB_ERROR_BUSY;
+	else
+		usbi_start_event_handling(ctx);
+	usbi_mutex_unlock(&ctx->event_data_lock);
+
+	if (r)
+		return r;
 
 	/* there are certain fds that libusb uses internally, currently:
 	 *

--- a/libusb/os/poll_posix.h
+++ b/libusb/os/poll_posix.h
@@ -8,4 +8,7 @@
 
 int usbi_pipe(int pipefd[2]);
 
+#define usbi_inc_fds_ref(x, y)
+#define usbi_dec_fds_ref(x, y)
+
 #endif /* LIBUSB_POLL_POSIX_H */

--- a/libusb/os/poll_windows.h
+++ b/libusb/os/poll_windows.h
@@ -71,6 +71,9 @@ ssize_t usbi_write(int fd, const void *buf, size_t count);
 ssize_t usbi_read(int fd, void *buf, size_t count);
 int usbi_close(int fd);
 
+int usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds);
+int usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds);
+
 /*
  * Timeval operations
  */

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -793,6 +793,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 	DWORD size;
 	uint8_t bus_number, depth;
 	int r;
+	int ginfotimeout;
 
 	priv = _device_priv(dev);
 
@@ -850,23 +851,46 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 		memset(&conn_info, 0, sizeof(conn_info));
 		conn_info.ConnectionIndex = (ULONG)port_number;
 		// coverity[tainted_data_argument]
-		if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
-			&conn_info, sizeof(conn_info), &size, NULL)) {
-			usbi_warn(ctx, "could not get node connection information for device '%s': %s",
-				  priv->dev_id, windows_error_str(0));
-			CloseHandle(hub_handle);
-			return LIBUSB_ERROR_NO_DEVICE;
+		ginfotimeout = 20;
+		do {
+			if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
+				&conn_info, sizeof(conn_info), &size, NULL)) {
+				usbi_warn(ctx, "could not get node connection information for device '%s': %s",
+					priv->dev_id, windows_error_str(0));
+				CloseHandle(hub_handle);
+				return LIBUSB_ERROR_NO_DEVICE;
+			}
+
+			if (conn_info.ConnectionStatus == NoDeviceConnected) {
+				usbi_err(ctx, "device '%s' is no longer connected!", priv->dev_id);
+				CloseHandle(hub_handle);
+				return LIBUSB_ERROR_NO_DEVICE;
+			}
+
+			memcpy(&priv->dev_descriptor, &(conn_info.DeviceDescriptor), sizeof(USB_DEVICE_DESCRIPTOR));
+			dev->num_configurations = priv->dev_descriptor.bNumConfigurations;
+			priv->active_config = conn_info.CurrentConfigurationValue;
+			if (priv->active_config == 0) {
+				usbi_dbg("0x%x:0x%x found %u configurations (active conf: %u) \n",
+					priv->dev_descriptor.idVendor,
+					priv->dev_descriptor.idProduct,
+					dev->num_configurations,
+					priv->active_config);
+			}
+			if (priv->active_config == 0)
+				Sleep(50);
+		} while (priv->active_config == 0 && --ginfotimeout >= 0);
+
+		if (priv->active_config == 0) {
+			usbi_dbg("after try 0x%x:0x%x found %u configurations (active conf: %u) \n",
+				priv->dev_descriptor.idVendor,
+				priv->dev_descriptor.idProduct,
+				dev->num_configurations,
+				priv->active_config);
+			usbi_dbg("Force this device active config to 1 in libusb! \nNOTICE: Should not reach this place!!!!!! \n");
+			priv->active_config = 1;
 		}
 
-		if (conn_info.ConnectionStatus == NoDeviceConnected) {
-			usbi_err(ctx, "device '%s' is no longer connected!", priv->dev_id);
-			CloseHandle(hub_handle);
-			return LIBUSB_ERROR_NO_DEVICE;
-		}
-
-		memcpy(&priv->dev_descriptor, &(conn_info.DeviceDescriptor), sizeof(USB_DEVICE_DESCRIPTOR));
-		dev->num_configurations = priv->dev_descriptor.bNumConfigurations;
-		priv->active_config = conn_info.CurrentConfigurationValue;
 		usbi_dbg("found %u configurations (active conf: %u)", dev->num_configurations, priv->active_config);
 
 		// Cache as many config descriptors as we can


### PR DESCRIPTION
There are low possiblity to open device before windows complete usb
configuration. Then claim interface will be always failure.
this patch workaround this problem, make sure return device until
windows finish usb configuration.

Signed-off-by: Frank Li <Frank.Li@nxp.com>
Signed-off-by: Tom Zheng <haidong.zheng@nxp.com>