### PR TITLE
fixes unknown warning option from ndk build

### DIFF
--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -32,7 +32,7 @@ APP_CFLAGS := \
   -Werror=missing-prototypes \
   -Werror=strict-prototypes \
   -Werror=undef \
-  -Werror=unintialized
+  -Werror=uninitialized
 
 # Workaround for MIPS toolchain linker being unable to find liblog dependency
 # of shared object in NDK versions at least up to r9.


### PR DESCRIPTION
A command line option is not correct.

**BEFORE**
```
[x86] Compile        : xusb <= xusb.c
warning: unknown warning option '-Werror=unintialized'; did you mean '-Werror=uninitialized'? [-Wunknown-warning-option]
```

**AFTER**
```
[x86] Compile        : xusb <= xusb.c
[x86] Executable     : xusb
[x86] Install        : xusb => libs/x86/xusb
```