### PR TITLE
linux_udev: provide an event thread name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,7 @@ linux)
 		THREAD_CFLAGS="-pthread"
 		LIBS="${LIBS} -pthread"
 	fi
+	AC_CHECK_FUNCS([pthread_setname_np])
 	;;
 netbsd)
 	AC_DEFINE([OS_NETBSD], [1], [NetBSD backend])

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -365,6 +365,13 @@ static void *linux_netlink_event_thread_main(void *arg)
 
 	UNUSED(arg);
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+	r = pthread_setname_np(pthread_self(), "libusb_event");
+	if (r) {
+		usbi_warn(NULL, "failed to set hotplug event thread name, errno=%d", r);
+	}
+#endif
+
 	usbi_dbg("netlink event thread entering");
 
 	while ((r = poll(fds, 2, -1)) >= 0 || errno == EINTR) {

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -176,6 +176,13 @@ static void *linux_udev_event_thread_main(void *arg)
 		 .events = POLLIN},
 	};
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+	r = pthread_setname_np(pthread_self(), "libusb_event");
+	if (r) {
+		usbi_warn(NULL, "failed to set hotplug event thread name, errno=%d", r);
+	}
+#endif
+
 	usbi_dbg("udev event thread entering.");
 
 	while ((r = poll(fds, 2, -1)) >= 0 || errno == EINTR) {


### PR DESCRIPTION
Instead of having just the application name as thread name, provide a more
descriptive one, which can e.g. read by htop.
If setting the name fails, the thread will still work as intended, just
raise a warning in this case.

Signed-off-by: Alexander Stein <alexander.stein@mailbox.org>