### PR TITLE
Core: Calling op_set_option even if no default context is set

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2313,12 +2313,8 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 	list_init(&_ctx->usb_devs);
 	list_init(&_ctx->open_devs);
 
-	/* default context should be initialized before calling usbi_dbg */
-	if (!ctx) {
-		usbi_default_context = _ctx;
-		default_context_refcnt = 1;
-		usbi_dbg(usbi_default_context, "created default context");
-
+	if (ctx || !usbi_default_context) {
+		/* It's a new context or we are not reusing the default context. */
 		for (enum libusb_option option = 0 ; option < LIBUSB_OPTION_MAX ; option++) {
 			if (LIBUSB_OPTION_LOG_LEVEL == option || !default_context_options[option].is_set) {
 				continue;
@@ -2327,6 +2323,13 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 			if (LIBUSB_SUCCESS != r)
 				goto err_free_ctx;
 		}
+	}
+
+	/* default context should be initialized before calling usbi_dbg */
+	if (!ctx) {
+		usbi_default_context = _ctx;
+		default_context_refcnt = 1;
+		usbi_dbg(usbi_default_context, "created default context");
 	}
 
 	usbi_dbg(_ctx, "libusb v%u.%u.%u.%u%s", libusb_version_internal.major, libusb_version_internal.minor,


### PR DESCRIPTION
Following the dicussion in #830, it appears that:

* Calling `libusb_init(NULL)` on Android doesn't work.

* We should call `libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY)` before calling `libusb_init(&ctx)`.

* `LIBUSB_OPTION_WEAK_AUTHORITY` is effectively used in `linux_usbfs.c`, in `op_set_option`, itself called from `core.c` via `usbi_backend.set_option`.

However, following the changes in commit a524555c987fec2c16417d2f58c8713efcbe11a9, it seems that `usbi_backend.set_option(...)` is never called if no default context has been set up. In the following code fragment ([line 2207](https://github.com/libusb/libusb/blob/a524555c987fec2c16417d2f58c8713efcbe11a9/libusb/core.c#L2207)):

```c
	ctx = usbi_get_context(ctx);
	if (NULL == ctx) {
		return LIBUSB_SUCCESS;
	}

	switch (option) {
	case LIBUSB_OPTION_LOG_LEVEL:
#if defined(ENABLE_LOGGING) && !defined(ENABLE_DEBUG_LOGGING)
		if (!ctx->debug_fixed)
			ctx->debug = (enum libusb_log_level)arg;
#endif
		break;

		/* Handle all backend-specific options here */
	case LIBUSB_OPTION_USE_USBDK:
	case LIBUSB_OPTION_WEAK_AUTHORITY:
		if (usbi_backend.set_option)
			return usbi_backend.set_option(ctx, option, ap);

		return LIBUSB_ERROR_NOT_SUPPORTED;
		break;
```

If the default context (`usbi_default_context`) is `NULL` and we call `libusb_set_option` with a `NULL` context, then [`usbi_get_context(ctx)` returns `NULL`](https://github.com/libusb/libusb/blob/a524555c987fec2c16417d2f58c8713efcbe11a9/libusb/libusbi.h#L442):

```c
static inline struct libusb_context *usbi_get_context(struct libusb_context *ctx)
{
	return ctx ? ctx : usbi_default_context;
}
```

As a result, in this case, we return from `libusb_set_option` at line 2209 (`if (NULL == ctx) { return LIBUSB_SUCCESS; }`), so `usbi_backend.set_option` is never called, and `weak_authority` in `linux_usbfs.c` is never set to 1.

Moving `if (NULL == ctx) { return LIBUSB_SUCCESS; }` after that switch statement seems to fix the problem for `LIBUSB_OPTION_WEAK_AUTHORITY`.

That said, I'm not sure how it affects `LIBUSB_OPTION_USE_USBDK`, which is currently treated in the same case as `LIBUSB_OPTION_WEAK_AUTHORITY` in the switch statement. Although `op_set_option` doesn't make use of `ctx` in `linux_usbfs.c` when it deals with `LIBUSB_OPTION_WEAK_AUTHORITY`, it seems that [`windows_set_option` in `windows_common.c`](https://github.com/libusb/libusb/blob/a524555c987fec2c16417d2f58c8713efcbe11a9/libusb/os/windows_common.c#L579) makes use of it.

I don't know enough about the implementation details of libusb, but maybe `LIBUSB_OPTION_USE_USBDK` and `LIBUSB_OPTION_WEAK_AUTHORITY` should be treated separately, perhaps like this:

```c
	case LIBUSB_OPTION_USE_USBDK:
		if (ctx && usbi_backend.set_option)
			return usbi_backend.set_option(ctx, option, ap);
		return LIBUSB_ERROR_NOT_SUPPORTED;
		
	case LIBUSB_OPTION_WEAK_AUTHORITY:
		if (usbi_backend.set_option)
			return usbi_backend.set_option(ctx, option, ap);
		return LIBUSB_ERROR_NOT_SUPPORTED;
```