### PR TITLE
core: allow libusb_set_option on the default context before libusb_init

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2107,7 +2107,9 @@ enum libusb_option {
 	 *
 	 * Only valid for Android builds.
 	 */
-	LIBUSB_OPTION_WEAK_AUTHORITY = 2
+	LIBUSB_OPTION_WEAK_AUTHORITY = 2,
+
+	LIBUSB_OPTION_MAX = 3
 };
 
 int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -791,6 +791,13 @@ int usbi_add_event_source(struct libusb_context *ctx, usbi_os_handle_t os_handle
 	short poll_events);
 void usbi_remove_event_source(struct libusb_context *ctx, usbi_os_handle_t os_handle);
 
+struct usbi_option {
+  int is_set;
+  union {
+    int ival;
+  } arg;
+};
+
 /* OS event abstraction */
 
 int usbi_create_event(usbi_event_t *event);

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11620
+#define LIBUSB_NANO 11621

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -130,9 +130,12 @@ static libusb_testlib_result test_default_context_change(void)
 			return TEST_STATUS_FAILURE;
 		}
 
-		/* Enable debug output, to be sure to use the context */
-		libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
+		/* Enable debug output on new context, to be sure to use the context */
 		libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
+
+		/* Enable debug outout on the default context. This should work even before
+		 * the context has been created. */
+		libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 
 		/* Now create a reference to the default context */
 		r = libusb_init(NULL);


### PR DESCRIPTION
This commit updates libusb_set_option to save the options if setting them on the default
context. This ensures the options 1) can be set before libusb_init(NULL, ...), and 2)
are honored even if the default context is destroyed and re-created.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>