### PR TITLE
hotplug: Fix definition of libusb_hotplug_register_callback()

### DIFF
--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -143,6 +143,13 @@ int main (void) {
 \endcode
  */
 
+#define VALID_HOTPLUG_EVENTS			\
+	 (LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |	\
+	  LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT)
+
+#define VALID_HOTPLUG_FLAGS			\
+	 (LIBUSB_HOTPLUG_ENUMERATE)
+
 static int usbi_hotplug_match_cb(struct libusb_context *ctx,
 	struct libusb_device *dev, libusb_hotplug_event event,
 	struct libusb_hotplug_callback *hotplug_cb)
@@ -221,7 +228,7 @@ void usbi_hotplug_notification(struct libusb_context *ctx, struct libusb_device 
 }
 
 int API_EXPORTED libusb_hotplug_register_callback(libusb_context *ctx,
-	libusb_hotplug_event events, libusb_hotplug_flag flags,
+	int events, int flags,
 	int vendor_id, int product_id, int dev_class,
 	libusb_hotplug_callback_fn cb_fn, void *user_data,
 	libusb_hotplug_callback_handle *callback_handle)
@@ -229,8 +236,8 @@ int API_EXPORTED libusb_hotplug_register_callback(libusb_context *ctx,
 	struct libusb_hotplug_callback *new_callback;
 
 	/* check for sane values */
-	if ((!events || (~(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT) & events)) ||
-	    (flags && (~LIBUSB_HOTPLUG_ENUMERATE & flags)) ||
+	if ((!events || (~VALID_HOTPLUG_EVENTS & events)) ||
+	    (~VALID_HOTPLUG_FLAGS & flags) ||
 	    (LIBUSB_HOTPLUG_MATCH_ANY != vendor_id && (~0xffff & vendor_id)) ||
 	    (LIBUSB_HOTPLUG_MATCH_ANY != product_id && (~0xffff & product_id)) ||
 	    (LIBUSB_HOTPLUG_MATCH_ANY != dev_class && (~0xff & dev_class)) ||

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1924,29 +1924,30 @@ typedef int libusb_hotplug_callback_handle;
  *
  * Since version 1.0.16, \ref LIBUSB_API_VERSION >= 0x01000102
  *
- * Flags for hotplug events */
+ * Hotplug events */
 typedef enum {
-	/** Default value when not using any flags. */
-	LIBUSB_HOTPLUG_NO_FLAGS = 0U,
+	/** A device has been plugged in and is ready to use */
+	LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED = (1 << 0),
 
-	/** Arm the callback and fire it for all matching currently attached devices. */
-	LIBUSB_HOTPLUG_ENUMERATE = (1U << 0)
-} libusb_hotplug_flag;
+	/** A device has left and is no longer available.
+	 * It is the user's responsibility to call libusb_close on any handle associated with a disconnected device.
+	 * It is safe to call libusb_get_device_descriptor on a device that has left */
+	LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT = (1 << 1)
+} libusb_hotplug_event;
 
 /** \ingroup libusb_hotplug
  *
  * Since version 1.0.16, \ref LIBUSB_API_VERSION >= 0x01000102
  *
- * Hotplug events */
+ * Hotplug flags */
 typedef enum {
-	/** A device has been plugged in and is ready to use */
-	LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED = (1U << 0),
+	/** Arm the callback and fire it for all matching currently attached devices. */
+	LIBUSB_HOTPLUG_ENUMERATE = (1 << 0)
+} libusb_hotplug_flag;
 
-	/** A device has left and is no longer available.
-	 * It is the user's responsibility to call libusb_close on any handle associated with a disconnected device.
-	 * It is safe to call libusb_get_device_descriptor on a device that has left */
-	LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT = (1U << 1)
-} libusb_hotplug_event;
+/** \ingroup libusb_hotplug
+ * Convenience macro when not using any flags */
+#define LIBUSB_HOTPLUG_NO_FLAGS 0
 
 /** \ingroup libusb_hotplug
  * Wildcard matching for hotplug events */
@@ -2000,9 +2001,10 @@ typedef int (LIBUSB_CALL *libusb_hotplug_callback_fn)(libusb_context *ctx,
  * Since version 1.0.16, \ref LIBUSB_API_VERSION >= 0x01000102
  *
  * \param[in] ctx context to register this callback with
- * \param[in] events bitwise or of events that will trigger this callback. See \ref
- *            libusb_hotplug_event
- * \param[in] flags hotplug callback flags. See \ref libusb_hotplug_flag
+ * \param[in] events bitwise or of hotplug events that will trigger this callback.
+ *            See \ref libusb_hotplug_event
+ * \param[in] flags bitwise or of hotplug flags that affect registration.
+ *            See \ref libusb_hotplug_flag
  * \param[in] vendor_id the vendor id to match or \ref LIBUSB_HOTPLUG_MATCH_ANY
  * \param[in] product_id the product id to match or \ref LIBUSB_HOTPLUG_MATCH_ANY
  * \param[in] dev_class the device class to match or \ref LIBUSB_HOTPLUG_MATCH_ANY
@@ -2012,7 +2014,7 @@ typedef int (LIBUSB_CALL *libusb_hotplug_callback_fn)(libusb_context *ctx,
  * \returns LIBUSB_SUCCESS on success LIBUSB_ERROR code on failure
  */
 int LIBUSB_CALL libusb_hotplug_register_callback(libusb_context *ctx,
-	libusb_hotplug_event events, libusb_hotplug_flag flags,
+	int events, int flags,
 	int vendor_id, int product_id, int dev_class,
 	libusb_hotplug_callback_fn cb_fn, void *user_data,
 	libusb_hotplug_callback_handle *callback_handle);


### PR DESCRIPTION
The signature of the libusb_hotplug_register_callback() is slightly
incorrect in two regards:

  1) The 'events' parameter is meant to represent a bitwise OR of
     libusb_hotplug_event values. By OR'ing multiple values together,
     the result is not something that is actually a libusb_hotplug_event
     enumeration.

  2) The 'flags' parameter is meant to represent a bitwise OR of
     libusb_hotplug_flag values. The same considerations as above apply,
     though this has not practically been the case as there is currently
     only one flag value defined. However, a special value was already
     defined to represent the absence of any flags, which hinted at the
     problem with how it is currently defined.

Address these two issues by changing the types of the 'events' and
'flags' parameter to plain integers. As enumerations should already be
promoted to integers, this change should not cause any ABI concerns.

Signed-off-by: Chris Dickens <christopher.a.dickens@gmail.com>