### PR TITLE
linux_usbfs: Fix exit crash on Android

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -415,6 +415,11 @@ static int op_init(struct libusb_context *ctx)
 static void op_exit(struct libusb_context *ctx)
 {
 	UNUSED(ctx);
+#ifdef __ANDROID__
+	if (weak_authority) {
+        return;
+    }
+#endif
 	usbi_mutex_static_lock(&linux_hotplug_startstop_lock);
 	assert(init_count != 0);
 	if (!--init_count) {


### PR DESCRIPTION
In commit "89b810ec Android: Add option LIBUSB_OPTION_WEAK_AUTHORITY to support used in apk", we should also check weak_authority when exiting the backend.

This fixes #841 