### PR TITLE
Darwin: update the list of endpoints after successfull SetAlternateInterface()

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1582,7 +1582,17 @@ static int darwin_set_interface_altsetting(struct libusb_device_handle *dev_hand
     return LIBUSB_ERROR_NO_DEVICE;
 
   kresult = (*(cInterface->interface))->SetAlternateInterface (cInterface->interface, altsetting);
-  if (kresult != kIOReturnSuccess)
+  if (kresult == kIOReturnSuccess) {
+    /* update the list of endpoints */
+    ret = get_endpoints (dev_handle, iface);
+    if (ret) {
+      /* this should not happen */
+      darwin_release_interface (dev_handle, iface);
+      usbi_err (HANDLE_CTX (dev_handle), "could not build endpoint table");
+    }
+    return ret;
+  }
+  else
     usbi_warn (HANDLE_CTX (dev_handle), "SetAlternateInterface: %s", darwin_error_str(kresult));
 
   if (kresult != kIOUSBPipeStalled)


### PR DESCRIPTION
Good day.

The problem has appeared after the commit 3e674040e.
My device has no endpoints to read from for default setting, so `libusb_set_interface_alt_setting()` should be called.

And on libusb v1.0.23 everything was alright:

    [ 0.000052] [00000f0b] libusb: debug [libusb_init] created default context
    [ 0.000186] [00000f0b] libusb: debug [libusb_init] libusb v1.0.23.11397
    ...
    [ 0.418928] [00000f0b] libusb: debug [libusb_set_configuration] configuration 1
    [ 0.419027] [00000f0b] libusb: debug [libusb_claim_interface] interface 1
    [ 0.420944] [00000f0b] libusb: debug [get_endpoints] building table of endpoints.
    [ 0.421083] [00000f0b] libusb: debug [darwin_claim_interface] interface opened
    [ 0.497804] [00000f0b] libusb: debug [libusb_claim_interface] interface 1
    [ 0.497862] [00000f0b] libusb: debug [libusb_set_interface_alt_setting] interface 1 altsetting 1
    [ 0.498642] [00000f0b] libusb: debug [get_endpoints] building table of endpoints.
    [ 0.498930] [00000f0b] libusb: debug [get_endpoints] interface: 1 pipe 1: dir: 1 number: 1
    [ 0.499275] [00000f0b] libusb: debug [get_endpoints] interface: 1 pipe 2: dir: 0 number: 2
    [ 1.534906] [00000f0b] libusb: debug [libusb_alloc_transfer] transfer 0x7fea24c0f6f8
    ...
    [ 1.535982] [00000f0b] libusb: debug [ep_to_pipeRef] converting ep address 0x81 to pipeRef and interface
    [ 1.535991] [00000f0b] libusb: debug [ep_to_pipeRef] pipe 1 on interface 1 matches
    ...

But with the current master there is a problem: calling `libusb_set_interface_alt_setting()` do not update the list of endpoints anymore:

    [ 0.000765] [00060f46] libusb: debug [libusb_init] libusb v1.0.24.11630
    ...
    [ 0.021038] [00060f46] libusb: debug [libusb_set_configuration] configuration 1
    [ 0.021108] [00060f46] libusb: debug [libusb_claim_interface] interface 1
    [ 0.022348] [00060f46] libusb: debug [get_endpoints] building table of endpoints.
    [ 0.022935] [00060f46] libusb: debug [darwin_claim_interface] interface opened
    [ 0.022988] [00060f46] libusb: debug [libusb_set_interface_alt_setting] interface 1 altsetting 1
    [ 0.028340] [00060f46] libusb: debug [libusb_alloc_transfer] transfer 0x7ffc23d10fd8
    ...
    [ 0.031797] [00060f46] libusb: debug [ep_to_pipeRef] converting ep address 0x81 to pipeRef and interface
    [ 0.031805] [00060f46] libusb: warning [ep_to_pipeRef] no pipeRef found with endpoint address 0x81.
    [ 0.031824] [00060f46] libusb: error [submit_bulk_transfer] endpoint not found on any open interface
    ...

So, this pr fixes this problem by updating the list of endpoints if `SetAlternateInterface()` returns `kIOReturnSuccess`.