### PR TITLE
threads_posix: Use thread-local storage to cache thread ID

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,16 +323,30 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 	nopointersign_cflags="-Wno-pointer-sign", nopointersign_cflags="")
 CFLAGS="${saved_CFLAGS}"
 
-dnl check for -std=gnu99 compiler support
+dnl check for -std=gnu11 compiler support
 saved_CFLAGS="${CFLAGS}"
-CFLAGS="-std=gnu99"
-AC_MSG_CHECKING([whether CC supports -std=gnu99])
+CFLAGS="-std=gnu11"
+AC_MSG_CHECKING([whether CC supports -std=gnu11])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 	[AC_MSG_RESULT([yes])
-	 AM_CFLAGS="${AM_CFLAGS} -std=gnu99"],
-	[AC_MSG_RESULT([no])]
-)
+	 AM_CFLAGS="${AM_CFLAGS} -std=gnu11"],
+	[AC_MSG_RESULT([no])])
 CFLAGS="${saved_CFLAGS}"
+
+dnl check for _Thread_local compiler support
+if test "x$backend" != xwindows; then
+	saved_CFLAGS="${CFLAGS}"
+	saved_LDFLAGS="${LDFLAGS}"
+	CFLAGS="${CFLAGS} -fPIC"
+	LDFLAGS="${LDFLAGS} -shared"
+	AC_MSG_CHECKING([whether CC supports _Thread_local])
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([], [static _Thread_local int v])],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE([HAVE_CC_THREAD_LOCAL], [1], [Define to 1 if the compiler supports _Thread_local.])],
+		[AC_MSG_RESULT([no])])
+	CFLAGS="${saved_CFLAGS}"
+	LDFLAGS="${saved_LDFLAGS}"
+fi
 
 AM_CFLAGS="${AM_CFLAGS} -Wall -Wundef -Wunused -Wstrict-prototypes -Werror-implicit-function-declaration ${nopointersign_cflags} -Wshadow ${THREAD_CFLAGS} ${VISIBILITY_CFLAGS}"
 

--- a/libusb/os/threads_posix.c
+++ b/libusb/os/threads_posix.c
@@ -52,22 +52,30 @@ int usbi_cond_timedwait(pthread_cond_t *cond,
 
 int usbi_get_tid(void)
 {
-	int ret;
+#ifdef HAVE_CC_THREAD_LOCAL
+	static _Thread_local int tid;
+
+	if (tid)
+		return tid;
+#else
+	int tid;
+#endif
+
 #if defined(__ANDROID__)
-	ret = gettid();
+	tid = gettid();
 #elif defined(__linux__)
-	ret = syscall(SYS_gettid);
+	tid = syscall(SYS_gettid);
 #elif defined(__OpenBSD__)
 	/* The following only works with OpenBSD > 5.1 as it requires
 	   real thread support. For 5.1 and earlier, -1 is returned. */
-	ret = syscall(SYS_getthrid);
+	tid = syscall(SYS_getthrid);
 #elif defined(__APPLE__)
-	ret = (int)pthread_mach_thread_np(pthread_self());
+	tid = (int)pthread_mach_thread_np(pthread_self());
 #elif defined(__CYGWIN__)
-	ret = GetCurrentThreadId();
+	tid = GetCurrentThreadId();
 #else
-	ret = -1;
+	tid = -1;
 #endif
 /* TODO: NetBSD thread ID support */
-	return ret;
+	return tid;
 }


### PR DESCRIPTION
Trying to capture debug logs that reproduce a problem can be tricky.
Turning up the debug level will automatically make the program a bit
slower. This alone cane make timing-sensitive bugs "disappear" when
capturing logs. One of the hot paths for debug messages is fetching the
thread ID, which is immeasurably helpful in understanding thread
interactions within the library. Unfortunately most implementations
require a system call to fetch the executing thread's ID, which isn't
exactly going to help in the way of execution time.

Add a check for thread-local storage support when configuring the
library to build. If the toolchain provides this support, only one
system call will be required per thread. This check is only done for
non-Windows systems because thread-local storage is inefficiently
implemented on MinGW.

Signed-off-by: Chris Dickens <christopher.a.dickens@gmail.com>