### PR TITLE
darwin: fix const array size to work with GCC compilers

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2148,7 +2148,7 @@ static int darwin_handle_transfer_completion (struct usbi_transfer *itransfer) {
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
   struct darwin_transfer_priv *tpriv = usbi_get_transfer_priv(itransfer);
   const unsigned char max_transfer_type = LIBUSB_TRANSFER_TYPE_BULK_STREAM;
-  const char *transfer_types[max_transfer_type + 1] = {"control", "isoc", "bulk", "interrupt", "bulk-stream"};
+  const char *transfer_types[] = {"control", "isoc", "bulk", "interrupt", "bulk-stream", NULL};
   bool is_isoc = LIBUSB_TRANSFER_TYPE_ISOCHRONOUS == transfer->type;
 
   if (transfer->type > max_transfer_type) {


### PR DESCRIPTION
Tested on macOS 11.2 20D5029f with Xcode 12.3 12C33 ARM64 and x86_64 both GCC and Clang, macOS 10.14.6 18G7016 and Xcode 11.3.1 11C504 both GCC and Clang, and macOS 10.5.8 9L31a Xcode 3.1.4 9M2809 with GCC. All tested Clang from early to current supports the original code, but all tested GCC from 5 to 10 show an error with setting the array size. Because the code related to this array does bounds checking, and the array is initialized and const, the actual array size makes no difference. Removing it allows for compiling using both Clang and GCC. See also https://trac.macports.org/ticket/61868#comment:17 .