### PR TITLE
Darwin: use IOUSBDevice as darwin_device_class for macOS Catalina

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -68,7 +68,7 @@ static CFRunLoopSourceRef libusb_darwin_acfls = NULL; /* shutdown signal for eve
 
 static usbi_mutex_t darwin_cached_devices_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct list_head darwin_cached_devices;
-static const char *darwin_device_class = kIOUSBDeviceClassName;
+static const char *darwin_device_class = "IOUSBDevice";
 
 #define DARWIN_CACHED_DEVICE(a) (((struct darwin_device_priv *)usbi_get_device_priv((a)))->dev)
 


### PR DESCRIPTION
`kIOUSBDeviceClassName` define from `IOUSBLib.h` file was changed from `IOUSBDevice` to `IOUSBHostDevice` in _macOS Catalina_. It might be checked by printing `darwin_device_class` value. As far as I understand, `libusb` worked with `IOUSBDevice` on macOS.

In previous macOS versions, it was always defined as `IOUSBDevice`:
```
 #define kIOUSBDeviceClassName		 "IOUSBDevice"
```
In macOS Catalina it looks as follows:
```
 #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14
 #define kIOUSBDeviceClassName           "IOUSBDevice"
 #define kIOUSBInterfaceClassName        "IOUSBInterface"
 #else
 #define kIOUSBDeviceClassName           kIOUSBHostDeviceClassName
 #define kIOUSBInterfaceClassName        kIOUSBHostInterfaceClassName
 #endif /* MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_14 */
```

By default, macOS Catalina uses `IOUSBHostDevice`. The problem is that using the `IOUSBHostDevice` class misses some devices.  This has been described in 044a7ee commit by @hjelmn. To work only with `IOUSBDevice`, `darwin_device_class` has been explicitly set to `IOUSBDevice`.

Closes #693

For reference, here's the output of the 'listdevs' example before my changes:
```shell
05ac:027b (bus 128, device 2) path: 5
2109:0102 (bus 20, device 6) path: 4
05e3:0751 (bus 20, device 5) path: 1
1a40:0801 (bus 20, device 3) path: 2
0bda:8153 (bus 0, device 2) path: 3
2109:2817 (bus 20, device 1) path: 8
2109:0817 (bus 0, device 1) path: 4
```

And here's the output after my changes:
```shell
05ac:027b (bus 128, device 2) path: 5
2109:0102 (bus 20, device 6) path: 3.2.4
05e3:0751 (bus 20, device 5) path: 3.2.1
1a40:0801 (bus 20, device 3) path: 3.2
0bda:8153 (bus 0, device 2) path: 2.3
2109:2817 (bus 20, device 1) path: 3
2109:0817 (bus 0, device 1) path: 2
```

**P.s.**
I'm not sure about the commit's description. This is my first PR to `libusb`