### PR TITLE
windows: remove total fds (256) limitations

### DIFF
--- a/libusb/os/poll_windows.h
+++ b/libusb/os/poll_windows.h
@@ -41,8 +41,6 @@
 
 #define DUMMY_HANDLE ((HANDLE)(LONG_PTR)-2)
 
-#define MAX_FDS     256
-
 #define POLLIN      0x0001    /* There is data to read */
 #define POLLPRI     0x0002    /* There is urgent data to read */
 #define POLLOUT     0x0004    /* Writing now will not block */


### PR DESCRIPTION
When queue more usb requests, and more devices working at the same time
256's limitation is easy to reach.

This patch remove such limitation of windows version.

dymatic allocate map fd_table.
each time increase 256 entry if request more fds.

Signed-off-by: Frank Li <Frank.Li@nxp.com>