### PR TITLE
Offer an internal hardware ID for more complex device matching

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -970,7 +970,7 @@ int API_EXPORTED libusb_get_port_path(libusb_context *ctx, libusb_device *dev,
  * function and make sure that you only access the parent before issuing
  * \ref libusb_free_device_list(). The reason is that libusb currently does
  * not maintain a permanent list of device instances, and therefore can
- * only guarantee that parents are fully instantiated within a 
+ * only guarantee that parents are fully instantiated within a
  * libusb_get_device_list() - libusb_free_device_list() block.
  */
 DEFAULT_VISIBILITY
@@ -987,6 +987,28 @@ libusb_device * LIBUSB_CALL libusb_get_parent(libusb_device *dev)
 uint8_t API_EXPORTED libusb_get_device_address(libusb_device *dev)
 {
 	return dev->device_address;
+}
+
+/** \ingroup libusb_dev
+ * Get a platform id string of the device on the bus it is connected to.
+ *
+ * Linux:   udev_device_new_from_subsystem_sysname(,"usb",id);
+ * macOS:   IORegistryEntryFromPath(,id)
+ * Windows: CM_Locate_DevNodeA(,id,)
+ *
+ * \param dev a device
+ * \param data a buffer to hold the string
+ * \param length the length of the buffer
+ * \returns the device address
+ */
+int API_EXPORTED libusb_get_platform_device_id(libusb_device *dev, char *data, int length)
+{
+	int ret = LIBUSB_ERROR_NOT_SUPPORTED;
+
+	if (usbi_backend.get_platform_device_id)
+		ret = usbi_backend.get_platform_device_id(dev, data, length);
+
+	return ret;
 }
 
 /** \ingroup libusb_dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -84,6 +84,8 @@ EXPORTS
   libusb_get_next_timeout@8 = libusb_get_next_timeout
   libusb_get_parent
   libusb_get_parent@4 = libusb_get_parent
+  libusb_get_platform_device_id
+  libusb_get_platform_device_id@12 = libusb_get_platform_device_id
   libusb_get_pollfds
   libusb_get_pollfds@4 = libusb_get_pollfds
   libusb_get_port_number

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1274,7 +1274,7 @@ enum libusb_capability {
 	 * still have to call additional libusb functions such as
 	 * \ref libusb_detach_kernel_driver(). */
 	LIBUSB_CAP_HAS_HID_ACCESS = 0x0100,
-	/** The library supports detaching of the default USB driver, using 
+	/** The library supports detaching of the default USB driver, using
 	 * \ref libusb_detach_kernel_driver(), if one is set by the OS kernel */
 	LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER = 0x0101
 };
