### PR TITLE
windows: Translate ERROR_DEVICE_NOT_CONNECTED to LIBUSB_TRANSFER_NO_D…

### DIFF
--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -563,6 +563,7 @@ static void windows_transfer_callback(const struct windows_backend *backend,
 		status = LIBUSB_TRANSFER_CANCELLED;
 		break;
 	case ERROR_FILE_NOT_FOUND:
+	case ERROR_DEVICE_NOT_CONNECTED:
 		usbi_dbg("detected device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;


### PR DESCRIPTION
…EVICE

Windows 7 reports error code ERROR_DEVICE_NOT_CONNECTED if transters fail
due to unplugging the device.