### PR TITLE
Add support for querying serial without opening device

### DIFF
--- a/examples/listdevs.c
+++ b/examples/listdevs.c
@@ -45,6 +45,13 @@ static void print_devs(libusb_device **devs)
 			for (j = 1; j < r; j++)
 				printf(".%d", path[j]);
 		}
+
+		unsigned char buf[255];
+		r = libusb_get_serial_string_descriptor_ascii(dev, buf, sizeof(buf));
+		if (r > 0) {
+			printf(" serial: \"%s\"", buf);
+		}
+
 		printf("\n");
 	}
 }

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -539,6 +539,49 @@ int API_EXPORTED libusb_get_device_descriptor(libusb_device *dev,
 }
 
 /** \ingroup libusb_desc
+ * Get the USB device serial for a given device. The string returned is Unicode,
+ * as detailed in the USB specifications.
+ *
+ * \param dev the device
+ * \param data output buffer for descriptor
+ * \param length size of data buffer
+ * \returns number of bytes returned in data, or LIBUSB_ERROR code on failure
+ * \see libusb_get_serial_string_descriptor_ascii()
+ */
+int API_EXPORTED libusb_get_serial_string_descriptor(libusb_device *dev,
+	unsigned char *data, int length)
+{
+	if (usbi_backend.get_serial_string_descriptor) {
+		return usbi_backend.get_serial_string_descriptor(dev, data, length);
+	}
+
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+/** \ingroup libusb_desc
+ * Get the USB device serial for a given device in C style ASCII.
+ *
+ * Wrapper around libusb_get_serial_string_descriptor().
+ *
+ * \param dev the device
+ * \param data output buffer for ASCII string descriptor
+ * \param length size of data buffer
+ * \returns number of bytes returned in data, or LIBUSB_ERROR code on failure
+ */
+int API_EXPORTED libusb_get_serial_string_descriptor_ascii(libusb_device *dev,
+	unsigned char *data, int length)
+{
+	union usbi_string_desc_buf str;
+	int r;
+
+	r = libusb_get_serial_string_descriptor(dev, str.buf, sizeof(str.buf));
+	if (r < 0)
+		return r;
+
+	return usbi_string_descriptor_to_ascii(&str, data, length);
+}
+
+/** \ingroup libusb_desc
  * Get the USB configuration descriptor for the currently active configuration.
  * This is a non-blocking function which does not involve any requests being
  * sent to the device.

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1070,6 +1070,27 @@ void API_EXPORTED libusb_free_container_id_descriptor(
 	free(container_id);
 }
 
+int usbi_string_descriptor_to_ascii(union usbi_string_desc_buf* str,
+	unsigned char *data, int length)
+{
+	int si, di;
+	uint16_t wdata;
+	di = 0;
+	for (si = 2; si < str->desc.bLength; si += 2) {
+		if (di >= (length - 1))
+			break;
+
+		wdata = libusb_le16_to_cpu(str->desc.wData[di]);
+		if (wdata < 0x80)
+			data[di++] = (unsigned char)wdata;
+		else
+			data[di++] = '?'; /* non-ASCII */
+	}
+
+	data[di] = 0;
+	return di;
+}
+
 /** \ingroup libusb_desc
  * Retrieve a string descriptor in C style ASCII.
  *
@@ -1086,8 +1107,8 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	uint8_t desc_index, unsigned char *data, int length)
 {
 	union usbi_string_desc_buf str;
-	int r, si, di;
-	uint16_t langid, wdata;
+	int r;
+	uint16_t langid;
 
 	/* Asking for the zero'th index is special - it returns a string
 	 * descriptor that contains all the language IDs supported by the
@@ -1122,18 +1143,5 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	else if ((str.desc.bLength & 1) || str.desc.bLength != r)
 		usbi_warn(HANDLE_CTX(dev_handle), "suspicious bLength %u for string descriptor", str.desc.bLength);
 
-	di = 0;
-	for (si = 2; si < str.desc.bLength; si += 2) {
-		if (di >= (length - 1))
-			break;
-
-		wdata = libusb_le16_to_cpu(str.desc.wData[di]);
-		if (wdata < 0x80)
-			data[di++] = (unsigned char)wdata;
-		else
-			data[di++] = '?'; /* non-ASCII */
-	}
-
-	data[di] = 0;
-	return di;
+	return usbi_string_descriptor_to_ascii(&str, data, length);
 }

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -92,6 +92,10 @@ EXPORTS
   libusb_get_port_numbers@12 = libusb_get_port_numbers
   libusb_get_port_path
   libusb_get_port_path@16 = libusb_get_port_path
