### PR TITLE
windows_winusb: Set policy ISO_ALWAYS_START_ASAP for libusbK

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2246,6 +2246,12 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			AUTO_CLEAR_STALL, sizeof(UCHAR), &policy))
 			usbi_dbg("failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
+
+		if (sub_api == SUB_API_LIBUSBK) {
+			if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
+				ISO_ALWAYS_START_ASAP, sizeof(UCHAR), &policy))
+				usbi_dbg("failed to enable ISO_ALWAYS_START_ASAP for endpoint %02X", endpoint_address);
+		}
 	}
 
 	return LIBUSB_SUCCESS;

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -412,6 +412,7 @@ typedef struct _USB_NODE_CONNECTION_INFORMATION_EX_V2 {
 
 /* winusb.dll interface */
 
+/* pipe policies */
 #define SHORT_PACKET_TERMINATE	0x01
 #define AUTO_CLEAR_STALL	0x02
 #define PIPE_TRANSFER_TIMEOUT	0x03
@@ -420,6 +421,8 @@ typedef struct _USB_NODE_CONNECTION_INFORMATION_EX_V2 {
 #define AUTO_FLUSH		0x06
 #define RAW_IO			0x07
 #define MAXIMUM_TRANSFER_SIZE	0x08
+/* libusbK */
+#define ISO_ALWAYS_START_ASAP	0x21
 
 typedef enum _USBD_PIPE_TYPE {
 	UsbdPipeTypeControl,


### PR DESCRIPTION
In some cases, this is required to avoid eventually getting a
USBD_STATUS_BAD_START_FRAME error back from the Windows USB stack.

This makes the libusbK code match the behaviour of the Linux backend.

It appears that the libusbK backend tried to get this behaviour by
setting StartFrame to 0. However, libusbK docs state that:

"Specifing 0 for KISO_CONTEXT::StartFrame (start transfer ASAP) is
restricted to the first transaction on a newly opened or reset pipe."