### PR TITLE
Minor changes

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -31,6 +31,7 @@
 #include <sys/time.h>
 #endif
 #ifdef USBI_TIMERFD_AVAILABLE
+#include <unistd.h>
 #include <sys/timerfd.h>
 #endif
 

--- a/msvc/fxload_2010.vcxproj
+++ b/msvc/fxload_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\examples\getopt;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__GNU_LIBRARY__;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/fxload_2010.vcxproj
+++ b/msvc/fxload_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/fxload_2012.vcxproj
+++ b/msvc/fxload_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/fxload_2012.vcxproj
+++ b/msvc/fxload_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\examples\getopt;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__GNU_LIBRARY__;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/fxload_2013.vcxproj
+++ b/msvc/fxload_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/fxload_2013.vcxproj
+++ b/msvc/fxload_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\examples\getopt;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__GNU_LIBRARY__;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/fxload_2015.vcxproj
+++ b/msvc/fxload_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/fxload_2015.vcxproj
+++ b/msvc/fxload_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\examples\getopt;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__GNU_LIBRARY__;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/fxload_2017.vcxproj
+++ b/msvc/fxload_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\examples\getopt;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__GNU_LIBRARY__;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/fxload_2017.vcxproj
+++ b/msvc/fxload_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/getopt_2010.vcxproj
+++ b/msvc/getopt_2010.vcxproj
@@ -38,8 +38,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/getopt_2010.vcxproj
+++ b/msvc/getopt_2010.vcxproj
@@ -43,6 +43,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_STRING_H;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/getopt_2012.vcxproj
+++ b/msvc/getopt_2012.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_STRING_H;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/getopt_2012.vcxproj
+++ b/msvc/getopt_2012.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/getopt_2013.vcxproj
+++ b/msvc/getopt_2013.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_STRING_H;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/getopt_2013.vcxproj
+++ b/msvc/getopt_2013.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/getopt_2015.vcxproj
+++ b/msvc/getopt_2015.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_STRING_H;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/getopt_2015.vcxproj
+++ b/msvc/getopt_2015.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/getopt_2017.vcxproj
+++ b/msvc/getopt_2017.vcxproj
@@ -63,6 +63,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_STRING_H;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/getopt_2017.vcxproj
+++ b/msvc/getopt_2017.vcxproj
@@ -58,8 +58,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/hotplugtest_2010.vcxproj
+++ b/msvc/hotplugtest_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/hotplugtest_2010.vcxproj
+++ b/msvc/hotplugtest_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/hotplugtest_2012.vcxproj
+++ b/msvc/hotplugtest_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/hotplugtest_2012.vcxproj
+++ b/msvc/hotplugtest_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/hotplugtest_2013.vcxproj
+++ b/msvc/hotplugtest_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/hotplugtest_2013.vcxproj
+++ b/msvc/hotplugtest_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/hotplugtest_2015.vcxproj
+++ b/msvc/hotplugtest_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/hotplugtest_2015.vcxproj
+++ b/msvc/hotplugtest_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/hotplugtest_2017.vcxproj
+++ b/msvc/hotplugtest_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/hotplugtest_2017.vcxproj
+++ b/msvc/hotplugtest_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/libusb_dll_2010.vcxproj
+++ b/msvc/libusb_dll_2010.vcxproj
@@ -38,8 +38,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_dll_2010.vcxproj
+++ b/msvc/libusb_dll_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>

--- a/msvc/libusb_dll_2012.vcxproj
+++ b/msvc/libusb_dll_2012.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_dll_2012.vcxproj
+++ b/msvc/libusb_dll_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>

--- a/msvc/libusb_dll_2013.vcxproj
+++ b/msvc/libusb_dll_2013.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_dll_2013.vcxproj
+++ b/msvc/libusb_dll_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>

--- a/msvc/libusb_dll_2015.vcxproj
+++ b/msvc/libusb_dll_2015.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_dll_2015.vcxproj
+++ b/msvc/libusb_dll_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>

--- a/msvc/libusb_dll_2017.vcxproj
+++ b/msvc/libusb_dll_2017.vcxproj
@@ -58,8 +58,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\dll\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_dll_2017.vcxproj
+++ b/msvc/libusb_dll_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>

--- a/msvc/libusb_static_2010.vcxproj
+++ b/msvc/libusb_static_2010.vcxproj
@@ -38,8 +38,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_static_2010.vcxproj
+++ b/msvc/libusb_static_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>

--- a/msvc/libusb_static_2012.vcxproj
+++ b/msvc/libusb_static_2012.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_static_2012.vcxproj
+++ b/msvc/libusb_static_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>

