### PR TITLE
Fixup signed/unsigned comparison compile warnings from loop variables

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2100,7 +2100,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 	POLL_NFDS_TYPE nfds = 0;
 	POLL_NFDS_TYPE internal_nfds;
 	struct pollfd *fds = NULL;
-	int i = -1;
+	unsigned int i = 0;
 	int timeout_ms;
 
 	/* prevent attempts to recursively handle events (e.g. calling into
@@ -2154,9 +2154,9 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 
 		list_for_each_entry(ipollfd, &ctx->ipollfds, list, struct usbi_pollfd) {
 			struct libusb_pollfd *pollfd = &ipollfd->pollfd;
-			i++;
 			ctx->pollfds[i].fd = pollfd->fd;
 			ctx->pollfds[i].events = pollfd->events;
+			++i;
 		}
 
 		/* reset the flag now that we have the updated list */

--- a/libusb/os/poll_windows.c
+++ b/libusb/os/poll_windows.c
@@ -151,7 +151,7 @@ struct winfd usbi_create_fd(void)
 
 void usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds)
 {
-	int n;
+	unsigned int n;
 	usbi_mutex_static_lock(&fd_table_lock);
 	for (n = 0; n < nfds; ++n) {
 		fd_table[fds[n].fd]->refcount++;
@@ -161,7 +161,7 @@ void usbi_inc_fds_ref(struct pollfd *fds, unsigned int nfds)
 
 void usbi_dec_fds_ref(struct pollfd *fds, unsigned int nfds)
 {
-	int n;
+	unsigned int n;
 	struct file_descriptor *fd;
 
 	usbi_mutex_static_lock(&fd_table_lock);


### PR DESCRIPTION
Just three loop variables that were declared as signed integers, and which were then performing comparisons against unsigned integers (normally nfds as the comparison targets).
Only the io.c item required a slight modification to actual code, since it was init'd as holding -1 and then incremented before reference use, so has been changed to init as 0 and then to increment following reference.