### PR TITLE
Fix linux_scan_devices() in Android

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -560,7 +560,7 @@ static int linux_scan_devices(struct libusb_context *ctx)
 
 #if defined(USE_UDEV)
 	ret = linux_udev_scan_devices(ctx);
-#elif !defined(__ANDROID__)
+#else
 	ret = linux_default_scan_devices(ctx);
 #endif
 


### PR DESCRIPTION
Use linux_default_scan_devices() in Android platform.

When building for Android the USE_UDEV is false and __ANDROID__ is true
resulting in no implementation for linux_scan_devices(). This commit fix
it by using linux_default_scan_devices() for Android.

Signed-off-by: Vinicius Tinti <vinicius.tinti@almg.gov.br>