### PR TITLE
netbsd: Recognize device timeouts.

### DIFF
--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -467,6 +467,9 @@ _errno_to_libusb(int err)
 		return (LIBUSB_ERROR_NO_DEVICE);
 	case ENOMEM:
 		return (LIBUSB_ERROR_NO_MEM);
+	case EWOULDBLOCK:
+	case ETIMEDOUT:
+		return (LIBUSB_ERROR_TIMEOUT);
 	}
 
 	usbi_dbg("error: %s", strerror(err));


### PR DESCRIPTION
Recognize device timeout errno values returned by the kernel and translate them to the appropriate libusb error code.