### PR TITLE
[darwin] wait 10 ms before restoring state after re-enumeration

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1702,6 +1702,10 @@ static int darwin_reset_device(struct libusb_device_handle *dev_handle) {
     nanosleep (&delay, NULL);
   }
 
+  /* avoid race condition with 10 ms delay (hack) */
+  struct timespec delay = {.tv_sec = 0, .tv_nsec = 10000000};
+  nanosleep (&delay, NULL);
+
   /* compare descriptors */
   usbi_dbg ("darwin/reset_device: checking whether descriptors changed");
 


### PR DESCRIPTION
This is a minimal work-around/hack to avoid issue #723 - and I'm aware that this isn't a correct fix, but it improves usability until there's one.