### PR TITLE
autotools: enable installation of fxload tool

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,7 +2,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/libusb
 LDADD = ../libusb/libusb-1.0.la
 LIBS =
 
-noinst_PROGRAMS = dpfp dpfp_threaded fxload hotplugtest listdevs sam3u_benchmark testlibusb xusb
+noinst_PROGRAMS = dpfp dpfp_threaded hotplugtest listdevs sam3u_benchmark testlibusb xusb
+
+bin_PROGRAMS = fxload
 
 dpfp_threaded_CPPFLAGS = $(AM_CPPFLAGS) -DDPFP_THREADED
 dpfp_threaded_CFLAGS = $(AM_CFLAGS) $(THREAD_CFLAGS)


### PR DESCRIPTION
The libusb examples contain a hidden gem, namely the fxload tool. But it seems one cannot install this tool, even with example build enabled. This would be beneficial, though, especially in packaging environments such as conda. Is there any particular reason *not* to deploy the tools?

This PR activates the installation of the fxload tool and serves as basis for discussion.
(Disclaimer: I am not used to autotools, but the change had the desired effect)
