### PR TITLE
Set project name for doxygen

### DIFF
--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           =
+PROJECT_NAME           = libusb
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
Currently, generated documentation shows `My Project` as the title: see http://libusb.sourceforge.net/api-1.0/index.html
Set it to `libusb`.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>