### PR TITLE
Various fixes for the Haiku port

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -47,7 +47,7 @@
 #else
 #define PTR_ALIGNED __declspec(align(4))
 #endif
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && (__GNUC__ >= 3)
 #define PTR_ALIGNED __attribute__((aligned(sizeof(void *))))
 #else
 #define PTR_ALIGNED

--- a/libusb/os/haiku_usb.h
+++ b/libusb/os/haiku_usb.h
@@ -69,6 +69,7 @@ public:
 	int			ReleaseInterface(int);
 	int			SetConfiguration(int);
 	int			SetAltSetting(int, int);
+	int			ClearHalt(int);
 	status_t		SubmitTransfer(struct usbi_transfer *);
 	status_t		CancelTransfer(USBTransfer *);
 	bool			InitCheck();

--- a/libusb/os/haiku_usb_backend.cpp
+++ b/libusb/os/haiku_usb_backend.cpp
@@ -310,6 +310,23 @@ USBDeviceHandle::SetAltSetting(int inumber, int alt)
 }
 
 
+int
+USBDevice::ClearHalt(int endpoint)
+{
+	usb_raw_command command;
+	command.control.request_type = USB_REQTYPE_ENDPOINT_OUT;
+	command.control.request = USB_REQUEST_CLEAR_FEATURE;
+	command.control.value = USB_FEATURE_ENDPOINT_HALT;
+	command.control.index = endpoint;
+	command.control.length = 0;
+
+	if (ioctl(fRawFD, B_USB_RAW_COMMAND_CONTROL_TRANSFER, &command, sizeof(command)) ||
+			command.control.status != B_USB_RAW_STATUS_SUCCESS) {
+		return _errno_to_libusb(command.control.status);
+	}
+}
+
+
 USBDevice::USBDevice(const char *path)
 	:
 	fPath(NULL),
@@ -458,18 +475,17 @@ USBDevice::Initialise()		//Do we need more error checking, etc? How to report?
 		}
 		fConfigToIndex[tmp_config.configuration_value] = i;
 		fConfigurationDescriptors[i] = new(std::nothrow) unsigned char[tmp_config.total_length];
-		command.control.request_type = 128;
-		command.control.request = 6;
-		command.control.value = (2 << 8) | i;
-		command.control.index = 0;
-		command.control.length = tmp_config.total_length;
-		command.control.data = fConfigurationDescriptors[i];
-		if (ioctl(fRawFD, B_USB_RAW_COMMAND_CONTROL_TRANSFER, &command, sizeof(command)) ||
-				command.control.status!=B_USB_RAW_STATUS_SUCCESS) {
+
+		command.config_etc.descriptor = (usb_configuration_descriptor*)fConfigurationDescriptors[i];
+		command.config_etc.length = tmp_config.total_length;
+		command.config_etc.config_index = i;
+		if (ioctl(fRawFD, B_USB_COMMAND_GET_CONFIGURATION_DESCRIPTOR_ETC, &command, sizeof(command)) ||
+				command.config_etc.status != B_USB_RAW_STATUS_SUCCESS) {
 			usbi_err(NULL, "failed retrieving full configuration descriptor");
 			close(fRawFD);
 			return B_ERROR;
 		}
+
 		for (int j = 0; j < tmp_config.number_interfaces; j++) {
 			command.alternate.config_index = i;
 			command.alternate.interface_index = j;

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -128,6 +128,20 @@ haiku_set_altsetting(struct libusb_device_handle *dev_handle, int interface_numb
 }
 
 static int
+haiku_clear_halt(struct libusb_device_handle *dev_handle, unsigned char endpoint)
+{
+	USBDeviceHandle *handle = *((USBDeviceHandle **)dev_handle->os_priv);
+	return handle->ClearHalt(endpoint);
+}
+
+static int
+haiku_reset_device(struct libusb_device_handle *dev_handle)
+{
+	/* TODO */
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+static int
 haiku_release_interface(struct libusb_device_handle *dev_handle, int interface_number)
 {
 	USBDeviceHandle *handle = *((USBDeviceHandle **)dev_handle->os_priv);
@@ -218,8 +232,8 @@ const struct usbi_os_backend usbi_backend = {
 	.release_interface = haiku_release_interface,
 
 	.set_interface_altsetting = haiku_set_altsetting,
-	.clear_halt = NULL,
-	.reset_device = NULL,
+	.clear_halt = haiku_clear_halt,
+	.reset_device = haiku_reset_device,
 
 	.alloc_streams = NULL,
 	.free_streams = NULL,

--- a/libusb/os/haiku_usb_raw.h
+++ b/libusb/os/haiku_usb_raw.h
@@ -25,6 +25,7 @@ typedef enum {
 	B_USB_RAW_COMMAND_GET_INTERFACE_DESCRIPTOR_ETC,
 	B_USB_RAW_COMMAND_GET_ENDPOINT_DESCRIPTOR_ETC,
 	B_USB_RAW_COMMAND_GET_GENERIC_DESCRIPTOR_ETC,
+	B_USB_RAW_COMMAND_GET_CONFIGURATION_DESCRIPTOR_ETC,
 
 	B_USB_RAW_COMMAND_SET_CONFIGURATION = 0x3000,
 	B_USB_RAW_COMMAND_SET_FEATURE,
@@ -73,6 +74,13 @@ typedef union {
 		usb_configuration_descriptor *descriptor;
 		uint32 config_index;
 	} config;
+
+	struct {
+		status_t status;
+		usb_configuration_descriptor *descriptor;
+		uint32 config_index;
+		size_t length;
+	} config_etc;
 
 	struct {
 		status_t status;


### PR DESCRIPTION
- Use native API for getting full configuration descriptors instead of
  using a raw request
- Implement some callbacks that are mandatory and result in crashes if
  not available