### PR TITLE
autogen: Support being called from external build dir

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-./bootstrap.sh
+srcdir="$(dirname "$0")"
+
+"$srcdir"/bootstrap.sh
 if [ -z "$NOCONFIGURE" ]; then
-    exec ./configure --enable-examples-build --enable-tests-build "$@"
+    exec "$srcdir"/configure --enable-examples-build --enable-tests-build "$@"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd "$(dirname "$0")"
+
 if [ ! -d m4 ]; then
     mkdir m4
 fi


### PR DESCRIPTION
Building libusb from another build directory doesn't properly work right
now, as calling autogen.sh from there won't work.

An example is when using jhbuild to build it.

So always use absolute paths to call configure and bootstrap scripts