### PR TITLE
fix windows crash when multi-thread do sync transfer

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2139,6 +2139,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 	}
 	fds = ctx->pollfds;
 	nfds = ctx->pollfds_cnt;
+	usbi_inc_fds_ref(fds, nfds);
 	usbi_mutex_unlock(&ctx->event_data_lock);
 
 	timeout_ms = (int)(tv->tv_sec * 1000) + (tv->tv_usec / 1000);
@@ -2271,6 +2272,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 
 done:
 	usbi_end_event_handling(ctx);
+	usbi_dec_fds_ref(fds, nfds);
 	return r;
 }
 

--- a/libusb/os/poll_posix.h
+++ b/libusb/os/poll_posix.h
@@ -8,4 +8,7 @@
 
 int usbi_pipe(int pipefd[2]);
 
+#define usbi_inc_fds_ref(x, y)
+#define usbi_dec_fds_ref(x, y)
+
 #endif /* LIBUSB_POLL_POSIX_H */

--- a/libusb/os/poll_windows.h
+++ b/libusb/os/poll_windows.h
@@ -71,6 +71,9 @@ ssize_t usbi_write(int fd, const void *buf, size_t count);
 ssize_t usbi_read(int fd, void *buf, size_t count);
 int usbi_close(int fd);
 
+int usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds);
+int usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds);
+
 /*
  * Timeval operations
  */


### PR DESCRIPTION
fun()
{
    libusb_open()
    ... sync transfer
    libusb_close()
}

two thread call fun infininately.

to speed up crash, enable application verifier

below 20 cycle, assert(fd!=NULL) happen at check_pollfds
below 100 cycle, crash at pollable_fd->overlappend in
winusb_get_overlapped result

with this fix, success fun over 1000 cycles

in handle_events

usbi_mutex_lock()
fds = ctx->pollfds
nfds = ctx->pollfds_cnt;
usbi_mutex_unclock()

usbi_poll()
callback.

usbi poll is not in mutex. pollfds may be change by usbi_add_pollfd
and usbi_remove_pollfd.

Although usbi_add_pollfd and usbi_remove_pollfd hold mutex, but
usbi_poll and callback is not in protext of mutex.

windows use fd as index of fb_table. fb_table may changed by
usbi_remove_pollfd.  the map between fd and internal file_descriptor may
be wrong.

this patch added ref count for file_descriptor, only free file_desciptor
and remove it from fb_table when ref count is 0.

ref count will be increase when fds copy with mutex lock.
so fd always index validate file_descriptor.

ref count will be descress before return from handle_events.
the file_descriptor can be free safely at this time.

Signed-off-by: Frank Li <Frank.Li@nxp.com>