### PR TITLE
libusb/core.c: bump DISCOVERED_DEVICES_SIZE_STEP to 16

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -633,7 +633,7 @@ libusb_free_device_list(list, 1);
  * which grows when required. it can be freed once discovery has completed,
  * eliminating the need for a list node in the libusb_device structure
  * itself. */
-#define DISCOVERED_DEVICES_SIZE_STEP 8
+#define DISCOVERED_DEVICES_SIZE_STEP 16
 
 static struct discovered_devs *discovered_devs_alloc(void)
 {


### PR DESCRIPTION
On OpenBSD USB controllers are shown as normal devices, making the
initial limit too small. On a recent machine this value is almost
always exceeded, so bump it.

Change committed to OpenBSD ports tree by Matthias Kilian <kili@openbsd.org>
on Tue Jun 19 21:10:59 2012 UTC