### PR TITLE
Fix alignment for 32-bit words in parse_descriptor

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -53,14 +53,14 @@ static void parse_descriptor(const void *source, const char *descriptor, void *d
 			*dp++ = *sp++;
 			break;
 		case 'w':	/* 16-bit word, convert from little endian to CPU */
-			dp += ((uintptr_t)dp & 1);	/* Align to word boundary */
+			dp += ((uintptr_t)dp & 1);			/* Align to word boundary */
 
 			*((uint16_t *)dp) = READ_LE16(sp);
 			sp += 2;
 			dp += 2;
 			break;
 		case 'd':	/* 32-bit word, convert from little endian to CPU */
-			dp += ((uintptr_t)dp & 1);	/* Align to word boundary */
+			dp = (uint8_t *)(((uintptr_t)dp + 3) & ~3);	/* Align to word boundary */
 
 			*((uint32_t *)dp) = READ_LE32(sp);
 			sp += 4;


### PR DESCRIPTION
`parse_descriptor` was aligning 32-bit words to 2 bytes, instead of 4 bytes. This didn't cause any issues before, because the only time the 32-bit word code path is used is from a 3 byte offset (which incidentally aligns to 4 bytes). However, a 1 byte offset would incorrectly align to 2 bytes.

Additionally, I added `static_assert`s to check the alignments are as expected because the C standard does not dictate an alignment. Alternatively, we could rewrite it to use `alignof` in the pointer arithmetic.

This pull request is completely untested.