### PR TITLE
Access violation fixed while processing foreign I/O completion packets

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1349,7 +1349,9 @@ void API_EXPORTED libusb_free_transfer(struct libusb_transfer *transfer)
 
 	priv_size = PTR_ALIGN(usbi_backend.transfer_priv_size);
 	ptr = (unsigned char *)itransfer - priv_size;
+
 	assert(ptr == itransfer->priv);
+	memset(ptr, 0, priv_size);
 	free(ptr);
 }
 

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <memory.h>
 #include "libusbi.h"
 #include "hotplug.h"
 

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -440,7 +440,7 @@ static unsigned __stdcall windows_iocp_thread(void *arg)
 
 		transfer_priv = container_of(overlapped, struct windows_transfer_priv, overlapped);
 
-		if (transfer_priv->marker_low == LIBUSB_TRANSFER_MARKER_LOW && transfer_priv->marker-high == LIBUSB_TRANSFER_MARKER_HIGH) {
+		if (transfer_priv->marker_low == LIBUSB_TRANSFER_MARKER_LOW && transfer_priv->marker_high == LIBUSB_TRANSFER_MARKER_HIGH) {
 			itransfer = ( struct usbi_transfer * )( (unsigned char *)transfer_priv + PTR_ALIGN( sizeof( *transfer_priv ) ) );
 			usbi_dbg( "transfer %p completed, length %lu",
 				USBI_TRANSFER_TO_LIBUSB_TRANSFER( itransfer ), ULONG_CAST( num_bytes ) );

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -345,6 +345,8 @@ union windows_device_handle_priv {
 
 struct windows_transfer_priv {
 	OVERLAPPED overlapped;
+	uint32_t marker_low;
+	uint32_t marker_high;
 	HANDLE handle;
 	union {
 		struct usbdk_transfer_priv usbdk_priv;


### PR DESCRIPTION
This PR fixes issue #844

In the order to distinguish libusb and foreign I/O completion packets, a marker was added to the `windows_transfer_priv` structure.
This approach still can cause an access violation in the case when a foreign I/O operation processor allocates a memory only for `OVERLAPPED` structure and the bytes after that memory are inaccessible for reading. But I think this is almost impossible situation.