### PR TITLE
windows: Fix libusb_get_device_list failure if virual usb host instal…

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -955,9 +955,9 @@ static int enumerate_hcd_root_hub(struct libusb_context *ctx, const char *dev_id
 	unsigned long session_id;
 	DEVINST child_devinst;
 
-	if (CM_Get_Child(&child_devinst, devinst, 0) != CR_SUCCESS) {
-		usbi_err(ctx, "could not get child devinst for '%s'", dev_id);
-		return LIBUSB_ERROR_OTHER;
+	if ((CM_Get_Child(&child_devinst, devinst, 0)) != CR_SUCCESS) {
+		usbi_warn(ctx, "could not get child devinst for '%s'", dev_id);
+		return LIBUSB_SUCCESS;
 	}
 
 	session_id = (unsigned long)child_devinst;


### PR DESCRIPTION
…lled

If a virtual usb host driver install, but no port on that.
libusb_get_device_list will return failure.

but it should skip this host devices.

the below is virtual host control information

============USB Host Controller =======================

        +++++++++++++++++ Device Information ++++++++++++++++++
	Device Description       : Leostream Corporation Virtual USB
	Host Controller
	Device Path              :
	\\?\root#system#0004#{3abf6f2d-71c4-462a-8a92-1e6861e6af27}
	Device ID                : ROOT\SYSTEM\0004
	Hardware IDs             : *lsusbdhcDevice
	Driver KeyName           :
	{4d36e97d-e325-11ce-bfc1-08002be10318}\0049
	(GUID_DEVCLASS_SYSTEM)
	Driver                   :
	\SystemRoot\System32\drivers\lsusbdbus.sys (Version: 6.3.2.2570
	Date: 2018-11-12)
	Driver Inf               : C:\WINDOWS\inf\oem25.inf
	Legacy BusType           : Internal
	Class                    : System
	Class GUID               :
	{4d36e97d-e325-11ce-bfc1-08002be10318} (GUID_DEVCLASS_SYSTEM)
	Interface GUID           :
	{3abf6f2d-71c4-462a-8a92-1e6861e6af27}
	(GUID_DEVINTERFACE_USB_HOST_CONTROLLER)
	Service                  : lsusbdbus
	Enumerator               : ROOT
	Location Info            : -
	Manufacturer Info        : Leostream Corporation
	Capabilities             : 0x00 (-)
	Status                   : 0x0180200B (DN_ROOT_ENUMERATED,
	DN_DRIVER_LOADED, DN_STARTED, DN_DISABLEABLE, DN_NT_ENUMERATOR,
	DN_NT_DRIVER)
	Problem Code             : 0
	Power State              : D0 (supported: D0, D3)

	HcInfo0 Error            : ERROR_INVALID_FUNCTION

	Roothub Symbolic Link    : LSUSBDBUS

	BusStatistics Error      : ERROR_INVALID_FUNCTION

	DriverVersion Error      : ERROR_INVALID_FUNCTION

	BandwidthInfo Error      : ERROR_INVALID_FUNCTION

	PowerInfo Error          : ERROR_INVALID_FUNCTION

Signed-off-by: Frank Li <Frank.Li@nxp.com>