### PR TITLE
winusb: Check for ClassGuid changes on re-enumeration

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -259,6 +259,7 @@ struct winusb_device_priv {
 	} usb_interface[USB_MAXINTERFACES];
 	struct hid_device_priv *hid;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors
+	GUID class_guid; // checked for change during re-enumeration
 };
 
 struct usbdk_device_handle_priv {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1680,6 +1680,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 
 					priv = winusb_device_priv_init(dev);
 					priv->dev_id = _strdup(dev_id);
+					priv->class_guid = dev_info_data.ClassGuid;
 					if (priv->dev_id == NULL) {
 						libusb_unref_device(dev);
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
@@ -1690,6 +1691,12 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 					priv = usbi_get_device_priv(dev);
 					if (strcmp(priv->dev_id, dev_id) != 0) {
 						usbi_dbg("device instance ID for session [%lX] changed", session_id);
+						usbi_disconnect_device(dev);
+						libusb_unref_device(dev);
+						goto alloc_device;
+					}
+					if (!IsEqualGUID(&priv->class_guid, &dev_info_data.ClassGuid)) {
+						usbi_dbg("device class GUID for session [%lX] changed", session_id);
 						usbi_disconnect_device(dev);
 						libusb_unref_device(dev);
 						goto alloc_device;


### PR DESCRIPTION
Previously only the dev_id (VID/PID/serial) was checked, but if the
bcdDevice has changed, Windows will have re-enumerated the device and
possibly attributed another ClassGuid to it.

Fixes issue #897.

Thanks to Craig Hutchinson for reporting, suggestion and testing.

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>