### PR TITLE
Document that libusb_set_option may also return NOT_FOUND

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2189,6 +2189,7 @@ void API_EXPORTED libusb_set_log_cb(libusb_context *ctx, libusb_log_cb cb,
  * \returns LIBUSB_ERROR_INVALID_PARAM if the option or arguments are invalid
  * \returns LIBUSB_ERROR_NOT_SUPPORTED if the option is valid but not supported
  * on this platform
+ * \returns LIBUSB_ERROR_NOT_FOUND if LIBUSB_OPTION_USE_USBDK is valid on this platform but UsbDk is not available
  */
 int API_EXPORTED libusb_set_option(libusb_context *ctx,
 	enum libusb_option option, ...)


### PR DESCRIPTION
If the platform is Windows but UsbDk is not available `libusb_set_option` returns `LIBUSB_ERROR_NOT_FOUND`.

https://github.com/libusb/libusb/blob/26611eaa494ed9e077b5b0e1f999f5ae377de958/libusb/os/windows_common.c#L570-L578

Adjust the documentation to reflect that.