### PR TITLE
darwin: fix reset device

### DIFF
--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -1,6 +1,7 @@
 /*
  * darwin backend for libusb 1.0
- * Copyright © 2008-2015 Nathan Hjelm <hjelmn@users.sourceforge.net>
+ * Copyright © 2008-2019 Nathan Hjelm <hjelmn@users.sourceforge.net>
+ * Copyright © 2019      Google LLC. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +20,8 @@
 
 #if !defined(LIBUSB_DARWIN_H)
 #define LIBUSB_DARWIN_H
+
+#include <stdbool.h>
 
 #include "libusbi.h"
 
@@ -162,6 +165,7 @@ struct darwin_cached_device {
   UInt8                 first_config, active_config, port;  
   int                   can_enumerate;
   int                   refcount;
+  bool                  in_reenumerate;
 };
 
 struct darwin_device_priv {
@@ -169,7 +173,7 @@ struct darwin_device_priv {
 };
 
 struct darwin_device_handle_priv {
-  int                  is_open;
+  bool                 is_open;
   CFRunLoopSourceRef   cfSource;
 
   struct darwin_interface {

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11347
+#define LIBUSB_NANO 11348


### PR DESCRIPTION
This commit fixes the backend of reset device to restore the state
of the device if possible. This fixes a bug introduced in
c14ab5fc4d22749aab9e3534d56012718a0b0f67. The previous commit
was necessary due to changes in the system USB stack that
essentially turned the ResetDevice function into a no-op. This
required libusb to move to USBDevuceReEnumerate to effectively
reset the device. The problem is that both the device handle and
libusb devices became invalid. This commit fixes the bug by
waiting for the re-enumeration to complete then 1) checking
whether the descriptors changed, 2) restoring the active
configuration, and 3) restoring claimed interfaces.

Closes #523

Signed-off-by: Nathan Hjelm <hjelmn@me.com>