### PR TITLE
Windows: Translate ERROR_NO_SUCH_DEVICE to LIBUSB_TRANSFER_NO_DEVICE

### DIFF
--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -430,6 +430,7 @@ static void windows_transfer_callback(const struct windows_backend *backend,
 		break;
 	case ERROR_FILE_NOT_FOUND:
 	case ERROR_DEVICE_NOT_CONNECTED:
+	case ERROR_NO_SUCH_DEVICE:
 		usbi_dbg("detected device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -135,6 +135,11 @@ typedef LONG USBD_STATUS;
 #define USBD_STATUS_CANCELED		((USBD_STATUS)0xC0010000L)
 #endif
 
+// error code added with Windows SDK 10.0.18362
+#ifndef ERROR_NO_SUCH_DEVICE
+#define ERROR_NO_SUCH_DEVICE	433L
+#endif
+
 /* Windows versions */
 enum windows_version {
 	WINDOWS_UNDEFINED,


### PR DESCRIPTION
Windows SDK 10.0.18362.0 adds a new error code ERROR_NO_SUCH_DEVICE which is returned when the device is disconnected.

Proposed change for #721 