### PR TITLE
Do not restrict "weak authority" option to Android

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2098,14 +2098,16 @@ enum libusb_option {
 	 */
 	LIBUSB_OPTION_USE_USBDK = 1,
 
-	/** Set libusb has weak authority. With this option, libusb will skip
-	 * scan devices in libusb_init.
+	/** Flag that libusb has weak authority.
+	 *
+	 * With this option set, libusb will skip scanning devices in
+	 * libusb_init().
 	 *
 	 * This option should be set before calling libusb_init(), otherwise
-	 * libusb_init will failed. Normally libusb_wrap_sys_device on Android
-	 * need set this option.
+	 * libusb_init() might fail. The option is typically needed on Android
+	 * and used together with libusb_wrap_sys_device().
 	 *
-	 * Only valid for Android builds.
+	 * Only valid on Linux.
 	 */
 	LIBUSB_OPTION_WEAK_AUTHORITY = 2
 };

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -95,10 +95,8 @@ static int sysfs_available = -1;
 /* how many times have we initted (and not exited) ? */
 static int init_count = 0;
 
-#ifdef __ANDROID__
 /* have no authority to operate usb device directly */
 static int weak_authority = 0;
-#endif
 
 /* Serialize scan-devices, event-thread, and poll */
 usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
@@ -399,11 +397,9 @@ static int op_init(struct libusb_context *ctx)
 		}
 	}
 
-#ifdef __ANDROID__
 	if (weak_authority) {
 		return LIBUSB_SUCCESS;
 	}
-#endif
 
 	r = LIBUSB_SUCCESS;
 	if (init_count == 0) {
@@ -427,11 +423,9 @@ static void op_exit(struct libusb_context *ctx)
 {
 	UNUSED(ctx);
 
-#ifdef __ANDROID__
 	if (weak_authority) {
 		return;
 	}
-#endif
 
 	assert(init_count != 0);
 	if (!--init_count) {
@@ -445,15 +439,11 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	UNUSED(ctx);
 	UNUSED(ap);
 
-#ifdef __ANDROID__
 	if (option == LIBUSB_OPTION_WEAK_AUTHORITY) {
 		usbi_dbg("set libusb has weak authority");
 		weak_authority = 1;
 		return LIBUSB_SUCCESS;
 	}
-#else
-	UNUSED(option);
-#endif
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }


### PR DESCRIPTION
libusb_wrap_sys_device() is an often needed feature on Android, but can
also be very convenient on other Linux platforms.

In many cases the initial device scanning is not needed and
LIBUSB_OPTION_WEAK_AUTHORITY thus provides a performance enhancement.

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>