### PR TITLE
Windows Hotplug Support and Driver Name API

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -614,7 +614,7 @@ libusb_free_device_list(list, 1);
  * itself. */
 #define DISCOVERED_DEVICES_SIZE_STEP 8
 
-static struct discovered_devs *discovered_devs_alloc(void)
+struct discovered_devs *usbi_discovered_devs_alloc(void)
 {
 	struct discovered_devs *ret =
 		malloc(sizeof(*ret) + (sizeof(void *) * DISCOVERED_DEVICES_SIZE_STEP));
@@ -626,7 +626,7 @@ static struct discovered_devs *discovered_devs_alloc(void)
 	return ret;
 }
 
-static void discovered_devs_free(struct discovered_devs *discdevs)
+void usbi_discovered_devs_free(struct discovered_devs *discdevs)
 {
 	size_t i;
 
@@ -660,7 +660,7 @@ struct discovered_devs *discovered_devs_append(
 	new_discdevs = realloc(discdevs,
 		sizeof(*discdevs) + (sizeof(void *) * capacity));
 	if (!new_discdevs) {
-		discovered_devs_free(discdevs);
+		usbi_discovered_devs_free(discdevs);
 		return NULL;
 	}
 
@@ -807,7 +807,7 @@ struct libusb_device *usbi_get_device_by_session_id(struct libusb_context *ctx,
 ssize_t API_EXPORTED libusb_get_device_list(libusb_context *ctx,
 	libusb_device ***list)
 {
-	struct discovered_devs *discdevs = discovered_devs_alloc();
+	struct discovered_devs *discdevs = usbi_discovered_devs_alloc();
 	struct libusb_device **ret;
 	int r = 0;
 	ssize_t i, len;
@@ -861,7 +861,7 @@ ssize_t API_EXPORTED libusb_get_device_list(libusb_context *ctx,
 
 out:
 	if (discdevs)
-		discovered_devs_free(discdevs);
+		usbi_discovered_devs_free(discdevs);
 	return len;
 }
 

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -918,6 +918,25 @@ uint8_t API_EXPORTED libusb_get_port_number(libusb_device *dev)
 }
 
 /** \ingroup libusb_dev
+ * Get the name of the driver that a device is used with.
+ *
+ * The function will write the maximum number of characters possible into the
+ * buffer while terminating the string correctly.
+ * \param dev a device
+ * \param driver buffer to write the driver name into
+ * \param size of the buffer to write the driver name into
+ * \returns the required buffer size to write the complete driver name
+ * 					(inclusive termination) or LIBUSB_ERROR_NOT_SUPPORTED.
+ */
+int API_EXPORTED libusb_get_driver(libusb_device *dev, char *driver, int size)
+{
+	if (usbi_backend.get_device_driver) {
+		return usbi_backend.get_device_driver(dev, driver, size);
+	}
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+/** \ingroup libusb_dev
  * Get the list of all port numbers from root for the specified device
  *
  * Since version 1.0.16, \ref LIBUSB_API_VERSION >= 0x01000102

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -62,6 +62,8 @@ EXPORTS
   libusb_get_config_descriptor@12 = libusb_get_config_descriptor
   libusb_get_config_descriptor_by_value
   libusb_get_config_descriptor_by_value@12 = libusb_get_config_descriptor_by_value
+  libusb_get_driver
+  libusb_get_driver@12 = libusb_get_driver
   libusb_get_configuration
   libusb_get_configuration@8 = libusb_get_configuration
   libusb_get_container_id_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1376,6 +1376,7 @@ int LIBUSB_CALL libusb_get_container_id_descriptor(struct libusb_context *ctx,
 void LIBUSB_CALL libusb_free_container_id_descriptor(
 	struct libusb_container_id_descriptor *container_id);
 uint8_t LIBUSB_CALL libusb_get_bus_number(libusb_device *dev);
+int LIBUSB_CALL libusb_get_driver(libusb_device *dev, char* driver, int size);
 uint8_t LIBUSB_CALL libusb_get_port_number(libusb_device *dev);
 int LIBUSB_CALL libusb_get_port_numbers(libusb_device *dev, uint8_t* port_numbers, int port_numbers_len);
 LIBUSB_DEPRECATED_FOR(libusb_get_port_numbers)

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -786,6 +786,21 @@ struct usbi_os_backend {
 	 */
 	void (*close)(struct libusb_device_handle *dev_handle);
 
+	/* Obtains the driver string for the device.
+	 *
+	 * Possible values "WinUSB", "libusb0" and "libusbK" - other values  may be
+	 * possible too.
+	 *
+	 * The function will write the maximum number of characters possible into the
+	 * buffer while terminating the string correctly.
+	 *
+	 * This function will do no lockup of itself - that is done at device
+	 * detection time, because of that this function should be called after the
+	 * given device was set up.
+	 */
+	int (*get_device_driver)(struct libusb_device *device, char *driver,
+													 int size);
+
 	/* Retrieve the device descriptor from a device.
 	 *
 	 * The descriptor should be retrieved from memory, NOT via bus I/O to the

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -318,6 +318,9 @@ struct libusb_context {
 	 */
 	struct list_head open_devs;
 	usbi_mutex_t open_devs_lock;
+	/* A mutex used to guarante that only one device will be refed or unrefed at
+	 * a time */
+	usbi_mutex_t ref_devs_lock;
 
 	/* A list of registered hotplug callbacks */
 	struct list_head hotplug_cbs;

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -608,6 +608,9 @@ struct discovered_devs {
 	struct libusb_device *devices[ZERO_SIZED_ARRAY];
 };
 
+struct discovered_devs *usbi_discovered_devs_alloc(void);
+void usbi_discovered_devs_free(struct discovered_devs *discdevs);
+
 struct discovered_devs *discovered_devs_append(
 	struct discovered_devs *discdevs, struct libusb_device *dev);
 

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -97,6 +97,7 @@ const struct usbi_os_backend usbi_backend = {
 	netbsd_open,
 	netbsd_close,
 
+	NULL,				/* netbsd_get_device_driver */,
 	netbsd_get_device_descriptor,
 	netbsd_get_active_config_descriptor,
 	netbsd_get_config_descriptor,

--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -60,7 +60,7 @@ static size_t fd_count;
 static size_t fd_size;
 #define INC_FDS_EACH 256
 
-static void usbi_dec_fd_table()
+static void usbi_dec_fd_table(void)
 {
 	fd_count--;
 	if (fd_count == 0) {

--- a/libusb/os/wince_usb.c
+++ b/libusb/os/wince_usb.c
@@ -847,6 +847,7 @@ const struct usbi_os_backend usbi_backend = {
 	wince_open,
 	wince_close,
 
+	NULL,				/* wince_get_device_driver */,
 	wince_get_device_descriptor,
 	wince_get_active_config_descriptor,
 	wince_get_config_descriptor,

--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -24,6 +24,8 @@
 
 #include <config.h>
 
+#include <windows.h>
+#include <tchar.h>
 #include <inttypes.h>
 #include <process.h>
 #include <stdio.h>
@@ -68,6 +70,24 @@ DLL_DECLARE_HANDLE(User32);
 DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, GetMessageA, (LPMSG, HWND, UINT, UINT));
 DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, PeekMessageA, (LPMSG, HWND, UINT, UINT, UINT));
 DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, PostThreadMessageA, (DWORD, UINT, WPARAM, LPARAM));
+
+
+// http://msdn.microsoft.com/en-us/library/ff545978.aspx
+// http://msdn.microsoft.com/en-us/library/ff545972.aspx
+// http://msdn.microsoft.com/en-us/library/ff545982.aspx
+#ifndef GUID_DEVINTERFACE_USB_HOST_CONTROLLER
+GUID const GUID_DEVINTERFACE_USB_HOST_CONTROLLER = {0x3ABF6F2D, 0x71C4, 0x462A, {0x8A, 0x92, 0x1E, 0x68, 0x61, 0xE6, 0xAF, 0x27}};
+#endif
+#ifndef GUID_DEVINTERFACE_USB_DEVICE
+GUID const GUID_DEVINTERFACE_USB_DEVICE = {0xA5DCBF10, 0x6530, 0x11D2, {0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED}};
+#endif
+#ifndef GUID_DEVINTERFACE_USB_HUB
+GUID const GUID_DEVINTERFACE_USB_HUB = {0xF18A0E88, 0xC30C, 0x11D0, {0x88, 0x15, 0x00, 0xA0, 0xC9, 0x06, 0xBE, 0xD8}};
+#endif
+#ifndef GUID_DEVINTERFACE_LIBUSB0_FILTER
+GUID const GUID_DEVINTERFACE_LIBUSB0_FILTER = {0xF9F3FF14, 0xAE21, 0x48A0, {0x8A, 0x25, 0x80, 0x11, 0xA7, 0xA9, 0x31, 0xD9}};
+#endif
+
 
 static unsigned __stdcall windows_clock_gettime_threaded(void *param);
 
@@ -970,6 +990,13 @@ static int windows_clock_gettime(int clk_id, struct timespec *tp)
 	}
 }
 
+static int windows_get_device_driver(struct libusb_device *const device,
+																		 char *driver, int size)
+{
+	struct windows_context_priv const *const priv = _context_priv(device->ctx);
+	return priv->backend->get_device_driver(device, driver, size);
+}
+
 // NB: MSVC6 does not support named initializers.
 const struct usbi_os_backend usbi_backend = {
 	"Windows",
@@ -982,6 +1009,7 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* wrap_sys_device */
 	windows_open,
 	windows_close,
+	windows_get_device_driver,
 	windows_get_device_descriptor,
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,

--- a/libusb/os/windows_nt_common.h
+++ b/libusb/os/windows_nt_common.h
@@ -54,6 +54,8 @@ struct windows_backend {
 		struct discovered_devs **discdevs);
 	int (*open)(struct libusb_device_handle *dev_handle);
 	void (*close)(struct libusb_device_handle *dev_handle);
+	void (*enumerate_device)(struct libusb_context *ctx, TCHAR const *device_path);
+	void (*disconnect_device)(struct libusb_context *ctx, TCHAR const *device_path);
 	int (*get_device_driver)(struct libusb_device *device, char *driver,
 													 int size);
 	int (*get_device_descriptor)(struct libusb_device *device, unsigned char *buffer);

--- a/libusb/os/windows_nt_common.h
+++ b/libusb/os/windows_nt_common.h
@@ -54,6 +54,8 @@ struct windows_backend {
 		struct discovered_devs **discdevs);
 	int (*open)(struct libusb_device_handle *dev_handle);
 	void (*close)(struct libusb_device_handle *dev_handle);
+	int (*get_device_driver)(struct libusb_device *device, char *driver,
+													 int size);
 	int (*get_device_descriptor)(struct libusb_device *device, unsigned char *buffer);
 	int (*get_active_config_descriptor)(struct libusb_device *device,
 		unsigned char *buffer, size_t len);
@@ -107,4 +109,20 @@ void windows_force_sync_completion(OVERLAPPED *overlapped, ULONG size);
 
 #if defined(ENABLE_LOGGING)
 const char *windows_error_str(DWORD error_code);
+#endif
+
+// http://msdn.microsoft.com/en-us/library/ff545978.aspx
+// http://msdn.microsoft.com/en-us/library/ff545972.aspx
+// http://msdn.microsoft.com/en-us/library/ff545982.aspx
+#ifndef GUID_DEVINTERFACE_USB_HOST_CONTROLLER
+extern GUID const GUID_DEVINTERFACE_USB_HOST_CONTROLLER;
+#endif
+#ifndef GUID_DEVINTERFACE_USB_DEVICE
+extern GUID const GUID_DEVINTERFACE_USB_DEVICE;
+#endif
+#ifndef GUID_DEVINTERFACE_USB_HUB
+extern GUID const GUID_DEVINTERFACE_USB_HUB;
+#endif
+#ifndef GUID_DEVINTERFACE_LIBUSB0_FILTER
+extern GUID const GUID_DEVINTERFACE_LIBUSB0_FILTER;
 #endif

--- a/libusb/os/windows_nt_shared_types.h
+++ b/libusb/os/windows_nt_shared_types.h
@@ -80,6 +80,7 @@ struct usbdk_device_priv {
 	HANDLE redirector_handle;
 	HANDLE system_handle;
 	uint8_t active_configuration;
+	char *driver;
 };
 
 struct winusb_device_priv {
@@ -104,6 +105,7 @@ struct winusb_device_priv {
 	struct hid_device_priv *hid;
 	USB_DEVICE_DESCRIPTOR dev_descriptor;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors
+	const char *driver;
 };
 
 struct usbdk_device_handle_priv {

--- a/libusb/os/windows_usbdk.h
+++ b/libusb/os/windows_usbdk.h
@@ -101,3 +101,17 @@ typedef BOOL (__cdecl *USBDK_RESET_DEVICE)(
 typedef HANDLE (__cdecl *USBDK_GET_REDIRECTOR_SYSTEM_HANDLE)(
 	HANDLE DeviceHandle
 );
+
+/* SetupAPI dependencies */
+DLL_DECLARE_HANDLE(SetupAPI);
+DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, SetupDiEnumDeviceInfo,
+													(HDEVINFO, DWORD, PSP_DEVINFO_DATA));
+DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, SetupDiGetDeviceInstanceIdW,
+													(HDEVINFO, PSP_DEVINFO_DATA, PWSTR, DWORD, PDWORD));
+DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, SetupDiDestroyDeviceInfoList,
+													(HDEVINFO));
+DLL_DECLARE_FUNC_PREFIXED(WINAPI, HDEVINFO, p, SetupDiGetClassDevsW,
+													(GUID const *, PCWSTR, HWND, DWORD));
+DLL_DECLARE_FUNC_PREFIXED(WINAPI, BOOL, p, SetupDiGetDeviceRegistryPropertyA,
+													(HDEVINFO, PSP_DEVINFO_DATA, DWORD, PDWORD, PBYTE,
+													 DWORD, PDWORD));

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3483,7 +3483,7 @@ static int _hid_get_report(struct hid_device_priv *dev, HANDLE hid_handle, int i
 		usbi_dbg("program assertion failed: hid_buffer is not NULL");
 
 	if ((*size == 0) || (*size > MAX_HID_REPORT_SIZE)) {
-		usbi_dbg("invalid size (%zu)", *size);
+		usbi_dbg("invalid size (%"PRIuMAX")", *size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
@@ -3562,7 +3562,7 @@ static int _hid_set_report(struct hid_device_priv *dev, HANDLE hid_handle, int i
 		usbi_dbg("program assertion failed: hid_buffer is not NULL");
 
 	if ((*size == 0) || (*size > max_report_size)) {
-		usbi_dbg("invalid size (%zu)", *size);
+		usbi_dbg("invalid size (%"PRIuMAX")", *size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -57,23 +57,6 @@
 // Additional return code for HID operations that completed synchronously
 #define LIBUSB_COMPLETED	(LIBUSB_SUCCESS + 1)
 
-// http://msdn.microsoft.com/en-us/library/ff545978.aspx
-// http://msdn.microsoft.com/en-us/library/ff545972.aspx
-// http://msdn.microsoft.com/en-us/library/ff545982.aspx
-#ifndef GUID_DEVINTERFACE_USB_HOST_CONTROLLER
-const GUID GUID_DEVINTERFACE_USB_HOST_CONTROLLER = {0x3ABF6F2D, 0x71C4, 0x462A, {0x8A, 0x92, 0x1E, 0x68, 0x61, 0xE6, 0xAF, 0x27}};
-#endif
-#ifndef GUID_DEVINTERFACE_USB_DEVICE
-const GUID GUID_DEVINTERFACE_USB_DEVICE = {0xA5DCBF10, 0x6530, 0x11D2, {0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED}};
-#endif
-#ifndef GUID_DEVINTERFACE_USB_HUB
-const GUID GUID_DEVINTERFACE_USB_HUB = {0xF18A0E88, 0xC30C, 0x11D0, {0x88, 0x15, 0x00, 0xA0, 0xC9, 0x06, 0xBE, 0xD8}};
-#endif
-#ifndef GUID_DEVINTERFACE_LIBUSB0_FILTER
-const GUID GUID_DEVINTERFACE_LIBUSB0_FILTER = {0xF9F3FF14, 0xAE21, 0x48A0, {0x8A, 0x25, 0x80, 0x11, 0xA7, 0xA9, 0x31, 0xD9}};
-#endif
-
-
 /*
  * Multiple USB API backend support
  */


### PR DESCRIPTION
This adds hotplug support for the two windows backends, as well as an API to get the name of the driver that is used for a device (this is only relevant for windows).

This implementation uses the already existing enumeration functionality which means that this could be made more efficient in the future.

Feedback is very much appreciated!

#86 