### PR TITLE
New NO_ENUMERATION option to replace WEAK_AUTHORITY option

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1205,8 +1205,10 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
  * handle for the underlying device. The handle allows you to use libusb to
  * perform I/O on the device in question.
  *
- * Must call libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY)
- * before libusb_init if don't have authority to access the usb device directly.
+ * Call libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY) before
+ * libusb_init() if you want to skip enumeration of USB devices. In particular,
+ * this might be needed on Android if you don't have authority to access USB
+ * devices in general.
  *
  * On Linux, the system device handle must be a valid file descriptor opened
  * on the device node.
@@ -2219,6 +2221,7 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 
 		/* Handle all backend-specific options here */
 	case LIBUSB_OPTION_USE_USBDK:
+	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
 	case LIBUSB_OPTION_WEAK_AUTHORITY:
 		if (usbi_backend.set_option)
 			return usbi_backend.set_option(ctx, option, ap);

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2098,20 +2098,30 @@ enum libusb_option {
 	 */
 	LIBUSB_OPTION_USE_USBDK = 1,
 
-	/** Flag that libusb has weak authority.
+	/** Do not scan for devices
 	 *
 	 * With this option set, libusb will skip scanning devices in
-	 * libusb_init().
+	 * libusb_init(). Must be set before calling libusb_init().
 	 *
-	 * This option should be set before calling libusb_init(), otherwise
-	 * libusb_init() might fail. The option is typically needed on Android
-	 * and used together with libusb_wrap_sys_device().
+	 * Hotplug functionality will also be deactivated.
+	 *
+	 * The option is useful in combination with libusb_wrap_sys_device(),
+	 * which can access a device directly without prior device scanning.
+	 *
+	 * This is typically needed on Android, where access to USB devices
+	 * is limited.
 	 *
 	 * Only valid on Linux.
 	 */
-	LIBUSB_OPTION_WEAK_AUTHORITY = 2,
+	LIBUSB_OPTION_NO_DEVICE_DISCOVERY = 2,
 
-	LIBUSB_OPTION_MAX = 3
+	/** Flag that libusb has weak authority.
+	 *
+	 * (Deprecated) alias for LIBUSB_OPTION_NO_DEVICE_DISCOVERY
+	 */
+	LIBUSB_OPTION_WEAK_AUTHORITY = 3,
+
+	LIBUSB_OPTION_MAX = 4
 };
 
 int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -96,7 +96,7 @@ static int sysfs_available = -1;
 static int init_count = 0;
 
 /* have no authority to operate usb device directly */
-static int weak_authority = 0;
+static int no_enumeration = 0;
 
 /* Serialize scan-devices, event-thread, and poll */
 usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
@@ -397,7 +397,7 @@ static int op_init(struct libusb_context *ctx)
 		}
 	}
 
-	if (weak_authority) {
+	if (no_enumeration) {
 		return LIBUSB_SUCCESS;
 	}
 
@@ -423,7 +423,7 @@ static void op_exit(struct libusb_context *ctx)
 {
 	UNUSED(ctx);
 
-	if (weak_authority) {
+	if (no_enumeration) {
 		return;
 	}
 
@@ -439,9 +439,10 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	UNUSED(ctx);
 	UNUSED(ap);
 
-	if (option == LIBUSB_OPTION_WEAK_AUTHORITY) {
-		usbi_dbg("set libusb has weak authority");
-		weak_authority = 1;
+	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY ||
+	    option == LIBUSB_OPTION_WEAK_AUTHORITY) {
+		usbi_dbg("no enumeration will be performed");
+		no_enumeration = 1;
 		return LIBUSB_SUCCESS;
 	}
 


### PR DESCRIPTION
All that the old option was doing, was skipping the device enumeration.
Since this has a much broader usage scope than "weak authority", give
the option a name reflecting exactly what it does.

For now, keep the old option name working as an alias.

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>