### PR TITLE
Quick fix for crashes (NULL pointer dereference) in poll_windows.c

### DIFF
--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -65,6 +65,7 @@ static void usbi_dec_fd_table()
 	fd_count--;
 	if (fd_count == 0) {
 		free(fd_table);
+		fd_size = 0;
 		fd_table = NULL;
 	}
 }

--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -71,8 +71,8 @@ static void usbi_dec_fd_table()
 
 static void smart_realloc_fd_table_space(int inc)
 {
-	if (fd_count + inc > fd_size) {
-		struct file_descriptor **p = (struct file_descriptor *)realloc(fd_table, (fd_size + INC_FDS_EACH) * sizeof(struct file_descriptor *));
+	if (fd_table == NULL || fd_count + inc > fd_size) {
+		struct file_descriptor **p = (struct file_descriptor **)realloc(fd_table, (fd_size + INC_FDS_EACH) * sizeof(struct file_descriptor *));
 		if (p != NULL) {
 			memset(p + fd_size, 0, INC_FDS_EACH * sizeof(struct file_descriptor *));
 			fd_size += INC_FDS_EACH;


### PR DESCRIPTION
Since I updated to the latest commits, my program crashes in libusb-1.0.dll.

I found the reason is a dereferenced NULL pointer in line 337 of poll_windows.c:
```
334:		smart_realloc_fd_table_space(2);
335:
336:		for (i = 0; i < fd_size; i++) {
337:			if (fd_table[i] != NULL)
```
fd_table happens to be NULL here, so fd_table[i] leads to the crash.

My quick fix extends smart_realloc_fd_table_space (called beforehand in line 334) so that it will (re)alloc fd_table in any case if fd_table is NULL. **I verified this fix, works for me.**

However, I have no clue why the previous condition (fd_count + inc > fd_size) in smart_realloc_fd_table_space happens to be false for inc = 2 (line 334) since I'd expect fd_count and fd_size to be 0.
But all these global variables have recently been introduced without initialization, probably that's the root cause:

```
58: static struct file_descriptor **fd_table;
59: static size_t fd_count;
60: static size_t fd_size;
```

Someone who has a better understanding for the code should have a closer look IMHO...

p.s.: I also fixed a wrong type cast (* instead of **) in the line right below, though that one should not be critical.