### PR TITLE
Add not implemented guard for linux like systems

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -562,6 +562,8 @@ static int linux_scan_devices(struct libusb_context *ctx)
 	ret = linux_udev_scan_devices(ctx);
 #elif !defined(__ANDROID__)
 	ret = linux_default_scan_devices(ctx);
+#else
+#error "linux_scan_devices not implemented for this config"
 #endif
 
 	usbi_mutex_static_unlock(&linux_hotplug_lock);
@@ -575,6 +577,8 @@ static void op_hotplug_poll(void)
 	linux_udev_hotplug_poll();
 #elif !defined(__ANDROID__)
 	linux_netlink_hotplug_poll();
+#else
+#error "op_hotplug_poll not implemented for this config"
 #endif
 }
 


### PR DESCRIPTION
When compiling for android and disable udev the following functions do
nothing: linux_scan_devices() and op_hotplug_poll(). The result is that
libusb is not able to list devices.

This patch raise a compile time error if the config.h results in no
implementation for those functions.

For instance if USE_UDEV is not defined and __ANDROID__ is defined the
following error will be raised "<function> not implemented for this config".

Signed-off-by: Vinicius Tinti <vinicius.tinti@almg.gov.br>