### PR TITLE
fix constant not in range of enumerated type

### DIFF
--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -62,7 +62,7 @@ static void sync_transfer_wait_for_completion(struct libusb_transfer *transfer)
 		}
 		if (NULL == transfer->dev_handle) {
 			/* transfer completion after libusb_close() */
-			transfer->status = LIBUSB_ERROR_NO_DEVICE;
+			transfer->status = LIBUSB_TRANSFER_NO_DEVICE;
 			*completed = 1;
 		}
 	}


### PR DESCRIPTION
fix "Integer constant not in range of enumerated type 'enum libusb_transfer_status'"

LIBUSB_ERROR_NO_DEVICE doesn't exist on enum libusb_transfer_status