### PR TITLE
core: include sys/time.h on any GNU libc OS

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -54,7 +54,7 @@ typedef unsigned __int32  uint32_t;
 #include <sys/types.h>
 #endif
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__HAIKU__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__HAIKU__) || defined(__GLIBC__)
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
GNU libc provides `sys/time.h`, so unconditionally include it when using that libc.