### PR TITLE
Improved system out of memory handling

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2079,6 +2079,8 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 		if (r < 0) {
 			if (errno == ENODEV) {
 				r = LIBUSB_ERROR_NO_DEVICE;
+			} else if (errno == ENOMEM) {
+				r = LIBUSB_ERROR_NO_MEM;
 			} else {
 				usbi_err(TRANSFER_CTX(transfer),
 					"submiturb failed error %d errno=%d", r, errno);


### PR DESCRIPTION
Maps ENOMEM system error to LIBUSB_ERROR_NO_MEM. When the USBFS memory limit is reached, I get a LIBUSB_ERROR_IO, which is a bit confusing. I think LIBUSB_ERROR_NO_MEM makes the situation clear.