### PR TITLE
Fix for (obviously serious) bug when compiling for Windows

### DIFF
--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -974,6 +974,7 @@ const struct usbi_os_backend usbi_backend = {
 	windows_set_option,
 	windows_get_device_list,
 	NULL,	/* hotplug_poll */
+	NULL,	/* wrap_sys_device */
 	windows_open,
 	windows_close,
 	windows_get_device_descriptor,


### PR DESCRIPTION
Today Visual Studio 2015 threw a lots of warnings below that line I now added, which was not the case a few weeks ago.

Obviously the usbi_os_backend struct was extended recently without adjusting this place where it gets filled for Windows.
Unfortunately, named initializers are not used here (though they are supported for C in the last versions of MSVC !) . This leads to a shift of 1 in the rest of all assignments. Irritating enough, this only yields warnings about non-matching types (still compiles without error) but I'd strongly expect this bug cause serious(!) problems.

Note that the value of NULL (not implemented) is my best guess.