### PR TITLE
Windows: Fix detection of Windows 10 when manifest declares support

### DIFF
--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -470,7 +470,8 @@ static void get_windows_version(void)
 	case 0x61: windows_version = WINDOWS_7;	    w = (ws ? "7" : "2008_R2");	  break;
 	case 0x62: windows_version = WINDOWS_8;	    w = (ws ? "8" : "2012");	  break;
 	case 0x63: windows_version = WINDOWS_8_1;   w = (ws ? "8.1" : "2012_R2"); break;
-	case 0x64: windows_version = WINDOWS_10;    w = (ws ? "10" : "2016");	  break;
+	case 0x64: // Early Windows 10 Insider Previews and Windows Server 2017 Technical Preview 1 used version 6.4
+	case 0xA0: windows_version = WINDOWS_10;    w = (ws ? "10" : "2016");	  break;
 	default:
 		if (version < 0x50) {
 			return;


### PR DESCRIPTION
On Windows 10 `GetVersionEx` will return version 10.0 when the running application has a manifest that declares Windows 10 compatibility.

https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests#supportedOS

When no such manifest is found, the call will report version 6.2, which is Windows 8.

The 6.4 version is returned by early Windows 10 Insider Previews and Windows Server 2017 Technical Preview 1.

Signed-off-by: Axel Gembe <derago@gmail.com>
