### PR TITLE
Fix build on linux

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -410,7 +410,7 @@ static inline int usbi_pending_events(struct libusb_context *ctx)
 static inline int usbi_using_timerfd(struct libusb_context *ctx)
 {
 #ifdef HAVE_TIMERFD
-	return ctx->timerfd >= 0);
+	return ctx->timerfd >= 0;
 #else
 	UNUSED(ctx);
 	return 0;


### PR DESCRIPTION
Commit 7bc0ff3 left a parenthesis over which prevents succesful build.

Signed-off-by: Andrey Perevortkin <asavah@avh.od.ua>

```
Making all in libusb
make[2]: Entering directory '/home/asavah/myrepos/libusb/libusb'
  CC       libusb_1_0_la-core.lo
In file included from core.c:23:
libusbi.h: In function ‘usbi_using_timerfd’:
libusbi.h:413:26: error: expected ‘;’ before ‘)’ token
  413 |  return ctx->timerfd >= 0);
      |                          ^
      |                          ;
libusbi.h:413:26: error: expected statement before ‘)’ token
make[2]: *** [Makefile:686: libusb_1_0_la-core.lo] Error 1
```