### PR TITLE
winusb: return NOT_SUPPORTED instead of INVALID_PARAM when trying to set a non-default configuration

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2457,7 +2457,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 			&& (setup->Request == LIBUSB_REQUEST_SET_CONFIGURATION)) {
 		if (setup->Value != priv->active_config) {
 			usbi_warn(TRANSFER_CTX(transfer), "cannot set configuration other than the default one");
-			return LIBUSB_ERROR_INVALID_PARAM;
+			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 		windows_force_sync_completion(overlapped, 0);
 	} else {


### PR DESCRIPTION
The PR I promised for #743 turned out to be very simple, as all the other platforms already seem to do the right thing.

That said, openbsd, netbsd and darwin don't seem to do any parameter checks for libusb_set_configuration(). Which could simple mean they *do* support setting non-default configurations and de-configuring a device. I can't check that for the former two, but I might for the latter.

I would have also added a comment to [the api docs](http://libusb.sourceforge.net/api-1.0/group__libusb__dev.html#ga785ddea63a2b9bcb879a614ca4867bed), but I couldn't find them in a repository?