@@ -1382,6 +1382,7 @@ LIBUSB_DEPRECATED_FOR(libusb_get_port_numbers)
 int LIBUSB_CALL libusb_get_port_path(libusb_context *ctx, libusb_device *dev, uint8_t* path, uint8_t path_length);
 libusb_device * LIBUSB_CALL libusb_get_parent(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_device_address(libusb_device *dev);
+int LIBUSB_CALL libusb_get_platform_device_id(libusb_device *dev, char *data, int length);
 int LIBUSB_CALL libusb_get_device_speed(libusb_device *dev);
 int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -866,6 +866,15 @@ struct usbi_os_backend {
 		uint8_t bConfigurationValue, unsigned char **buffer,
 		int *host_endian);
 
+	/* Get the platform specific string handle. Useful for doing hardware queries
+	 * outside of libusb.
+	 *
+	 * Return:
+	 * - 0 on success
+	 * - LIBUSB_ERROR code on failure.
+	 */
+	int (*get_platform_device_id)(struct libusb_device *device, char *data, int length);
+
 	/* Get the bConfigurationValue for the active configuration for a device.
 	 * Optional. This should only be implemented if you can retrieve it from
 	 * cache (don't generate I/O).

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -210,7 +210,7 @@ const struct usbi_os_backend usbi_backend = {
 	.get_active_config_descriptor = haiku_get_active_config_descriptor,
 	.get_config_descriptor = haiku_get_config_descriptor,
 	.get_config_descriptor_by_value = NULL,
-
+	.get_platform_device_id = NULL,
 
 	.get_configuration = NULL,
 	.set_configuration = haiku_set_configuration,

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -101,6 +101,7 @@ const struct usbi_os_backend usbi_backend = {
 	netbsd_get_active_config_descriptor,
 	netbsd_get_config_descriptor,
 	NULL,				/* get_config_descriptor_by_value() */
+	NULL,				/* get_platform_device_id() */
 
 	netbsd_get_configuration,
 	netbsd_set_configuration,

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -104,6 +104,7 @@ const struct usbi_os_backend usbi_backend = {
 	obsd_get_active_config_descriptor,
 	obsd_get_config_descriptor,
 	NULL,				/* get_config_descriptor_by_value() */
+	NULL,				/* get_platform_device_id() */
 
 	obsd_get_configuration,
 	obsd_set_configuration,

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -1651,6 +1651,7 @@ const struct usbi_os_backend usbi_backend = {
         .get_device_descriptor = sunos_get_device_descriptor,
         .get_active_config_descriptor = sunos_get_active_config_descriptor,
         .get_config_descriptor = sunos_get_config_descriptor,
+        .get_platform_device_id = NULL,
         .hotplug_poll = NULL,
         .open = sunos_open,
         .close = sunos_close,

--- a/libusb/os/wince_usb.c
+++ b/libusb/os/wince_usb.c
@@ -851,6 +851,7 @@ const struct usbi_os_backend usbi_backend = {
 	wince_get_active_config_descriptor,
 	wince_get_config_descriptor,
 	NULL,				/* get_config_descriptor_by_value() */
+	NULL,				/* get_platform_device_id() */
 
 	wince_get_configuration,
 	wince_set_configuration,

--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -785,6 +785,12 @@ static int windows_get_config_descriptor_by_value(struct libusb_device *dev,
 	return priv->backend->get_config_descriptor_by_value(dev, bConfigurationValue, buffer);
 }
 
+static int windows_get_platform_device_id(struct libusb_device *dev, char *data, int length)
+{
+	struct windows_context_priv *priv = _context_priv(DEVICE_CTX(dev));
+	return priv->backend->get_platform_device_id(dev, data, length);
+}
+
 static int windows_get_configuration(struct libusb_device_handle *dev_handle, int *config)
 {
 	struct windows_context_priv *priv = _context_priv(HANDLE_CTX(dev_handle));
@@ -981,6 +987,7 @@ const struct usbi_os_backend usbi_backend = {
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,
 	windows_get_config_descriptor_by_value,
+	windows_get_platform_device_id,
 	windows_get_configuration,
 	windows_set_configuration,
 	windows_claim_interface,

--- a/libusb/os/windows_nt_common.h
+++ b/libusb/os/windows_nt_common.h
@@ -61,6 +61,7 @@ struct windows_backend {
 		uint8_t config_index, unsigned char *buffer, size_t len);
 	int (*get_config_descriptor_by_value)(struct libusb_device *device,
 		uint8_t bConfigurationValue, unsigned char **buffer);
+	int (*get_platform_device_id)(struct libusb_device *dev, char *data, int length);
 	int (*get_configuration)(struct libusb_device_handle *dev_handle, int *config);
 	int (*set_configuration)(struct libusb_device_handle *dev_handle, int config);
 	int (*claim_interface)(struct libusb_device_handle *dev_handle, int interface_number);

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -388,6 +388,11 @@ static int usbdk_get_config_descriptor_by_value(struct libusb_device *dev, uint8
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
+static int usbdk_get_platform_device_id(struct libusb_device *dev, char *data, int length)
+{
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int usbdk_get_active_config_descriptor(struct libusb_device *dev, unsigned char *buffer, size_t len)
 {
 	return usbdk_get_config_descriptor(dev, _usbdk_device_priv(dev)->active_configuration,
@@ -813,6 +818,7 @@ const struct windows_backend usbdk_backend = {
 	usbdk_get_active_config_descriptor,
 	usbdk_get_config_descriptor,
 	usbdk_get_config_descriptor_by_value,
+	usbdk_get_platform_device_id,
 	usbdk_get_configuration,
 	usbdk_set_configuration,
 	usbdk_claim_interface,

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1564,6 +1564,19 @@ static int winusb_get_config_descriptor_by_value(struct libusb_device *dev, uint
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
+static int winusb_get_platform_device_id(struct libusb_device *dev, char *data, int length)
+{
+	struct winusb_device_priv *priv = _device_priv(dev);
+	size_t s;
+
+	s = strlen(priv->dev_id) + 1;
+	if (s > length)
+		return LIBUSB_ERROR_OVERFLOW;
+
+	memcpy(data, priv->dev_id, s);
+	return LIBUSB_SUCCESS;
+}
+
 /*
  * return the cached copy of the active config descriptor
  */
@@ -1873,6 +1886,7 @@ const struct windows_backend winusb_backend = {
 	winusb_get_active_config_descriptor,
 	winusb_get_config_descriptor,
 	winusb_get_config_descriptor_by_value,
+	winusb_get_platform_device_id,
 	winusb_get_configuration,
 	winusb_set_configuration,
 	winusb_claim_interface,


### PR DESCRIPTION
* Working on Linux, macOS and WinUSB

On Linux we return `sysfs_dir` which can be used with `udev_device_new_from_subsystem_sysname(,"usb",id)` to get a udev_device. On macOS we return an IOServicePath which can be used with `IORegistryEntryFromPath(,id)` to make an `io_service_t`. On Windows WinUSB we return the `dev_id` which can be used with `CM_Locate_DevNodeA(,id,)` to get device information.