### PR TITLE
libusb: fix a memory leak in sunos_new_string_list func

### DIFF
--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -248,8 +248,10 @@ sunos_new_string_list(void)
 	if (list == NULL)
 		return (NULL);
 	list->string = calloc(DEFAULT_LISTSIZE, sizeof(char *));
-	if (list->string == NULL)
+	if (list->string == NULL) {
+		free(list);
 		return (NULL);
+	}
 	list->nargs = 0;
 	list->listsize = DEFAULT_LISTSIZE;
 


### PR DESCRIPTION
In sunos_new_string_list func, if alloc list->string fails,
we will return NULL without free list, which has alread been
allocated successfully.

Fixes: 17348731b4 ('Solaris backend depends on Solaris private symbols')
Signed-off-by: Zhiqiang Liu <lzhq28@mail.ustc.edu.cn>