### PR TITLE
windows_winusb: Add support for reporting super speed plus devices

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -881,6 +881,8 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 				&conn_info_v2, sizeof(conn_info_v2), &conn_info_v2, sizeof(conn_info_v2), &size, NULL)) {
 				usbi_warn(ctx, "could not get node connection information (V2) for device '%s': %s",
 					  priv->dev_id,  windows_error_str(0));
+			} else if (conn_info_v2.Flags.DeviceIsOperatingAtSuperSpeedPlusOrHigher) {
+				conn_info.Speed = 4;
 			} else if (conn_info_v2.Flags.DeviceIsOperatingAtSuperSpeedOrHigher) {
 				conn_info.Speed = 3;
 			}
@@ -898,6 +900,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 		case 1: dev->speed = LIBUSB_SPEED_FULL; break;
 		case 2: dev->speed = LIBUSB_SPEED_HIGH; break;
 		case 3: dev->speed = LIBUSB_SPEED_SUPER; break;
+		case 4: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
 		default:
 			usbi_warn(ctx, "unknown device speed %u", conn_info.Speed);
 			break;

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -397,7 +397,9 @@ typedef union _USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS {
 	struct {
 		ULONG DeviceIsOperatingAtSuperSpeedOrHigher:1;
 		ULONG DeviceIsSuperSpeedCapableOrHigher:1;
-		ULONG ReservedMBZ:30;
+		ULONG DeviceIsOperatingAtSuperSpeedPlusOrHigher:1;
+		ULONG DeviceIsSuperSpeedPlusCapableOrHigher:1;
+		ULONG ReservedMBZ:28;
 	};
 } USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS, *PUSB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS;
 


### PR DESCRIPTION
Tested with USB-C 3.1 device on Windows 10 latest with Dell Laptop.