### PR TITLE
Linux non hotplug for containers

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -568,6 +568,12 @@ void usbi_disconnect_device (struct libusb_device *dev);
 int usbi_signal_event(struct libusb_context *ctx);
 int usbi_clear_event(struct libusb_context *ctx);
 
+/* unlike the exported API version, libusbi_unref_device()
+ * only unref device without destroying device. It is used
+ * only when the API version is not suitable.
+ */
+void usbi_unref_device(libusb_device *dev);
+
 /* Internal abstraction for poll (needs struct usbi_transfer on Windows) */
 #if defined(OS_LINUX) || defined(OS_DARWIN) || defined(OS_OPENBSD) || defined(OS_NETBSD) ||\
 	defined(OS_HAIKU) || defined(OS_SUNOS)

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1190,9 +1190,16 @@ int linux_enumerate_device(struct libusb_context *ctx,
 out:
 	if (r < 0)
 		libusb_unref_device(dev);
-	else
+	else if (libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
+		/* The usbi_alloc_device() has been called and that function calls
+		 * usbi_connect_device() in non-hotplug case. The check here is to
+		 * prevent calling it twice in such situation.
+		 *
+		 * Maybe we shouldn't call usbi_connect_device() in usbi_alloc_device()
+		 * at first place since what it does is irrelevant to alloc a device...
+		 */
 		usbi_connect_device(dev);
-
+	}
 	return r;
 }
 


### PR DESCRIPTION
Dear reviewers and maintainers,

Please refer to the commit message in each patch for issues fixed.

The new added non-hotplug discovery won't be popular on most linux boxes, but will be useful when we running apps in non-privileged containers where uevents are blocked for some reasons like security.

Once this series is accepted, I can also try to turn the conditional compiling into a runtime option so the apps can work on the same libusb release in and outside containers seamlessly.