### PR TITLE
windows: fix return type of usbi_{inc,dec}_fds_ref.

### DIFF
--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -119,7 +119,7 @@ struct winfd usbi_create_fd(void)
 	return wfd;
 }
 
-int usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds)
+void usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds)
 {
 	int n;
 	usbi_mutex_static_lock(&fd_table_lock);
@@ -129,7 +129,7 @@ int usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds)
 	usbi_mutex_static_unlock(&fd_table_lock);
 }
 
-int usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds)
+void usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds)
 {
 	int n;
 	struct file_descriptor *fd;

--- a/libusb/os/poll_windows.h
+++ b/libusb/os/poll_windows.h
@@ -71,8 +71,8 @@ ssize_t usbi_write(int fd, const void *buf, size_t count);
 ssize_t usbi_read(int fd, void *buf, size_t count);
 int usbi_close(int fd);
 
-int usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds);
-int usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds);
+void usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds);
+void usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds);
 
 /*
  * Timeval operations


### PR DESCRIPTION
These functions were declared as returning int, but failed to actually
return anything, and no one was using their return values anyway.

Some compilers will "helpfully" emit a function that just falls through
to whatever happens to be below it (and MSVC seems to reject it entirely?): https://gcc.godbolt.org/z/mUcf2f