+  libusb_get_serial_string_descriptor
+  libusb_get_serial_string_descriptor@12 = libusb_get_serial_string_descriptor
+  libusb_get_serial_string_descriptor_ascii
+  libusb_get_serial_string_descriptor_ascii@12 = libusb_get_serial_string_descriptor_ascii
   libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_endpoint_companion_descriptor@12 = libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_usb_device_capability_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1368,6 +1368,10 @@ int LIBUSB_CALL libusb_get_configuration(libusb_device_handle *dev,
 	int *config);
 int LIBUSB_CALL libusb_get_device_descriptor(libusb_device *dev,
 	struct libusb_device_descriptor *desc);
+int LIBUSB_CALL libusb_get_serial_string_descriptor(libusb_device *dev,
+	unsigned char *data, int length);
+int LIBUSB_CALL libusb_get_serial_string_descriptor_ascii(libusb_device *dev,
+	unsigned char *data, int length);
 int LIBUSB_CALL libusb_get_active_config_descriptor(libusb_device *dev,
 	struct libusb_config_descriptor **config);
 int LIBUSB_CALL libusb_get_config_descriptor(libusb_device *dev,

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -728,6 +728,9 @@ void usbi_destroy_event(usbi_event_t *event);
 void usbi_signal_event(usbi_event_t *event);
 void usbi_clear_event(usbi_event_t *event);
 
+int usbi_string_descriptor_to_ascii(union usbi_string_desc_buf* str,
+	unsigned char *data, int length);
+
 #ifdef HAVE_OS_TIMER
 int usbi_create_timer(usbi_timer_t *timer);
 void usbi_destroy_timer(usbi_timer_t *timer);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -980,6 +980,20 @@ struct usbi_os_backend {
 	 */
 	void (*close)(struct libusb_device_handle *dev_handle);
 
+	/* Retrieve the device serial number string from a device.
+	 *
+	 * The descriptor should be retrieved from memory, NOT via bus I/O to the
+	 * device. This means that you may have to cache it in a private structure
+	 * during get_device_list enumeration. Alternatively, you may be able
+	 * to retrieve it from a kernel interface still without generating bus I/O.
+	 *
+	 * This function is expected to write length bytes into data or fewer.
+	 *
+	 * Return size of written data on success or a LIBUSB_ERROR code on failure.
+	 */
+	int (*get_serial_string_descriptor)(struct libusb_device *dev,
+		unsigned char *data, int length);
+
 	/* Get the ACTIVE configuration descriptor for a device.
 	 *
 	 * The descriptor should be retrieved from memory, NOT via bus I/O to the

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -663,6 +663,56 @@ static void darwin_exit (struct libusb_context *ctx) {
   pthread_mutex_unlock (&libusb_darwin_init_mutex);
 }
 
+static int darwin_get_serial_string_descriptor(struct libusb_device *dev, unsigned char *buffer, int length) {
+  struct darwin_cached_device *priv = DARWIN_CACHED_DEVICE(dev);
+  io_iterator_t deviceIterator;
+  io_service_t service;
+  kern_return_t kresult;
+  int r;
+  CFStringRef cf;
+  UInt8 utf16[255];
+  CFIndex utf16_len;
+
+  utf16_len = -1;
+
+  kresult = usb_setup_device_iterator (&deviceIterator, priv->location);
+  if (kresult != kIOReturnSuccess)
+    return darwin_to_libusb (kresult);
+
+  service = IOIteratorNext (deviceIterator);
+  IOObjectRelease(deviceIterator);
+  if (service == IO_OBJECT_NULL)
+    return LIBUSB_ERROR_NOT_FOUND;
+
+  cf = IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
+  IOObjectRelease(service);
+  if (cf == NULL)
+    return LIBUSB_ERROR_NOT_FOUND;
+
+  CFStringGetBytes(cf, CFRangeMake(0, CFStringGetLength(cf)), kCFStringEncodingUTF16LE, '?', false, utf16, sizeof(utf16), &utf16_len);
+  CFRelease(cf);
+
+  if (utf16_len <= 0)
+    return LIBUSB_ERROR_NOT_FOUND;
+
+  r = 0;
+
+  if (length > 2) {
+    r = r + MIN(length - 2, utf16_len);
+    memcpy(buffer + 2, utf16, r);
+  }
+  if (length > 1) {
+    r = r + 1;
+    buffer[1] = LIBUSB_DT_STRING;
+  }
+  if (length > 0) {
+    r = r + 1;
+    buffer[0] = r;
+  }
+
+  return r;
+}
+
 static int get_configuration_index (struct libusb_device *dev, UInt8 config_value) {
   struct darwin_cached_device *priv = DARWIN_CACHED_DEVICE(dev);
   UInt8 i, numConfig;
@@ -2273,6 +2323,7 @@ const struct usbi_os_backend usbi_backend = {
         .caps = 0,
         .init = darwin_init,
         .exit = darwin_exit,
+        .get_serial_string_descriptor = darwin_get_serial_string_descriptor,
         .get_active_config_descriptor = darwin_get_active_config_descriptor,
         .get_config_descriptor = darwin_get_config_descriptor,
         .hotplug_poll = darwin_hotplug_poll,

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -191,6 +191,7 @@ const struct usbi_os_backend usbi_backend = {
 	/*.open =*/ haiku_open,
 	/*.close =*/ haiku_close,
 
+	/*.get_serial_string_descriptor =*/ NULL,
 	/*.get_active_config_descriptor =*/ haiku_get_active_config_descriptor,
 	/*.get_config_descriptor =*/ haiku_get_config_descriptor,
 	/*.get_config_descriptor_by_value =*/ NULL,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -30,6 +30,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <iconv.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -507,6 +508,70 @@ static int open_sysfs_attr(struct libusb_context *ctx,
 	return fd;
 }
 
+static int iconv_utf8_to_utf16le(char *in, size_t in_len, char *out, size_t out_len) {
+	char *i, *o;
+	iconv_t convert;
+
+	i = in;
+	o = out;
+
+	convert = iconv_open("UTF-16LE", "UTF-8");
+	if (iconv(convert, &i, &in_len, &o, &out_len) == (size_t)-1) {
+		return -1;
+	}
+	iconv_close(convert);
+	return (o - out);
+}
+
+static int read_sysfs_attr_string_descriptor(struct libusb_context *ctx,
+	const char *sysfs_dir, const char *attr, unsigned char *buffer, int length)
+{
+	char utf16[255];
+	char utf8[255];
+	ssize_t r;
+	int fd, utf16_len, utf8_len;
+
+	fd = open_sysfs_attr(ctx, sysfs_dir, attr);
+	if (fd < 0)
+		return fd;
+
+	r = read(fd, utf8, sizeof(utf8) - 1);
+	if (r < 0) {
+		r = errno;
+		close(fd);
+		if (r == ENODEV)
+			return LIBUSB_ERROR_NO_DEVICE;
+		usbi_err(ctx, "attribute %s read failed, errno=%zd", attr, r);
+		return LIBUSB_ERROR_IO;
+	}
+	close(fd);
+
+	utf8_len = r;
+
+	utf16_len = iconv_utf8_to_utf16le(utf8, utf8_len, utf16, sizeof(utf16));
+	if (utf16_len < 0) {
+		usbi_err(ctx, "iconv %s failed errno=%d", attr, errno);
+		return LIBUSB_ERROR_OTHER;
+	}
+
+	r = 0;
+
+	if (length > 2) {
+		r = r + MIN(length - 2, utf16_len);
+		memcpy(buffer + 2, utf16, r);
+	}
+	if (length > 1) {
+		r = r + 1;
+		buffer[1] = LIBUSB_DT_STRING;
+	}
+	if (length > 0) {
+		r = r + 1;
+		buffer[0] = r;
+	}
+
+	return r;
+}
+
 /* Note only suitable for attributes which always read >= 0, < 0 is error */
 static int read_sysfs_attr(struct libusb_context *ctx,
 	const char *sysfs_dir, const char *attr, int max_value, int *value_p)
@@ -586,6 +651,15 @@ static int sysfs_scan_device(struct libusb_context *ctx, const char *devname)
 		return ret;
 
 	return linux_enumerate_device(ctx, busnum, devaddr, devname);
+}
+
+static int op_get_serial_string_descriptor(struct libusb_device *dev,
+	unsigned char *data, int length)
+{
+	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+
+	return read_sysfs_attr_string_descriptor(DEVICE_CTX(dev), priv->sysfs_dir,
+		"serial", data, length);
 }
 
 /* read the bConfigurationValue for a device */
@@ -2783,6 +2857,7 @@ const struct usbi_os_backend usbi_backend = {
 	.exit = op_exit,
 	.set_option = op_set_option,
 	.hotplug_poll = op_hotplug_poll,
+	.get_serial_string_descriptor = op_get_serial_string_descriptor,
 	.get_active_config_descriptor = op_get_active_config_descriptor,
 	.get_config_descriptor = op_get_config_descriptor,
 	.get_config_descriptor_by_value = op_get_config_descriptor_by_value,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -898,6 +898,7 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* wrap_sys_device */
 	windows_open,
 	windows_close,
+	NULL,	/* get_serial_string_descriptor */
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,
 	windows_get_config_descriptor_by_value,


### PR DESCRIPTION
I will definitely need some help testing this change and much reviewing. 

* Originally I made this change against 1.0.22 so some of it may be out of style/date (please shout and I will make changes).
* The darwin backend is reasonably well used, but the linux and windows backends are not!
* Linux backend requires iconv

Please feel free to ask about anything in here, comments etc.

## UPDATE:

* Linux backend had to go through some porting from my internal version, it builds *but I do not have a machine to test it on at the moment*
* Windows backend was so broken by the 1.0.22 -> master rebase that I have removed it from this PR. Again I do not have a PC to try it on.