### PR TITLE
OpenBSD: support libusb_get_port_number

### DIFF
--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -173,6 +173,7 @@ obsd_get_device_list(struct libusb_context * ctx,
 				dev->bus_number = di.udi_bus;
 				dev->device_address = di.udi_addr;
 				dev->speed = di.udi_speed;
+				dev->port_number = di.udi_port;
 
 				dpriv = usbi_get_device_priv(dev);
 				dpriv->fd = -1;


### PR DESCRIPTION
Fixes #314

From mpi@openbsd.org