### PR TITLE
Fix msvc 2019 project files (internal linkage)

### DIFF
--- a/msvc/fxload_2019.vcxproj
+++ b/msvc/fxload_2019.vcxproj
@@ -95,11 +95,11 @@
     <ClInclude Include="..\examples\ezusb.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\getopt_2017.vcxproj">
+    <ProjectReference Include=".\getopt_2019.vcxproj">
       <Project>{ae83e1b4-ce06-47ee-b7a3-c3a1d7c2d71e}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/msvc/hotplugtest_2019.vcxproj
+++ b/msvc/hotplugtest_2019.vcxproj
@@ -91,7 +91,7 @@
     <ClCompile Include="..\examples\hotplugtest.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/msvc/listdevs_2019.vcxproj
+++ b/msvc/listdevs_2019.vcxproj
@@ -91,7 +91,7 @@
     <ClCompile Include="..\examples\listdevs.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/msvc/stress_2019.vcxproj
+++ b/msvc/stress_2019.vcxproj
@@ -95,7 +95,7 @@
     <ClInclude Include="..\tests\libusb_testlib.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/msvc/testlibusb_2019.vcxproj
+++ b/msvc/testlibusb_2019.vcxproj
@@ -91,7 +91,7 @@
     <ClCompile Include="..\examples\testlibusb.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/msvc/xusb_2019.vcxproj
+++ b/msvc/xusb_2019.vcxproj
@@ -91,7 +91,7 @@
     <ClCompile Include="..\examples\xusb.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=".\libusb_static_2017.vcxproj">
+    <ProjectReference Include=".\libusb_static_2019.vcxproj">
       <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>


### PR DESCRIPTION
The Visual Studio 2019 project files did internally still link to the 2017 ones.
As a consequence, compilation fails (might succeed if VS2017 build files are installed, though).

After these corrections it compiles flawlessly again.