### PR TITLE
darwin: Fix invalid GetPipePropertiesV3 argument

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1775,7 +1775,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) {
 
   struct darwin_interface *cInterface;
 #if InterfaceVersion >= 550
-  IOUSBEndpointProperties pipeProperties;
+  IOUSBEndpointProperties pipeProperties = {.bVersion = kUSBEndpointPropertiesVersion3};
 #else
   /* None of the values below are used in libusb for bulk transfers */
   uint8_t                 direction, number, interval;


### PR DESCRIPTION
GetPipePropertiesV3 seems to require that the bVersion field of the
properties argument be set before calling it:
"Version of the structure. Currently kUSBEndpointPropertiesVersion3.
Need to set this when using this structure"

Not doing so results in an invalid argument error.

Signed-off-by: Ido Yariv <ido@wizery.com>