--- a/msvc/libusb_static_2013.vcxproj
+++ b/msvc/libusb_static_2013.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_static_2013.vcxproj
+++ b/msvc/libusb_static_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>

--- a/msvc/libusb_static_2015.vcxproj
+++ b/msvc/libusb_static_2015.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/libusb_static_2015.vcxproj
+++ b/msvc/libusb_static_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>

--- a/msvc/libusb_static_2017.vcxproj
+++ b/msvc/libusb_static_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>

--- a/msvc/libusb_static_2017.vcxproj
+++ b/msvc/libusb_static_2017.vcxproj
@@ -58,8 +58,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\$(TargetName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\lib\</OutDir>
     <TargetName>libusb-1.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/msvc/listdevs_2010.vcxproj
+++ b/msvc/listdevs_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/listdevs_2010.vcxproj
+++ b/msvc/listdevs_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/listdevs_2012.vcxproj
+++ b/msvc/listdevs_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/listdevs_2012.vcxproj
+++ b/msvc/listdevs_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/listdevs_2013.vcxproj
+++ b/msvc/listdevs_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/listdevs_2013.vcxproj
+++ b/msvc/listdevs_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/listdevs_2015.vcxproj
+++ b/msvc/listdevs_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/listdevs_2015.vcxproj
+++ b/msvc/listdevs_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/listdevs_2017.vcxproj
+++ b/msvc/listdevs_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/listdevs_2017.vcxproj
+++ b/msvc/listdevs_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2010.vcxproj
+++ b/msvc/stress_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/stress_2010.vcxproj
+++ b/msvc/stress_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2012.vcxproj
+++ b/msvc/stress_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/stress_2012.vcxproj
+++ b/msvc/stress_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2013.vcxproj
+++ b/msvc/stress_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/stress_2013.vcxproj
+++ b/msvc/stress_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2015.vcxproj
+++ b/msvc/stress_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/stress_2015.vcxproj
+++ b/msvc/stress_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2017.vcxproj
+++ b/msvc/stress_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\tests\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/stress_2017.vcxproj
+++ b/msvc/stress_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2010.vcxproj
+++ b/msvc/testlibusb_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/testlibusb_2010.vcxproj
+++ b/msvc/testlibusb_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2012.vcxproj
+++ b/msvc/testlibusb_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2012.vcxproj
+++ b/msvc/testlibusb_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/testlibusb_2013.vcxproj
+++ b/msvc/testlibusb_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2013.vcxproj
+++ b/msvc/testlibusb_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/testlibusb_2015.vcxproj
+++ b/msvc/testlibusb_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2015.vcxproj
+++ b/msvc/testlibusb_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/testlibusb_2017.vcxproj
+++ b/msvc/testlibusb_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/testlibusb_2017.vcxproj
+++ b/msvc/testlibusb_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/xusb_2010.vcxproj
+++ b/msvc/xusb_2010.vcxproj
@@ -39,8 +39,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/xusb_2010.vcxproj
+++ b/msvc/xusb_2010.vcxproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/xusb_2012.vcxproj
+++ b/msvc/xusb_2012.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/xusb_2012.vcxproj
+++ b/msvc/xusb_2012.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/xusb_2013.vcxproj
+++ b/msvc/xusb_2013.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/xusb_2013.vcxproj
+++ b/msvc/xusb_2013.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/xusb_2015.vcxproj
+++ b/msvc/xusb_2015.vcxproj
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/xusb_2015.vcxproj
+++ b/msvc/xusb_2015.vcxproj
@@ -40,8 +40,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/msvc/xusb_2017.vcxproj
+++ b/msvc/xusb_2017.vcxproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/xusb_2017.vcxproj
+++ b/msvc/xusb_2017.vcxproj
@@ -59,8 +59,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <IntDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
-    <OutDir>$(SolutionDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
+    <IntDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\$(ProjectName)\</IntDir>
+    <OutDir>$(ProjectDir)..\$(Platform)\$(Configuration)\examples\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
-On windows compiling with visual studio 2017 results in a compilation error:
strerror.c(111): error C2001: newline in constant
(that's the first russian error message)

Adding the /utf-8 option to compiler parameters seems to fix it(thanks pbatard), fixes https://github.com/libusb/libusb/issues/207.

-I also changed all the $(SolutionDir) to $(ProjectDir) which make including the existing project files into a different solution much easier.

-Added unistd.h for the mingw build(only if USBI_TIMERFD_AVAILABLE is defined) as the CI seemed to have trouble finding close function.