### PR TITLE
darwin: fix libusb_get_port_numbers()

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -68,7 +68,7 @@ static CFRunLoopSourceRef libusb_darwin_acfls = NULL; /* shutdown signal for eve
 
 static usbi_mutex_t darwin_cached_devices_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct list_head darwin_cached_devices;
-static const char *darwin_device_class = kIOUSBDeviceClassName;
+static const char *darwin_device_class = "IOUSBDevice";
 
 #define DARWIN_CACHED_DEVICE(a) (((struct darwin_device_priv *)usbi_get_device_priv((a)))->dev)
 


### PR DESCRIPTION
**UPDATED to use different method than first version of this PR**:

Use `darwin_device_class = "IOUSBDevice"` to fix libusb_get_port_numbers() on MacOS 10.15.

In older versions of IOKit, constant kIOUSBDeviceClassName was always equal to "IOUSBDevice":
see https://opensource.apple.com/source/IOUSBFamily/IOUSBFamily-630.4.5/IOUSBFamily/Headers/IOUSBLib.h.auto.html.

However, in IOKit provided in XCode 11.x, kIOUSBDeviceClassName is defined as "IOUSBHostDevice" for MacOS 10.15:

/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/Headers/usb/IOUSBLib.h:
```
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14
 #define kIOUSBDeviceClassName           "IOUSBDevice"
 #define kIOUSBInterfaceClassName        "IOUSBInterface"
 #else
 #define kIOUSBDeviceClassName           kIOUSBHostDeviceClassName
 #define kIOUSBInterfaceClassName        kIOUSBHostInterfaceClassName
 #endif /* MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14 */
```

This breaks discovery of parent devices in get_device_parent_sessionID() on MacOS 10.15.
Always using constant "IOUSBDevice" fixes this problem and makes libusb_get_port_numbers()
work as expected, and closes #707.

Without this patch, examples/listdevs prints incorrect port path on my MacOS 10.15:

05ac:100f (bus 20, device 11) path: 5
0930:6545 (bus 20, device 10) path: 1
05ac:1460 (bus 20, device 12) path: 2

With this patch, examples/listdevs prints port path correctly:

05ac:100f (bus 20, device 11) path: 5
0930:6545 (bus 20, device 10) path: 5.1
05ac:1460 (bus 20, device 12) path: 5.2