### PR TITLE
linux_udev: silently ignore "bind" action

### DIFF
--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -262,6 +262,8 @@ static void udev_hotplug_event(struct udev_device* udev_dev)
 			linux_hotplug_enumerate(busnum, devaddr, sys_name);
 		} else if (detached) {
 			linux_device_disconnected(busnum, devaddr);
+		} else if (strncmp(udev_action, "bind", 4) == 0) {
+			/* silently ignore "known unhandled" action */
 		} else {
 			usbi_err(NULL, "ignoring udev action %s", udev_action);
 		}


### PR DESCRIPTION
When a driver is bound to a device, udev emits a "bind" action that
causes libusb to log an error message:

	libusb: error [udev_hotplug_event] ignoring udev action bind

Since we know this action is not relevant for libusb, silently ignore it
to avoid people thinking there is something wrong.

There is already a debug log entry for the action, so there is no need
to add a duplicate here.

Signed-off-by: John Keeping <john@metanate.com>