### PR TITLE
Unix: fix library version for next release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_INIT([libusb],[LIBUSB_MAJOR[.]LIBUSB_MINOR[.]LIBUSB_MICRO[]LIBUSB_RC],[libusb
 # http://sourceware.org/autobook/autobook/autobook_91.html
 lt_current=2
 lt_revision=0
-lt_age=1
+lt_age=2
 LTLDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age}"
 
 AM_INIT_AUTOMAKE

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11377
+#define LIBUSB_NANO 11378


### PR DESCRIPTION
https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
says:

4. If any interfaces have been added, removed, or changed since the last
update, increment current, and set revision to 0.

5. If any interfaces have been added since the last public release, then
increment age.

So both current and age must be incremented. The patch in
fde20bb9b7cba0ea6e96db920d0a0169c361ca92 was not complete.

Signed-off-by: Ludovic Rousseau <ludovic.rousseau@free.fr>