### PR TITLE
Support unrooted android and rooted android

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2188,12 +2188,16 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 		break;
 
 	/* Handle all backend-specific options here */
-	default:
+	case LIBUSB_OPTION_USE_USBDK:
+	case LIBUSB_OPTION_WEAK_AUTHORITY:
 		if (usbi_backend.set_option)
 			r = usbi_backend.set_option(ctx, option, ap);
 		else
 			r = LIBUSB_ERROR_NOT_SUPPORTED;
 		break;
+
+	default:
+		r = LIBUSB_ERROR_INVALID_PARAM;
 	}
 	va_end(ap);
 

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1193,6 +1193,9 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
  * handle for the underlying device. The handle allows you to use libusb to
  * perform I/O on the device in question.
  *
+ * Must call libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY)
+ * before libusb_init if don't have authority to access the usb device directly.
+ *
  * On Linux, the system device handle must be a valid file descriptor opened
  * on the device node.
  *
@@ -2185,15 +2188,12 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 		break;
 
 	/* Handle all backend-specific options here */
-	case LIBUSB_OPTION_USE_USBDK:
+	default:
 		if (usbi_backend.set_option)
 			r = usbi_backend.set_option(ctx, option, ap);
 		else
 			r = LIBUSB_ERROR_NOT_SUPPORTED;
 		break;
-
-	default:
-		r = LIBUSB_ERROR_INVALID_PARAM;
 	}
 	va_end(ap);
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2081,11 +2081,11 @@ enum libusb_option {
 	LIBUSB_OPTION_USE_USBDK = 1,
 
 	/** Set libusb has weak authority. With this option, libusb will skip
-     * scan devices in libusb_init.
+	 * scan devices in libusb_init.
 	 *
 	 * This option should be set before calling libusb_init(), otherwise
 	 * libusb_init will failed. Normally libusb_wrap_sys_device need set
-     * this option.
+	 * this option.
 	 *
 	 * Only valid on Linux-based operating system, such as Android.
 	 */

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2078,7 +2078,18 @@ enum libusb_option {
 	 *
 	 * Only valid on Windows.
 	 */
-	LIBUSB_OPTION_USE_USBDK = 1
+	LIBUSB_OPTION_USE_USBDK = 1,
+
+	/** Set libusb has weak authority. With this option, libusb will skip
+     * scan devices in libusb_init.
+	 *
+	 * This option should be set before calling libusb_init(), otherwise
+	 * libusb_init will failed. Normally libusb_wrap_sys_device need set
+     * this option.
+	 *
+	 * Only valid on Linux-based operating system, such as Android.
+	 */
+	LIBUSB_OPTION_WEAK_AUTHORITY = 2
 };
 
 int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -95,6 +95,9 @@ static int sysfs_available = -1;
 /* how many times have we initted (and not exited) ? */
 static int init_count = 0;
 
+/* is no authority to operate usb device directly */
+static int weak_authority = 0;
+
 /* Serialize hotplug start/stop */
 static usbi_mutex_static_t linux_hotplug_startstop_lock = USBI_MUTEX_INITIALIZER;
 /* Serialize scan-devices, event-thread, and poll */
@@ -381,6 +384,10 @@ static int op_init(struct libusb_context *ctx)
 		}
 	}
 
+    if (weak_authority) {
+        return LIBUSB_SUCCESS;
+    }
+
 	usbi_mutex_static_lock(&linux_hotplug_startstop_lock);
 	r = LIBUSB_SUCCESS;
 	if (init_count == 0) {
@@ -411,6 +418,21 @@ static void op_exit(struct libusb_context *ctx)
 		linux_stop_event_monitor();
 	}
 	usbi_mutex_static_unlock(&linux_hotplug_startstop_lock);
+}
+
+static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
+{
+	UNUSED(ctx);
+	UNUSED(ap);
+
+	switch ((int)option) {
+	case LIBUSB_OPTION_WEAK_AUTHORITY:
+        usbi_dbg("set libusb has weak authority");
+        weak_authority = 1;
+        return LIBUSB_SUCCESS;
+	default:
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+	}
 }
 
 static int linux_scan_devices(struct libusb_context *ctx)
@@ -2688,6 +2710,7 @@ const struct usbi_os_backend usbi_backend = {
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER,
 	.init = op_init,
 	.exit = op_exit,
+	.set_option = op_set_option,
 	.hotplug_poll = op_hotplug_poll,
 	.get_active_config_descriptor = op_get_active_config_descriptor,
 	.get_config_descriptor = op_get_config_descriptor,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -95,8 +95,10 @@ static int sysfs_available = -1;
 /* how many times have we initted (and not exited) ? */
 static int init_count = 0;
 
+#ifdef __ANDROID__
 /* is no authority to operate usb device directly */
 static int weak_authority = 0;
+#endif
 
 /* Serialize hotplug start/stop */
 static usbi_mutex_static_t linux_hotplug_startstop_lock = USBI_MUTEX_INITIALIZER;
@@ -384,9 +386,11 @@ static int op_init(struct libusb_context *ctx)
 		}
 	}
 
+#ifdef __ANDROID__
 	if (weak_authority) {
 		return LIBUSB_SUCCESS;
 	}
+#endif
 
 	usbi_mutex_static_lock(&linux_hotplug_startstop_lock);
 	r = LIBUSB_SUCCESS;

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -384,9 +384,9 @@ static int op_init(struct libusb_context *ctx)
 		}
 	}
 
-    if (weak_authority) {
-        return LIBUSB_SUCCESS;
-    }
+	if (weak_authority) {
+		return LIBUSB_SUCCESS;
+	}
 
 	usbi_mutex_static_lock(&linux_hotplug_startstop_lock);
 	r = LIBUSB_SUCCESS;
@@ -426,10 +426,12 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	UNUSED(ap);
 
 	switch ((int)option) {
+#ifdef __ANDROID__
 	case LIBUSB_OPTION_WEAK_AUTHORITY:
-        usbi_dbg("set libusb has weak authority");
-        weak_authority = 1;
-        return LIBUSB_SUCCESS;
+		usbi_dbg("set libusb has weak authority");
+		weak_authority = 1;
+		return LIBUSB_SUCCESS;
+#endif
 	default:
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -96,7 +96,7 @@ static int sysfs_available = -1;
 static int init_count = 0;
 
 #ifdef __ANDROID__
-/* is no authority to operate usb device directly */
+/* have no authority to operate usb device directly */
 static int weak_authority = 0;
 #endif
 
@@ -429,7 +429,7 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	UNUSED(ctx);
 	UNUSED(ap);
 
-	switch ((int)option) {
+	switch (option) {
 #ifdef __ANDROID__
 	case LIBUSB_OPTION_WEAK_AUTHORITY:
 		usbi_dbg("set libusb has weak authority");


### PR DESCRIPTION
On unrooted Android, we can not operate usb directly and need use `libusb_wrap_sys_device`, we also will failed on `linux_scan_devices`. For 1.0.23, before commit `211d791`,  libusb can not work with rooted android. After commit `211d791`,  libusb can not work with unrooted android. Libusb can not know if it has authority to scan devices, so i add `libusb_init_ex` to specify it manually.