### PR TITLE
Fix build failure on Mac OS X 10.7

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1143,7 +1143,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
     case kUSBDeviceSpeedLow: dev->speed = LIBUSB_SPEED_LOW; break;
     case kUSBDeviceSpeedFull: dev->speed = LIBUSB_SPEED_FULL; break;
     case kUSBDeviceSpeedHigh: dev->speed = LIBUSB_SPEED_HIGH; break;
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
     case kUSBDeviceSpeedSuper: dev->speed = LIBUSB_SPEED_SUPER; break;
 #endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200


### PR DESCRIPTION
Apple documentation says kUSBDeviceSpeedSuper is available in 10.7 and
later but in fact it is only defined in the 10.8 SDK and later.

Closes #410