### PR TITLE
WinUSB Compare ClassGuid in check for existing cached device

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -259,7 +259,7 @@ struct winusb_device_priv {
 	} usb_interface[USB_MAXINTERFACES];
 	struct hid_device_priv *hid;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors
-+	GUID class_guid; // ClassGUID is cheched for change during re-enumeration @note cached descriptors invalidated if the class changes
+	GUID class_guid; // ClassGUID is cheched for change during re-enumeration @note cached descriptors invalidated if the class changes
 };
 
 struct usbdk_device_handle_priv {

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -259,6 +259,7 @@ struct winusb_device_priv {
 	} usb_interface[USB_MAXINTERFACES];
 	struct hid_device_priv *hid;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors
++	GUID class_guid; // ClassGUID is cheched for change during re-enumeration @note cached descriptors invalidated if the class changes
 };
 
 struct usbdk_device_handle_priv {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1680,6 +1680,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 
 					priv = winusb_device_priv_init(dev);
 					priv->dev_id = _strdup(dev_id);
+					priv->class_guid = dev_info_data.ClassGuid;
 					if (priv->dev_id == NULL) {
 						libusb_unref_device(dev);
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
@@ -1690,6 +1691,12 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 					priv = usbi_get_device_priv(dev);
 					if (strcmp(priv->dev_id, dev_id) != 0) {
 						usbi_dbg("device instance ID for session [%lX] changed", session_id);
+						usbi_disconnect_device(dev);
+						libusb_unref_device(dev);
+						goto alloc_device;
+					}
+					if (!IsEqualGUID(&priv->class_guid, &dev_info_data.ClassGuid)) {
+						usbi_dbg("device class GUID for session [%lX] changed", session_id);
 						usbi_disconnect_device(dev);
 						libusb_unref_device(dev);
 						goto alloc_device;


### PR DESCRIPTION
Fixed #897 