### PR TITLE
Support for reporting USB 3.2 Gen2x2 speeds over libusb

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -718,6 +718,8 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 	dev->ctx = ctx;
 	dev->session_data = session_id;
 	dev->speed = LIBUSB_SPEED_UNKNOWN;
+	dev->num_rx_lanes = 0;
+	dev->num_tx_lanes = 0;
 
 	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
 		usbi_connect_device(dev);
@@ -1012,6 +1014,30 @@ uint8_t API_EXPORTED libusb_get_device_address(libusb_device *dev)
 int API_EXPORTED libusb_get_device_speed(libusb_device *dev)
 {
 	return dev->speed;
+}
+
+/** \ingroup libusb_dev
+ * Get the number of receive (rx) lanes for a device.
+ * e.g. a SuperSpeedPlus Gen2x2 device has 2 rx lanes.
+ * \param dev a device
+ * \returns the number of rx lanes, where 0 means that the OS doesn't know or
+ * doesn't support returning the number of rx lanes.
+ */
+int API_EXPORTED libusb_get_device_num_rx_lanes(libusb_device *dev)
+{
+	return dev->num_rx_lanes;
+}
+
+/** \ingroup libusb_dev
+ * Get the number of transmit (tx) lanes for a device.
+ * e.g. a SuperSpeedPlus Gen2x2 device has 2 tx lanes.
+ * \param dev a device
+ * \returns the number of tx lanes, where 0 means that the OS doesn't know or
+ * doesn't support returning the number of tx lanes.
+ */
+int API_EXPORTED libusb_get_device_num_tx_lanes(libusb_device *dev)
+{
+	return dev->num_tx_lanes;
 }
 
 static const struct libusb_endpoint_descriptor *find_endpoint(

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -80,6 +80,10 @@ EXPORTS
   libusb_get_device_descriptor@8 = libusb_get_device_descriptor
   libusb_get_device_list
   libusb_get_device_list@8 = libusb_get_device_list
+  libusb_get_device_num_rx_lanes
+  libusb_get_device_num_rx_lanes@4 = libusb_get_device_num_rx_lanes
+  libusb_get_device_num_tx_lanes
+  libusb_get_device_num_tx_lanes@4 = libusb_get_device_num_tx_lanes
   libusb_get_device_speed
   libusb_get_device_speed@4 = libusb_get_device_speed
   libusb_get_interface_association_descriptors

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1121,7 +1121,8 @@ typedef struct libusb_device libusb_device;
 typedef struct libusb_device_handle libusb_device_handle;
 
 /** \ingroup libusb_dev
- * Speed codes. Indicates the speed at which the device is operating.
+ * Speed codes. Indicates the speed at which the device is operating. Specifically
+ * it is the speed of the lane (e.g. SuperSpeedPlus Gen2x2 has 2 lanes).
  */
 enum libusb_speed {
 	/** The OS doesn't report or know the device speed. */
@@ -1635,6 +1636,8 @@ int LIBUSB_CALL libusb_get_port_path(libusb_context *ctx, libusb_device *dev, ui
 libusb_device * LIBUSB_CALL libusb_get_parent(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_device_address(libusb_device *dev);
 int LIBUSB_CALL libusb_get_device_speed(libusb_device *dev);
+int LIBUSB_CALL libusb_get_device_num_rx_lanes(libusb_device *dev);
+int LIBUSB_CALL libusb_get_device_num_tx_lanes(libusb_device *dev);
 int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -505,6 +505,8 @@ struct libusb_device {
 	uint8_t port_number;
 	uint8_t device_address;
 	enum libusb_speed speed;
+	uint8_t num_rx_lanes;
+	uint8_t num_tx_lanes;
 
 	struct list_head list;
 	unsigned long session_data;

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -304,7 +304,7 @@ static usb_device_t **darwin_device_from_service (struct libusb_context *ctx, io
   const int max_retries = 5;
 
   /* The IOCreatePlugInInterfaceForService function might consistently return
-     an "out of resources" error with certain USB devices the first time we run 
+     an "out of resources" error with certain USB devices the first time we run
      it. The reason is still unclear, but retrying fixes the problem */
   for (int count = 0; count < max_retries; count++) {
     kresult = IOCreatePlugInInterfaceForService(service, kIOUSBDeviceUserClientTypeID,
@@ -1151,14 +1151,47 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
     (*(priv->dev->device))->GetDeviceSpeed (priv->dev->device, &devSpeed);
 
     switch (devSpeed) {
-    case kUSBDeviceSpeedLow: dev->speed = LIBUSB_SPEED_LOW; break;
-    case kUSBDeviceSpeedFull: dev->speed = LIBUSB_SPEED_FULL; break;
-    case kUSBDeviceSpeedHigh: dev->speed = LIBUSB_SPEED_HIGH; break;
+    case kUSBDeviceSpeedLow: {
+      dev->speed = LIBUSB_SPEED_LOW;
+      dev->num_rx_lanes = 1;
+      dev->num_tx_lanes = 1;
+      break;
+    }
+    case kUSBDeviceSpeedFull: {
+      dev->speed = LIBUSB_SPEED_FULL;
+      dev->num_rx_lanes = 1;
+      dev->num_tx_lanes = 1;
+      break;
+    }
+    case kUSBDeviceSpeedHigh: {
+      dev->speed = LIBUSB_SPEED_HIGH;
+      dev->num_rx_lanes = 1;
+      dev->num_tx_lanes = 1;
+      break;
+    }
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
-    case kUSBDeviceSpeedSuper: dev->speed = LIBUSB_SPEED_SUPER; break;
+    case kUSBDeviceSpeedSuper: {
+      dev->speed = LIBUSB_SPEED_SUPER;
+      dev->num_rx_lanes = 1;
+      dev->num_tx_lanes = 1;
+      break;
+    }
 #endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
-    case kUSBDeviceSpeedSuperPlus: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
+    case kUSBDeviceSpeedSuperPlus: {
+      dev->speed = LIBUSB_SPEED_SUPER_PLUS;
+      dev->num_rx_lanes = 1;
+      dev->num_tx_lanes = 1;
+      break;
+    }
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+    case kUSBDeviceSpeedSuperPlusBy2: {
+      dev->speed = LIBUSB_SPEED_SUPER_PLUS;
+      dev->num_rx_lanes = 2;
+      dev->num_tx_lanes = 2;
+      break;
+    }
 #endif
     default:
       usbi_warn (ctx, "Got unknown device speed %d", devSpeed);


### PR DESCRIPTION
This PR is presented for comments only. I have not got a device so it is untested. I put it on the mailing list [here](https://sourceforge.net/p/libusb/mailman/libusb-devel/thread/191976D6-76DB-4864-B840-B6575625A5CA%40codex.online/#msg36900847).

USB 3.2 Gen1x2 and USB3.2 Gen2x2 have 2 tx and 2 rx channels running to the device, giving `10000 Mbit/s (USB SuperSpeedPlus Gen1x2)` and `20000 Mbit/s (USB SuperSpeedPlus Gen2x2)`. Support was tied into Linux in 4.18 and is shown in usbfs as `tx_lanes==2` and `rx_lanes==2`. Is this the way libusb should support reporting this (as separate functions to `libusb_get_device_speed` which would report the speed of a lane, `libusb_get_device_num_tx_lanes` and `libusb_get_device_num_rx_lanes`)?

macOS 10.15 SDK supports `kUSBDeviceSpeedSuperPlusBy2` but doesn't seem to have a way to identify `kUSBDeviceSpeedSuperBy2` (i.e. USB 3.2 Gen1x2 @ 2 x 5000Mbit/s).

See links:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=460fd21618bf95a16b30500eb4b5452dab04e023
* https://github.com/Nebulino/MacOS-X-SKDs/blob/bbefac19f53aed1f1322d649bbb91591cb5b5006/MacOSX10.15.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/Headers/usb/USB.h#L924