### PR TITLE
windows: Fix USBD_STATUS to LIBUSB_TRANSFER_STATUS translation

### DIFF
--- a/libusb/os/windows_nt_shared_types.h
+++ b/libusb/os/windows_nt_shared_types.h
@@ -34,6 +34,19 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
 
 #include <poppack.h>
 
+// https://msdn.microsoft.com/en-us/library/windows/hardware/ff539136(v=vs.85).aspx
+typedef LONG USBD_STATUS;
+
+#define USBD_STATUS_SUCCESS(Status) ((USBD_STATUS) (Status) >= 0)
+#define USBD_STATUS_PENDING(Status) ((ULONG) (Status) >> 30 == 1)
+#define USBD_STATUS_ERROR(Status)   ((USBD_STATUS) (Status) < 0)
+#define USBD_STATUS_STALL_PID       ((USBD_STATUS) 0xC0000004)
+#define USBD_STATUS_ENDPOINT_HALTED ((USBD_STATUS) 0xC0000030)
+#define USBD_STATUS_BAD_START_FRAME ((USBD_STATUS) 0xC0000a00)
+#define USBD_STATUS_TIMEOUT         ((USBD_STATUS) 0xC0006000)
+#define USBD_STATUS_DEVICE_GONE     ((USBD_STATUS) 0xC0007000)
+#define USBD_STATUS_CANCELED        ((USBD_STATUS) 0xC0010000)
+
 #define MAX_DEVICE_ID_LEN	200
 
 typedef struct USB_DK_DEVICE_ID {

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -44,18 +44,6 @@ typedef LONG NTSTATUS;
 #define STATUS_REQUEST_CANCELED		((NTSTATUS)0xC0000703L)
 #endif
 
-#if !defined(USBD_SUCCESS)
-typedef LONG USBD_STATUS;
-#define USBD_SUCCESS(Status)		((USBD_STATUS) (Status) >= 0)
-#define USBD_PENDING(Status)		((ULONG) (Status) >> 30 == 1)
-#define USBD_ERROR(Status)		((USBD_STATUS) (Status) < 0)
-#define USBD_STATUS_STALL_PID		((USBD_STATUS) 0xc0000004)
-#define USBD_STATUS_ENDPOINT_HALTED	((USBD_STATUS) 0xc0000030)
-#define USBD_STATUS_BAD_START_FRAME	((USBD_STATUS) 0xc0000a00)
-#define USBD_STATUS_TIMEOUT		((USBD_STATUS) 0xc0006000)
-#define USBD_STATUS_CANCELED		((USBD_STATUS) 0xc0010000)
-#endif
-
 static inline struct usbdk_device_priv *_usbdk_device_priv(struct libusb_device *dev)
 {
 	return (struct usbdk_device_priv *)dev->os_priv;
@@ -754,7 +742,7 @@ static int usbdk_get_transfer_fd(struct usbi_transfer *itransfer)
 
 static DWORD usbdk_translate_usbd_status(USBD_STATUS UsbdStatus)
 {
-	if (USBD_SUCCESS(UsbdStatus))
+	if (USBD_STATUS_SUCCESS(UsbdStatus))
 		return NO_ERROR;
 
 	switch (UsbdStatus) {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2552,27 +2552,21 @@ static int winusbx_set_interface_altsetting(int sub_api, struct libusb_device_ha
 
 static enum libusb_transfer_status usbd_status_to_libusb_transfer_status(USBD_STATUS status)
 {
-	/* Based on https://msdn.microsoft.com/en-us/library/windows/hardware/ff539136(v=vs.85).aspx :
-	* USBD_STATUS have the most significant 4 bits indicating overall status and the rest gives the details. */
-	switch (status >> 28) {
-	case 0x00: /* USBD_STATUS_SUCCESS */
+	if (USBD_STATUS_SUCCESS(status))
 		return LIBUSB_TRANSFER_COMPLETED;
-	case 0x01: /* USBD_STATUS_PENDING */
-		return LIBUSB_TRANSFER_COMPLETED;
-	default: /* USBD_STATUS_ERROR */
-		switch (status & 0x0fffffff) {
-		case 0xC0006000: /* USBD_STATUS_TIMEOUT */
-			return LIBUSB_TRANSFER_TIMED_OUT;
-		case 0xC0010000: /* USBD_STATUS_CANCELED */
-			return LIBUSB_TRANSFER_CANCELLED;
-		case 0xC0000030: /* USBD_STATUS_ENDPOINT_HALTED */
-			return LIBUSB_TRANSFER_STALL;
-		case 0xC0007000: /* USBD_STATUS_DEVICE_GONE */
-			return LIBUSB_TRANSFER_NO_DEVICE;
-		default:
-			usbi_dbg("USBD_STATUS 0x%08lx translated to LIBUSB_TRANSFER_ERROR", status);
-			return LIBUSB_TRANSFER_ERROR;
-		}
+
+	switch (status) {
+	case USBD_STATUS_TIMEOUT:
+		return LIBUSB_TRANSFER_TIMED_OUT;
+	case USBD_STATUS_CANCELED:
+		return LIBUSB_TRANSFER_CANCELLED;
+	case USBD_STATUS_ENDPOINT_HALTED:
+		return LIBUSB_TRANSFER_STALL;
+	case USBD_STATUS_DEVICE_GONE:
+		return LIBUSB_TRANSFER_NO_DEVICE;
+	default:
+		usbi_dbg("USBD_STATUS 0x%08lx translated to LIBUSB_TRANSFER_ERROR", status);
+		return LIBUSB_TRANSFER_ERROR;
 	}
 }
 


### PR DESCRIPTION
The MSDN documentaion says that the most significant 4 bits of the
USBD_STATUS value indicate success/pending/error state, but then gives
them as 2 bit values.

The broken translations code assumes these to be the lower 2 bits:

0b0000 for success
0b0001 for pending
0b0010 for error
0b0011 for error

But actually it's the higher 2 bits:

0b0000 for success
0b0100 for pending
0b1000 for error
0b1100 for error

The USBDK code already deals with USBD_STATUS and gets it correct.

Another problem is that the broken translations code then masks off
the most significant 4 bits of the USBD_STATUS value, but then compares
it to the full 32 bit error codes to figure out the actual error. This
switch will always jump to the default case, because all checked error
codes have their most significant 2 bits set, but the values they are
compared against have those bits masked off.

Move the working code from the USBDK backend to the shared header and
reuse it in the WinUSB backend too.