### PR TITLE
windows_winusb: Mask wIndex correctly when checking interfaces

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2474,7 +2474,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 		return LIBUSB_ERROR_INVALID_PARAM;
 
 	if ((setup->RequestType & 0x1F) == LIBUSB_RECIPIENT_INTERFACE)
-		current_interface = check_valid_interface(transfer->dev_handle, setup->Index, USB_API_WINUSBX);
+		current_interface = check_valid_interface(transfer->dev_handle, setup->Index & 0xff, USB_API_WINUSBX);
 	else
 		current_interface = get_valid_interface(transfer->dev_handle, USB_API_WINUSBX);
 	if (current_interface < 0) {


### PR DESCRIPTION
According to the USB 3.0 spec (9.3.4), the interface number is in the
lower 8 bits of wIndex.

Note that wIndex must not be modified because some (non-compliant?)
devices actually use the higher 8 bits for custom data with
recipient-interface requests.