### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL_WIN.txt
+++ b/INSTALL_WIN.txt
@@ -12,6 +12,19 @@ If you are using Microsoft Visual Studio:
   in msvc\config.h
 - Select your configuration and compile the project
 
+Installing and building libusb via vcpkg
+****************************************
+
+You can download and install libusb using the vcpkg dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.bat
+    ./vcpkg integrate install
+    vcpkg install libusb
+
+The libusb port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Destination directories
 ***********************
 


### PR DESCRIPTION
`libusb`  is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for libusb and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libusb, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libusb/portfile.cmake) We try to keep the library maintained as close as possible to the original library.