### PR TITLE
core: provide function libusb_get_refcnt()

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -387,6 +387,7 @@ if (cfg != desired)
   * - libusb_get_port_number()
   * - libusb_get_port_numbers()
   * - libusb_get_port_path()
+  * - libusb_get_refcnt()
   * - libusb_get_ss_endpoint_companion_descriptor()
   * - libusb_get_ss_usb_device_capability_descriptor()
   * - libusb_get_string_descriptor()
@@ -1149,6 +1150,22 @@ libusb_device * LIBUSB_CALL libusb_ref_device(libusb_device *dev)
 	dev->refcnt++;
 	usbi_mutex_unlock(&dev->lock);
 	return dev;
+}
+
+/** \ingroup libusb_dev
+ * Get the reference count of a device.
+ * \param dev the device for which to get the reference count
+ * \returns the reference count
+ */
+int API_EXPORTED libusb_get_refcnt(libusb_device *dev)
+{
+	int refcnt;
+
+	usbi_mutex_lock(&dev->lock);
+	refcnt = dev->refcnt;
+	usbi_mutex_unlock(&dev->lock);
+
+	return refcnt;
 }
 
 /** \ingroup libusb_dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -92,6 +92,8 @@ EXPORTS
   libusb_get_port_numbers@12 = libusb_get_port_numbers
   libusb_get_port_path
   libusb_get_port_path@16 = libusb_get_port_path
+  libusb_get_refcnt
+  libusb_get_refcnt@4 = libusb_get_refcnt
   libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_endpoint_companion_descriptor@12 = libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_usb_device_capability_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -933,7 +933,8 @@ typedef struct libusb_context libusb_context;
  * New devices presented by libusb_get_device_list() have a reference count of
  * 1, and libusb_free_device_list() can optionally decrease the reference count
  * on all devices in the list. libusb_open() adds another reference which is
- * later destroyed by libusb_close().
+ * later destroyed by libusb_close(). libusb_get_refcnt() can be used to
+ * retrieve the current reference count.
  */
 typedef struct libusb_device libusb_device;
 
@@ -1317,6 +1318,7 @@ ssize_t LIBUSB_CALL libusb_get_device_list(libusb_context *ctx,
 void LIBUSB_CALL libusb_free_device_list(libusb_device **list,
 	int unref_devices);
 libusb_device * LIBUSB_CALL libusb_ref_device(libusb_device *dev);
+int LIBUSB_CALL libusb_get_refcnt(libusb_device *dev);
 void LIBUSB_CALL libusb_unref_device(libusb_device *dev);
 
 int LIBUSB_CALL libusb_get_configuration(libusb_device_handle *dev,


### PR DESCRIPTION
libusb relies on correct reference counting. For debugging a user
application it is useful to have a function to check the current reference
count of a device.

Closes #355

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>