### PR TITLE
core: Kill usbi_backend.clock_gettime() function

### DIFF
--- a/Xcode/config.h
+++ b/Xcode/config.h
@@ -1,5 +1,12 @@
 /* config.h.  Manually generated for Xcode.  */
 
+/* On 10.12 and later, use newly available clock_*() functions */
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+#endif
+
 /* Default visibility */
 #define DEFAULT_VISIBILITY /**/
 

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,15 @@ fi
 dnl headers not available on all platforms but required on others
 AC_CHECK_HEADERS([sys/time.h])
 
+dnl the clock_gettime() function needs certain clock IDs defined
+AC_CHECK_FUNCS([clock_gettime], [have_clock_gettime=yes], [have_clockgettime=no])
+if test "x$have_clock_gettime" = xyes; then
+	AC_CHECK_DECL([CLOCK_REALTIME], [], [AC_MSG_ERROR([C library headers missing definition for CLOCK_REALTIME])], [[#include <time.h>]])
+	AC_CHECK_DECL([CLOCK_MONOTONIC], [], [AC_MSG_ERROR([C library headers missing definition for CLOCK_MONOTONIC])], [[#include <time.h>]])
+elif test "x$backend" != xdarwin && test "x$backend" != xwindows; then
+       AC_MSG_ERROR([clock_gettime() is required on this platform])
+fi
+
 dnl timerfd support
 if test "x$backend" = xlinux || test "x$backend" = xsunos; then
 	AC_ARG_ENABLE([timerfd],

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2246,7 +2246,7 @@ int API_EXPORTED libusb_init(libusb_context **context)
 	usbi_mutex_static_lock(&default_context_lock);
 
 	if (!timestamp_origin.tv_sec) {
-		usbi_backend.clock_gettime(USBI_CLOCK_REALTIME, &timestamp_origin);
+		usbi_clock_gettime(USBI_CLOCK_REALTIME, &timestamp_origin);
 	}
 
 	if (!context && usbi_default_context) {
@@ -2578,7 +2578,7 @@ void usbi_log_v(struct libusb_context *ctx, enum libusb_log_level level,
 	global_debug = (ctx_level == LIBUSB_LOG_LEVEL_DEBUG);
 #endif
 
-	usbi_backend.clock_gettime(USBI_CLOCK_REALTIME, &now);
+	usbi_clock_gettime(USBI_CLOCK_REALTIME, &now);
 	if ((global_debug) && (!has_debug_header_been_displayed)) {
 		has_debug_header_been_displayed = 1;
 		usbi_log_str(LIBUSB_LOG_LEVEL_DEBUG, "[timestamp] [threadID] facility level [function call] <message>" USBI_LOG_LINE_END);

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1210,7 +1210,7 @@ static int calculate_timeout(struct usbi_transfer *itransfer)
 		return 0;
 	}
 
-	r = usbi_backend.clock_gettime(USBI_CLOCK_MONOTONIC, &itransfer->timeout);
+	r = usbi_clock_gettime(USBI_CLOCK_MONOTONIC, &itransfer->timeout);
 	if (r < 0) {
 		usbi_err(ITRANSFER_CTX(itransfer),
 			"failed to read monotonic clock, errno=%d", errno);
@@ -2024,7 +2024,7 @@ static int handle_timeouts_locked(struct libusb_context *ctx)
 		return 0;
 
 	/* get current time */
-	r = usbi_backend.clock_gettime(USBI_CLOCK_MONOTONIC, &systime);
+	r = usbi_clock_gettime(USBI_CLOCK_MONOTONIC, &systime);
 	if (r < 0)
 		return r;
 
@@ -2624,7 +2624,7 @@ int API_EXPORTED libusb_get_next_timeout(libusb_context *ctx,
 		return 0;
 	}
 
-	r = usbi_backend.clock_gettime(USBI_CLOCK_MONOTONIC, &systime);
+	r = usbi_clock_gettime(USBI_CLOCK_MONOTONIC, &systime);
 	if (r < 0) {
 		usbi_err(ctx, "failed to read monotonic clock, errno=%d", errno);
 		return 0;

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -193,16 +193,6 @@ haiku_handle_transfer_completion(struct usbi_transfer *itransfer)
 	return usbi_handle_transfer_completion(itransfer, status);
 }
 
-static int
-haiku_clock_gettime(int clkid, struct timespec *tp)
-{
-	if (clkid == USBI_CLOCK_REALTIME)
-		return clock_gettime(CLOCK_REALTIME, tp);
-	if (clkid == USBI_CLOCK_MONOTONIC)
-		return clock_gettime(CLOCK_MONOTONIC, tp);
-	return LIBUSB_ERROR_INVALID_PARAM;
-}
-
 const struct usbi_os_backend usbi_backend = {
 	.name = "Haiku usbfs",
 	.caps = 0,
@@ -228,8 +218,6 @@ const struct usbi_os_backend usbi_backend = {
 	.cancel_transfer = haiku_cancel_transfer,
 
 	.handle_transfer_completion = haiku_handle_transfer_completion,
-
-	.clock_gettime = haiku_clock_gettime,
 
 	.device_priv_size = sizeof(USBDevice *),
 	.device_handle_priv_size = sizeof(USBDeviceHandle *),

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2664,18 +2664,6 @@ out:
 	return r;
 }
 
-static int op_clock_gettime(int clk_id, struct timespec *tp)
-{
-	switch (clk_id) {
-	case USBI_CLOCK_MONOTONIC:
-		return clock_gettime(CLOCK_MONOTONIC, tp);
-	case USBI_CLOCK_REALTIME:
-		return clock_gettime(CLOCK_REALTIME, tp);
-	default:
-		return LIBUSB_ERROR_INVALID_PARAM;
-	}
-}
-
 const struct usbi_os_backend usbi_backend = {
 	.name = "Linux usbfs",
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER,
@@ -2716,8 +2704,6 @@ const struct usbi_os_backend usbi_backend = {
 	.clear_transfer_priv = op_clear_transfer_priv,
 
 	.handle_events = op_handle_events,
-
-	.clock_gettime = op_clock_gettime,
 
 	.device_priv_size = sizeof(struct linux_device_priv),
 	.device_handle_priv_size = sizeof(struct linux_device_handle_priv),

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -74,7 +74,6 @@ static void netbsd_destroy_device(struct libusb_device *);
 static int netbsd_submit_transfer(struct usbi_transfer *);
 static int netbsd_cancel_transfer(struct usbi_transfer *);
 static int netbsd_handle_transfer_completion(struct usbi_transfer *);
-static int netbsd_clock_gettime(int, struct timespec *);
 
 /*
  * Private functions
@@ -112,8 +111,6 @@ const struct usbi_os_backend usbi_backend = {
 	.cancel_transfer = netbsd_cancel_transfer,
 
 	.handle_transfer_completion = netbsd_handle_transfer_completion,
-
-	.clock_gettime = netbsd_clock_gettime,
 
 	.device_priv_size = sizeof(struct device_priv),
 	.device_handle_priv_size = sizeof(struct handle_priv),
@@ -466,18 +463,6 @@ int
 netbsd_handle_transfer_completion(struct usbi_transfer *itransfer)
 {
 	return usbi_handle_transfer_completion(itransfer, LIBUSB_TRANSFER_COMPLETED);
-}
-
-int
-netbsd_clock_gettime(int clkid, struct timespec *tp)
-{
-	if (clkid == USBI_CLOCK_REALTIME)
-		return clock_gettime(CLOCK_REALTIME, tp);
-
-	if (clkid == USBI_CLOCK_MONOTONIC)
-		return clock_gettime(CLOCK_MONOTONIC, tp);
-
-	return (LIBUSB_ERROR_INVALID_PARAM);
 }
 
 int

--- a/libusb/os/null_usb.c
+++ b/libusb/os/null_usb.c
@@ -106,19 +106,6 @@ null_cancel_transfer(struct usbi_transfer *itransfer)
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }
 
-static int
-null_clock_gettime(int clkid, struct timespec *tp)
-{
-	switch (clkid) {
-	case USBI_CLOCK_MONOTONIC:
-		return clock_gettime(CLOCK_REALTIME, tp);
-	case USBI_CLOCK_REALTIME:
-		return clock_gettime(CLOCK_REALTIME, tp);
-	default:
-		return LIBUSB_ERROR_INVALID_PARAM;
-	}
-}
-
 const struct usbi_os_backend usbi_backend = {
 	.name = "Null backend",
 	.caps = 0,
@@ -136,5 +123,4 @@ const struct usbi_os_backend usbi_backend = {
 	.reset_device = null_reset_device,
 	.submit_transfer = null_submit_transfer,
 	.cancel_transfer = null_cancel_transfer,
-	.clock_gettime = null_clock_gettime,
 };

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -74,7 +74,6 @@ static void obsd_destroy_device(struct libusb_device *);
 static int obsd_submit_transfer(struct usbi_transfer *);
 static int obsd_cancel_transfer(struct usbi_transfer *);
 static int obsd_handle_transfer_completion(struct usbi_transfer *);
-static int obsd_clock_gettime(int, struct timespec *);
 
 /*
  * Private functions
@@ -113,8 +112,6 @@ const struct usbi_os_backend usbi_backend = {
 	.cancel_transfer = obsd_cancel_transfer,
 
 	.handle_transfer_completion = obsd_handle_transfer_completion,
-
-	.clock_gettime = obsd_clock_gettime,
 
 	.device_priv_size = sizeof(struct device_priv),
 	.device_handle_priv_size = sizeof(struct handle_priv),
@@ -505,18 +502,6 @@ int
 obsd_handle_transfer_completion(struct usbi_transfer *itransfer)
 {
 	return usbi_handle_transfer_completion(itransfer, LIBUSB_TRANSFER_COMPLETED);
-}
-
-int
-obsd_clock_gettime(int clkid, struct timespec *tp)
-{
-	if (clkid == USBI_CLOCK_REALTIME)
-		return clock_gettime(CLOCK_REALTIME, tp);
-
-	if (clkid == USBI_CLOCK_MONOTONIC)
-		return clock_gettime(CLOCK_MONOTONIC, tp);
-
-	return (LIBUSB_ERROR_INVALID_PARAM);
 }
 
 int

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -80,7 +80,6 @@ static void sunos_destroy_device(struct libusb_device *);
 static int sunos_submit_transfer(struct usbi_transfer *);
 static int sunos_cancel_transfer(struct usbi_transfer *);
 static int sunos_handle_transfer_completion(struct usbi_transfer *);
-static int sunos_clock_gettime(int, struct timespec *);
 static int sunos_kernel_driver_active(struct libusb_device_handle *, int interface);
 static int sunos_detach_kernel_driver (struct libusb_device_handle *dev, int interface_number);
 static int sunos_attach_kernel_driver (struct libusb_device_handle *dev, int interface_number);
@@ -1505,18 +1504,6 @@ sunos_handle_transfer_completion(struct usbi_transfer *itransfer)
 }
 
 int
-sunos_clock_gettime(int clkid, struct timespec *tp)
-{
-	if (clkid == USBI_CLOCK_REALTIME)
-		return clock_gettime(CLOCK_REALTIME, tp);
-
-	if (clkid == USBI_CLOCK_MONOTONIC)
-		return clock_gettime(CLOCK_MONOTONIC, tp);
-
-	return (LIBUSB_ERROR_INVALID_PARAM);
-}
-
-int
 _errno_to_libusb(int err)
 {
 	usbi_dbg("error: %s (%d)", strerror(err), err);
@@ -1662,7 +1649,6 @@ const struct usbi_os_backend usbi_backend = {
         .submit_transfer = sunos_submit_transfer,
         .cancel_transfer = sunos_cancel_transfer,
         .handle_transfer_completion = sunos_handle_transfer_completion,
-        .clock_gettime = sunos_clock_gettime,
         .device_priv_size = sizeof(sunos_dev_priv_t),
         .device_handle_priv_size = sizeof(sunos_dev_handle_priv_t),
         .transfer_priv_size = sizeof(sunos_xfer_priv_t),

--- a/libusb/os/threads_posix.c
+++ b/libusb/os/threads_posix.c
@@ -36,7 +36,7 @@ int usbi_cond_timedwait(pthread_cond_t *cond,
 	struct timespec timeout;
 	int r;
 
-	r = usbi_backend.clock_gettime(USBI_CLOCK_REALTIME, &timeout);
+	r = usbi_clock_gettime(USBI_CLOCK_REALTIME, &timeout);
 	if (r < 0)
 		return r;
 


### PR DESCRIPTION
Out of all the backends supported by libusb, only two need to provide an
implementation of the clock_gettime() function. Windows completely lacks
such a function and versions of Mac OS prior to 10.12 do not provide it.
In all other cases the backend simply ends up calling the C library's
clock_gettime() function.

Let's optimize for the common case and check for the availability of
clock_gettime() during configure. If available, we will just call it
directly from any part of the library that needs it. If not available,
the backend is required to provide an implementation of
usbi_clock_gettime() that matches the current requirements.

Signed-off-by: Chris Dickens <christopher.a.dickens@gmail.com>