### PR TITLE
doc: Add since version tag to libusb_set_log_cb()

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2127,6 +2127,8 @@ void API_EXPORTED libusb_set_debug(libusb_context *ctx, int level)
  * If ENABLE_DEBUG_LOGGING is defined then per context callback function will
  * never be called.
  *
+ * Since version 1.0.23, \ref LIBUSB_API_VERSION >= 0x01000107
+ *
  * \param ctx context on which to assign log handler, or NULL for the default
  * context. Parameter ignored if only LIBUSB_LOG_CB_GLOBAL mode is requested.
  * \param cb pointer to the callback function, or NULL to stop log

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1325,6 +1325,9 @@ enum libusb_log_level {
 
 /** \ingroup libusb_lib
  *  Log callback mode.
+ *
+ *  Since version 1.0.23, \ref LIBUSB_API_VERSION >= 0x01000107
+ *
  * \see libusb_set_log_cb()
  */
 enum libusb_log_cb_mode {
@@ -1341,6 +1344,9 @@ enum libusb_log_cb_mode {
  * is a global log message
  * \param level the log level, see \ref libusb_log_level for a description
  * \param str the log message
+ *
+ *  Since version 1.0.23, \ref LIBUSB_API_VERSION >= 0x01000107
+ *
  * \see libusb_set_log_cb()
  */
 typedef void (LIBUSB_CALL *libusb_log_cb)(libusb_context *ctx,


### PR DESCRIPTION
The commit f74c7f5 "core: new API libusb_set_log_cb() to redirect
global and per context log messages to the provided log handling
function" in 2018-12-05 is present from 1.0.23 onwards.

This commit just adds this to the docs.

Signed-off-by: Victor Toso <victortoso@redhat.com>