### PR TITLE
core: update usbi_dbg to take the context as an argument

### DIFF
--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode:t ; c-basic-offset:8 -*- */
 /*
  * Hotplug functions for libusb
- * Copyright © 2012-2013 Nathan Hjelm <hjelmn@mac.com>
+ * Copyright © 2012-2021 Nathan Hjelm <hjelmn@mac.com>
  * Copyright © 2012-2013 Peter Stuge <peter@stuge.se>
  *
  * This library is free software; you can redistribute it and/or
@@ -307,7 +307,7 @@ void usbi_hotplug_process(struct libusb_context *ctx, struct list_head *hotplug_
 	/* free any callbacks that have unregistered */
 	for_each_hotplug_cb_safe(ctx, hotplug_cb, next_cb) {
 		if (hotplug_cb->flags & USBI_HOTPLUG_NEEDS_FREE) {
-			usbi_dbg("freeing hotplug cb %p with handle %d",
+			usbi_dbg(ctx, "freeing hotplug cb %p with handle %d",
 				hotplug_cb, hotplug_cb->handle);
 			list_del(&hotplug_cb->list);
 			free(hotplug_cb);
@@ -374,7 +374,7 @@ int API_EXPORTED libusb_hotplug_register_callback(libusb_context *ctx,
 
 	usbi_mutex_unlock(&ctx->hotplug_cbs_lock);
 
-	usbi_dbg("new hotplug cb %p with handle %d", hotplug_cb, hotplug_cb->handle);
+	usbi_dbg(ctx, "new hotplug cb %p with handle %d", hotplug_cb, hotplug_cb->handle);
 
 	if ((flags & LIBUSB_HOTPLUG_ENUMERATE) && (events & LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED)) {
 		ssize_t i, len;
@@ -411,7 +411,7 @@ void API_EXPORTED libusb_hotplug_deregister_callback(libusb_context *ctx,
 	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
 		return;
 
-	usbi_dbg("deregister hotplug cb %d", callback_handle);
+	usbi_dbg(ctx, "deregister hotplug cb %d", callback_handle);
 
 	ctx = usbi_get_context(ctx);
 
@@ -449,7 +449,7 @@ void * LIBUSB_CALL libusb_hotplug_get_user_data(libusb_context *ctx,
 	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
 		return NULL;
 
-	usbi_dbg("get hotplug cb %d user data", callback_handle);
+	usbi_dbg(ctx, "get hotplug cb %d user data", callback_handle);
 
 	ctx = usbi_get_context(ctx);
 

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1180,12 +1180,12 @@ int usbi_io_init(struct libusb_context *ctx)
 #ifdef HAVE_OS_TIMER
 	r = usbi_create_timer(&ctx->timer);
 	if (r == 0) {
-		usbi_dbg("using timer for timeouts");
+		usbi_dbg(ctx, "using timer for timeouts");
 		r = usbi_add_event_source(ctx, USBI_TIMER_OS_HANDLE(&ctx->timer), USBI_TIMER_POLL_EVENTS);
 		if (r < 0)
 			goto err_destroy_timer;
 	} else {
-		usbi_dbg("timer not available for timeouts");
+		usbi_dbg(ctx, "timer not available for timeouts");
 	}
 #endif
 
@@ -1309,7 +1309,6 @@ struct libusb_transfer * LIBUSB_CALL libusb_alloc_transfer(
 	itransfer->priv = ptr;
 	usbi_mutex_init(&itransfer->lock);
 	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-	usbi_dbg("transfer %p", transfer);
 	return transfer;
 }
 
@@ -1339,7 +1338,7 @@ void API_EXPORTED libusb_free_transfer(struct libusb_transfer *transfer)
 	if (!transfer)
 		return;
 
-	usbi_dbg("transfer %p", transfer);
+	usbi_dbg(TRANSFER_CTX(transfer), "transfer %p", transfer);
 	if (transfer->flags & LIBUSB_TRANSFER_FREE_BUFFER)
 		free(transfer->buffer);
 
@@ -1375,12 +1374,12 @@ static int arm_timer_for_next_timeout(struct libusb_context *ctx)
 
 		/* act on first transfer that has not already been handled */
 		if (!(itransfer->timeout_flags & (USBI_TRANSFER_TIMEOUT_HANDLED | USBI_TRANSFER_OS_HANDLES_TIMEOUT))) {
-			usbi_dbg("next timeout originally %ums", USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)->timeout);
+			usbi_dbg(ctx, "next timeout originally %ums", USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)->timeout);
 			return usbi_arm_timer(&ctx->timer, cur_ts);
 		}
 	}
 
-	usbi_dbg("no timeouts, disarming timer");
+	usbi_dbg(ctx, "no timeouts, disarming timer");
 	return usbi_disarm_timer(&ctx->timer);
 }
 #else
@@ -1437,7 +1436,7 @@ out:
 	if (first && usbi_using_timer(ctx) && TIMESPEC_IS_SET(timeout)) {
 		/* if this transfer has the lowest timeout of all active transfers,
 		 * rearm the timer with this transfer's timeout */
-		usbi_dbg("arm timer for timeout in %ums (first in line)",
+		usbi_dbg(ctx, "arm timer for timeout in %ums (first in line)",
 			USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)->timeout);
 		r = usbi_arm_timer(&ctx->timer, timeout);
 	}
@@ -1493,7 +1492,7 @@ int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
 	struct libusb_context *ctx = TRANSFER_CTX(transfer);
 	int r;
 
-	usbi_dbg("transfer %p", transfer);
+	usbi_dbg(ctx, "transfer %p", transfer);
 
 	/*
 	 * Important note on locking, this function takes / releases locks
@@ -1581,9 +1580,10 @@ int API_EXPORTED libusb_cancel_transfer(struct libusb_transfer *transfer)
 {
 	struct usbi_transfer *itransfer =
 		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
+	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
 	int r;
 
-	usbi_dbg("transfer %p", transfer );
+	usbi_dbg(ctx, "transfer %p", transfer );
 	usbi_mutex_lock(&itransfer->lock);
 	if (!(itransfer->state_flags & USBI_TRANSFER_IN_FLIGHT)
 			|| (itransfer->state_flags & USBI_TRANSFER_CANCELLING)) {
@@ -1594,10 +1594,9 @@ int API_EXPORTED libusb_cancel_transfer(struct libusb_transfer *transfer)
 	if (r < 0) {
 		if (r != LIBUSB_ERROR_NOT_FOUND &&
 		    r != LIBUSB_ERROR_NO_DEVICE)
-			usbi_err(TRANSFER_CTX(transfer),
-				"cancel transfer failed error %d", r);
+			usbi_err(ctx, "cancel transfer failed error %d", r);
 		else
-			usbi_dbg("cancel transfer failed error %d", r);
+			usbi_dbg(ctx, "cancel transfer failed error %d", r);
 
 		if (r == LIBUSB_ERROR_NO_DEVICE)
 			itransfer->state_flags |= USBI_TRANSFER_DEVICE_DISAPPEARED;
@@ -1661,12 +1660,13 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 	struct libusb_transfer *transfer =
 		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
 	struct libusb_device_handle *dev_handle = transfer->dev_handle;
+	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
 	uint8_t flags;
 	int r;
 
 	r = remove_from_flying_list(itransfer);
 	if (r < 0)
-		usbi_err(ITRANSFER_CTX(itransfer), "failed to set timer for next timeout");
+		usbi_err(ctx, "failed to set timer for next timeout");
 
 	usbi_mutex_lock(&itransfer->lock);
 	itransfer->state_flags &= ~USBI_TRANSFER_IN_FLIGHT;
@@ -1678,7 +1678,7 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 		if (transfer->type == LIBUSB_TRANSFER_TYPE_CONTROL)
 			rqlen -= LIBUSB_CONTROL_SETUP_SIZE;
 		if (rqlen != itransfer->transferred) {
-			usbi_dbg("interpreting short transfer as error");
+			usbi_dbg(ctx, "interpreting short transfer as error");
 			status = LIBUSB_TRANSFER_ERROR;
 		}
 	}
@@ -1686,7 +1686,7 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 	flags = transfer->flags;
 	transfer->status = status;
 	transfer->actual_length = itransfer->transferred;
-	usbi_dbg("transfer %p has callback %p", transfer, transfer->callback);
+	usbi_dbg(ctx, "transfer %p has callback %p", transfer, transfer->callback);
 	if (transfer->callback)
 		transfer->callback(transfer);
 	/* transfer might have been freed by the above call, do not use from
@@ -1714,7 +1714,7 @@ int usbi_handle_transfer_cancellation(struct usbi_transfer *itransfer)
 
 	/* if the URB was cancelled due to timeout, report timeout to the user */
 	if (timed_out) {
-		usbi_dbg("detected timeout cancellation");
+		usbi_dbg(ctx, "detected timeout cancellation");
 		return usbi_handle_transfer_completion(itransfer, LIBUSB_TRANSFER_TIMED_OUT);
 	}
 
@@ -1775,7 +1775,7 @@ int API_EXPORTED libusb_try_lock_events(libusb_context *ctx)
 	ru = ctx->device_close;
 	usbi_mutex_unlock(&ctx->event_data_lock);
 	if (ru) {
-		usbi_dbg("someone else is closing a device");
+		usbi_dbg(ctx, "someone else is closing a device");
 		return 1;
 	}
 
@@ -1867,7 +1867,7 @@ int API_EXPORTED libusb_event_handling_ok(libusb_context *ctx)
 	r = ctx->device_close;
 	usbi_mutex_unlock(&ctx->event_data_lock);
 	if (r) {
-		usbi_dbg("someone else is closing a device");
+		usbi_dbg(ctx, "someone else is closing a device");
 		return 0;
 	}
 
@@ -1896,7 +1896,7 @@ int API_EXPORTED libusb_event_handler_active(libusb_context *ctx)
 	r = ctx->device_close;
 	usbi_mutex_unlock(&ctx->event_data_lock);
 	if (r) {
-		usbi_dbg("someone else is closing a device");
+		usbi_dbg(ctx, "someone else is closing a device");
 		return 1;
 	}
 
@@ -1917,7 +1917,7 @@ void API_EXPORTED libusb_interrupt_event_handler(libusb_context *ctx)
 {
 	unsigned int event_flags;
 
-	usbi_dbg(" ");
+	usbi_dbg(ctx, " ");
 
 	ctx = usbi_get_context(ctx);
 	usbi_mutex_lock(&ctx->event_data_lock);
@@ -2075,7 +2075,7 @@ static int handle_event_trigger(struct libusb_context *ctx)
 	int hotplug_event = 0;
 	int r = 0;
 
-	usbi_dbg("event triggered");
+	usbi_dbg(ctx, "event triggered");
 
 	list_init(&hotplug_msgs);
 
@@ -2084,26 +2084,26 @@ static int handle_event_trigger(struct libusb_context *ctx)
 
 	/* check if someone modified the event sources */
 	if (ctx->event_flags & USBI_EVENT_EVENT_SOURCES_MODIFIED)
-		usbi_dbg("someone updated the event sources");
+		usbi_dbg(ctx, "someone updated the event sources");
 
 	if (ctx->event_flags & USBI_EVENT_USER_INTERRUPT) {
-		usbi_dbg("someone purposefully interrupted");
+		usbi_dbg(ctx, "someone purposefully interrupted");
 		ctx->event_flags &= ~USBI_EVENT_USER_INTERRUPT;
 	}
 
 	if (ctx->event_flags & USBI_EVENT_HOTPLUG_CB_DEREGISTERED) {
-		usbi_dbg("someone unregistered a hotplug cb");
+		usbi_dbg(ctx, "someone unregistered a hotplug cb");
 		ctx->event_flags &= ~USBI_EVENT_HOTPLUG_CB_DEREGISTERED;
 		hotplug_event = 1;
 	}
 
 	/* check if someone is closing a device */
 	if (ctx->event_flags & USBI_EVENT_DEVICE_CLOSE)
-		usbi_dbg("someone is closing a device");
+		usbi_dbg(ctx, "someone is closing a device");
 
 	/* check for any pending hotplug messages */
 	if (ctx->event_flags & USBI_EVENT_HOTPLUG_MSG_PENDING) {
-		usbi_dbg("hotplug message received");
+		usbi_dbg(ctx, "hotplug message received");
 		ctx->event_flags &= ~USBI_EVENT_HOTPLUG_MSG_PENDING;
 		hotplug_event = 1;
 		assert(!list_empty(&ctx->hotplug_msgs));
@@ -2186,7 +2186,7 @@ static int handle_events(struct libusb_context *ctx, struct timeval *tv)
 	 * save the additional overhead */
 	usbi_mutex_lock(&ctx->event_data_lock);
 	if (ctx->event_flags & USBI_EVENT_EVENT_SOURCES_MODIFIED) {
-		usbi_dbg("event sources modified, reallocating event data");
+		usbi_dbg(ctx, "event sources modified, reallocating event data");
 
 		/* free anything removed since we last ran */
 		cleanup_removed_event_sources(ctx);
@@ -2333,7 +2333,7 @@ retry:
 	if (libusb_try_lock_events(ctx) == 0) {
 		if (completed == NULL || !*completed) {
 			/* we obtained the event lock: do our own event handling */
-			usbi_dbg("doing our own event handling");
+			usbi_dbg(ctx, "doing our own event handling");
 			r = handle_events(ctx, &poll_timeout);
 		}
 		libusb_unlock_events(ctx);
@@ -2351,11 +2351,11 @@ retry:
 		/* we hit a race: whoever was event handling earlier finished in the
 		 * time it took us to reach this point. try the cycle again. */
 		libusb_unlock_event_waiters(ctx);
-		usbi_dbg("event handler was active but went away, retrying");
+		usbi_dbg(ctx, "event handler was active but went away, retrying");
 		goto retry;
 	}
 
-	usbi_dbg("another thread is doing event handling");
+	usbi_dbg(ctx, "another thread is doing event handling");
 	r = libusb_wait_for_event(ctx, &poll_timeout);
 
 already_done:
@@ -2550,7 +2550,7 @@ int API_EXPORTED libusb_get_next_timeout(libusb_context *ctx,
 	usbi_mutex_lock(&ctx->flying_transfers_lock);
 	if (list_empty(&ctx->flying_transfers)) {
 		usbi_mutex_unlock(&ctx->flying_transfers_lock);
-		usbi_dbg("no URBs, no timeout!");
+		usbi_dbg(ctx, "no URBs, no timeout!");
 		return 0;
 	}
 
@@ -2569,19 +2569,19 @@ int API_EXPORTED libusb_get_next_timeout(libusb_context *ctx,
 	usbi_mutex_unlock(&ctx->flying_transfers_lock);
 
 	if (!TIMESPEC_IS_SET(&next_timeout)) {
-		usbi_dbg("no URB with timeout or all handled by OS; no timeout!");
+		usbi_dbg(ctx, "no URB with timeout or all handled by OS; no timeout!");
 		return 0;
 	}
 
 	usbi_get_monotonic_time(&systime);
 
 	if (!TIMESPEC_CMP(&systime, &next_timeout, <)) {
-		usbi_dbg("first timeout already expired");
+		usbi_dbg(ctx, "first timeout already expired");
 		timerclear(tv);
 	} else {
 		TIMESPEC_SUB(&next_timeout, &systime, &next_timeout);
 		TIMESPEC_TO_TIMEVAL(tv, &next_timeout);
-		usbi_dbg("next timeout in %ld.%06lds", (long)tv->tv_sec, (long)tv->tv_usec);
+		usbi_dbg(ctx, "next timeout in %ld.%06lds", (long)tv->tv_sec, (long)tv->tv_usec);
 	}
 
 	return 1;
@@ -2652,7 +2652,7 @@ int usbi_add_event_source(struct libusb_context *ctx, usbi_os_handle_t os_handle
 	if (!ievent_source)
 		return LIBUSB_ERROR_NO_MEM;
 
-	usbi_dbg("add " USBI_OS_HANDLE_FORMAT_STRING " events %d", os_handle, poll_events);
+	usbi_dbg(ctx, "add " USBI_OS_HANDLE_FORMAT_STRING " events %d", os_handle, poll_events);
 	ievent_source->data.os_handle = os_handle;
 	ievent_source->data.poll_events = poll_events;
 	usbi_mutex_lock(&ctx->event_data_lock);
@@ -2674,7 +2674,7 @@ void usbi_remove_event_source(struct libusb_context *ctx, usbi_os_handle_t os_ha
 	struct usbi_event_source *ievent_source;
 	int found = 0;
 
-	usbi_dbg("remove " USBI_OS_HANDLE_FORMAT_STRING, os_handle);
+	usbi_dbg(ctx, "remove " USBI_OS_HANDLE_FORMAT_STRING, os_handle);
 	usbi_mutex_lock(&ctx->event_data_lock);
 	for_each_event_source(ctx, ievent_source) {
 		if (ievent_source->data.os_handle == os_handle) {
@@ -2684,7 +2684,7 @@ void usbi_remove_event_source(struct libusb_context *ctx, usbi_os_handle_t os_ha
 	}
 
 	if (!found) {
-		usbi_dbg("couldn't find " USBI_OS_HANDLE_FORMAT_STRING " to remove", os_handle);
+		usbi_dbg(ctx, "couldn't find " USBI_OS_HANDLE_FORMAT_STRING " to remove", os_handle);
 		usbi_mutex_unlock(&ctx->event_data_lock);
 		return;
 	}
@@ -2783,7 +2783,7 @@ void usbi_handle_disconnect(struct libusb_device_handle *dev_handle)
 	struct usbi_transfer *cur;
 	struct usbi_transfer *to_cancel;
 
-	usbi_dbg("device %d.%d",
+	usbi_dbg(ctx, "device %d.%d",
 		dev_handle->dev->bus_number, dev_handle->dev->device_address);
 
 	/* terminate all pending transfers with the LIBUSB_TRANSFER_NO_DEVICE
@@ -2818,7 +2818,7 @@ void usbi_handle_disconnect(struct libusb_device_handle *dev_handle)
 		if (!to_cancel)
 			break;
 
-		usbi_dbg("cancelling transfer %p from disconnect",
+		usbi_dbg(ctx, "cancelling transfer %p from disconnect",
 			 USBI_TRANSFER_TO_LIBUSB_TRANSFER(to_cancel));
 
 		usbi_mutex_lock(&to_cancel->lock);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -317,14 +317,14 @@ void usbi_log(struct libusb_context *ctx, enum libusb_log_level level,
 #define usbi_err(ctx, ...)	_usbi_log(ctx, LIBUSB_LOG_LEVEL_ERROR, __VA_ARGS__)
 #define usbi_warn(ctx, ...)	_usbi_log(ctx, LIBUSB_LOG_LEVEL_WARNING, __VA_ARGS__)
 #define usbi_info(ctx, ...)	_usbi_log(ctx, LIBUSB_LOG_LEVEL_INFO, __VA_ARGS__)
-#define usbi_dbg(...)		_usbi_log(NULL, LIBUSB_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define usbi_dbg(ctx ,...)      	_usbi_log(ctx, LIBUSB_LOG_LEVEL_DEBUG, __VA_ARGS__)
 
 #else /* ENABLE_LOGGING */
 
 #define usbi_err(ctx, ...)	UNUSED(ctx)
 #define usbi_warn(ctx, ...)	UNUSED(ctx)
 #define usbi_info(ctx, ...)	UNUSED(ctx)
-#define usbi_dbg(...)		do {} while (0)
+#define usbi_dbg(ctx, ...)	do {} while (0)
 
 #endif /* ENABLE_LOGGING */
 

--- a/libusb/os/events_posix.c
+++ b/libusb/os/events_posix.c
@@ -222,9 +222,9 @@ int usbi_wait_for_events(struct libusb_context *ctx,
 	usbi_nfds_t nfds = (usbi_nfds_t)ctx->event_data_cnt;
 	int internal_fds, num_ready;
 
-	usbi_dbg("poll() %u fds with timeout in %dms", (unsigned int)nfds, timeout_ms);
+	usbi_dbg(ctx, "poll() %u fds with timeout in %dms", (unsigned int)nfds, timeout_ms);
 	num_ready = poll(fds, nfds, timeout_ms);
-	usbi_dbg("poll() returned %d", num_ready);
+	usbi_dbg(ctx, "poll() returned %d", num_ready);
 	if (num_ready == 0) {
 		if (usbi_using_timer(ctx))
 			goto done;
@@ -279,7 +279,7 @@ int usbi_wait_for_events(struct libusb_context *ctx,
 					continue;
 				/* pollfd was removed between the creation of the fds array and
 				 * here. remove triggered revent as it is no longer relevant. */
-				usbi_dbg("fd %d was removed, ignoring raised events", fds[n].fd);
+				usbi_dbg(ctx, "fd %d was removed, ignoring raised events", fds[n].fd);
 				fds[n].revents = 0;
 				num_ready--;
 				break;

--- a/libusb/os/events_windows.c
+++ b/libusb/os/events_windows.c
@@ -171,9 +171,9 @@ int usbi_wait_for_events(struct libusb_context *ctx,
 	DWORD num_handles = (DWORD)ctx->event_data_cnt;
 	DWORD result;
 
-	usbi_dbg("WaitForMultipleObjects() for %lu HANDLEs with timeout in %dms", ULONG_CAST(num_handles), timeout_ms);
+	usbi_dbg(ctx, "WaitForMultipleObjects() for %lu HANDLEs with timeout in %dms", ULONG_CAST(num_handles), timeout_ms);
 	result = WaitForMultipleObjects(num_handles, handles, FALSE, (DWORD)timeout_ms);
-	usbi_dbg("WaitForMultipleObjects() returned %lu", ULONG_CAST(result));
+	usbi_dbg(ctx, "WaitForMultipleObjects() returned %lu", ULONG_CAST(result));
 	if (result == WAIT_TIMEOUT) {
 		if (usbi_using_timer(ctx))
 			goto done;

--- a/libusb/os/haiku_pollfs.cpp
+++ b/libusb/os/haiku_pollfs.cpp
@@ -100,14 +100,14 @@ WatchedEntry::WatchedEntry(BMessenger *messenger, entry_ref *ref)
 			for_each_context(ctx) {
 				struct libusb_device *dev = usbi_get_device_by_session_id(ctx, session_id);
 				if (dev) {
-					usbi_dbg("using previously allocated device with location %lu", session_id);
+					usbi_dbg(NULL, "using previously allocated device with location %lu", session_id);
 					libusb_unref_device(dev);
 					continue;
 				}
-				usbi_dbg("allocating new device with location %lu", session_id);
+				usbi_dbg(NULL, "allocating new device with location %lu", session_id);
 				dev = usbi_alloc_device(ctx, session_id);
 				if (!dev) {
-					usbi_dbg("device allocation failed");
+					usbi_dbg(NULL, "device allocation failed");
 					continue;
 				}
 				*((USBDevice **)usbi_get_device_priv(dev)) = fDevice;
@@ -134,7 +134,7 @@ WatchedEntry::WatchedEntry(BMessenger *messenger, entry_ref *ref)
 				usbi_localize_device_descriptor(&dev->device_descriptor);
 
 				if (usbi_sanitize_device(dev) < 0) {
-					usbi_dbg("device sanitization failed");
+					usbi_dbg(NULL, "device sanitization failed");
 					libusb_unref_device(dev);
 					continue;
 				}
@@ -178,7 +178,7 @@ WatchedEntry::~WatchedEntry()
 				usbi_disconnect_device(dev);
 				libusb_unref_device(dev);
 			} else {
-				usbi_dbg("device with location %lu not found", session_id);
+				usbi_dbg(ctx, "device with location %lu not found", session_id);
 			}
 		}
 		usbi_mutex_static_unlock(&active_contexts_lock);

--- a/libusb/os/haiku_usb_backend.cpp
+++ b/libusb/os/haiku_usb_backend.cpp
@@ -296,7 +296,7 @@ USBDeviceHandle::SetAltSetting(uint8 inumber, uint8 alt)
 		return _errno_to_libusb(command.alternate.status);
 	}
 	if (command.alternate.alternate_info == (uint32)alt) {
-		usbi_dbg("Setting alternate interface successful");
+		usbi_dbg(NULL, "Setting alternate interface successful");
 		return LIBUSB_SUCCESS;
 	}
 	command.alternate.alternate_info = alt;
@@ -305,7 +305,7 @@ USBDeviceHandle::SetAltSetting(uint8 inumber, uint8 alt)
 		usbi_err(NULL, "Error setting alternate interface");
 		return _errno_to_libusb(command.alternate.status);
 	}
-	usbi_dbg("Setting alternate interface successful");
+	usbi_dbg(NULL, "Setting alternate interface successful");
 	return LIBUSB_SUCCESS;
 }
 

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -99,7 +99,7 @@ int linux_netlink_start_event_monitor(void)
 
 	linux_netlink_socket = socket(PF_NETLINK, socktype, NETLINK_KOBJECT_UEVENT);
 	if (linux_netlink_socket == -1 && errno == EINVAL) {
-		usbi_dbg("failed to create netlink socket of type %d, attempting SOCK_RAW", socktype);
+		usbi_dbg(NULL, "failed to create netlink socket of type %d, attempting SOCK_RAW", socktype);
 		socktype = SOCK_RAW;
 		linux_netlink_socket = socket(PF_NETLINK, socktype, NETLINK_KOBJECT_UEVENT);
 	}
@@ -204,7 +204,7 @@ static int linux_netlink_parse(const char *buffer, size_t len, int *detached,
 	} else if (strcmp(tmp, "remove") == 0) {
 		*detached = 1;
 	} else if (strcmp(tmp, "add") != 0) {
-		usbi_dbg("unknown device action %s", tmp);
+		usbi_dbg(NULL, "unknown device action %s", tmp);
 		return -1;
 	}
 
@@ -311,20 +311,20 @@ static int linux_netlink_read_message(void)
 	}
 
 	if (sa_nl.nl_groups != NL_GROUP_KERNEL || sa_nl.nl_pid != 0) {
-		usbi_dbg("ignoring netlink message from unknown group/PID (%u/%u)",
+		usbi_dbg(NULL, "ignoring netlink message from unknown group/PID (%u/%u)",
 			 (unsigned int)sa_nl.nl_groups, (unsigned int)sa_nl.nl_pid);
 		return -1;
 	}
 
 	cmsg = CMSG_FIRSTHDR(&msg);
 	if (!cmsg || cmsg->cmsg_type != SCM_CREDENTIALS) {
-		usbi_dbg("ignoring netlink message with no sender credentials");
+		usbi_dbg(NULL, "ignoring netlink message with no sender credentials");
 		return -1;
 	}
 
 	cred = (struct ucred *)CMSG_DATA(cmsg);
 	if (cred->uid != 0) {
-		usbi_dbg("ignoring netlink message with non-zero sender UID %u", (unsigned int)cred->uid);
+		usbi_dbg(NULL, "ignoring netlink message with non-zero sender UID %u", (unsigned int)cred->uid);
 		return -1;
 	}
 
@@ -332,7 +332,7 @@ static int linux_netlink_read_message(void)
 	if (r)
 		return r;
 
-	usbi_dbg("netlink hotplug found device busnum: %hhu, devaddr: %hhu, sys_name: %s, removed: %s",
+	usbi_dbg(NULL, "netlink hotplug found device busnum: %hhu, devaddr: %hhu, sys_name: %s, removed: %s",
 		 busnum, devaddr, sys_name, detached ? "yes" : "no");
 
 	/* signal device is available (or not) to all contexts */
@@ -362,7 +362,7 @@ static void *linux_netlink_event_thread_main(void *arg)
 		usbi_warn(NULL, "failed to set hotplug event thread name, error=%d", r);
 #endif
 
-	usbi_dbg("netlink event thread entering");
+	usbi_dbg(NULL, "netlink event thread entering");
 
 	while (1) {
 		r = poll(fds, 2, -1);
@@ -384,7 +384,7 @@ static void *linux_netlink_event_thread_main(void *arg)
 		}
 	}
 
-	usbi_dbg("netlink event thread exiting");
+	usbi_dbg(NULL, "netlink event thread exiting");
 
 	return NULL;
 }

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -177,7 +177,7 @@ static void *linux_udev_event_thread_main(void *arg)
 		usbi_warn(NULL, "failed to set hotplug event thread name, error=%d", r);
 #endif
 
-	usbi_dbg("udev event thread entering");
+	usbi_dbg(NULL, "udev event thread entering");
 
 	while (1) {
 		r = poll(fds, 2, -1);
@@ -201,7 +201,7 @@ static void *linux_udev_event_thread_main(void *arg)
 		}
 	}
 
-	usbi_dbg("udev event thread exiting");
+	usbi_dbg(NULL, "udev event thread exiting");
 
 	return NULL;
 }
@@ -246,7 +246,7 @@ static void udev_hotplug_event(struct udev_device *udev_dev)
 			break;
 		}
 
-		usbi_dbg("udev hotplug event. action: %s.", udev_action);
+		usbi_dbg(NULL, "udev hotplug event. action: %s.", udev_action);
 
 		if (strncmp(udev_action, "add", 3) == 0) {
 			linux_hotplug_enumerate(busnum, devaddr, sys_name);
@@ -313,7 +313,7 @@ void linux_udev_hotplug_poll(void)
 	do {
 		udev_dev = udev_monitor_receive_device(udev_monitor);
 		if (udev_dev) {
-			usbi_dbg("Handling hotplug event from hotplug_poll");
+			usbi_dbg(NULL, "Handling hotplug event from hotplug_poll");
 			udev_hotplug_event(udev_dev);
 		}
 	} while (udev_dev);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -234,11 +234,11 @@ static int is_usbdev_entry(const char *name, uint8_t *bus_p, uint8_t *dev_p)
 	if (sscanf(name, "usbdev%d.%d", &busnum, &devnum) != 2)
 		return 0;
 	if (busnum < 0 || busnum > UINT8_MAX || devnum < 0 || devnum > UINT8_MAX) {
-		usbi_dbg("invalid usbdev format '%s'", name);
+		usbi_dbg(NULL, "invalid usbdev format '%s'", name);
 		return 0;
 	}
 
-	usbi_dbg("found: %s", name);
+	usbi_dbg(NULL, "found: %s", name);
 	if (bus_p)
 		*bus_p = (uint8_t)busnum;
 	if (dev_p)
@@ -323,7 +323,7 @@ static int get_kernel_version(struct libusb_context *ctx,
 	if (atoms < 3)
 		ver->sublevel = -1;
 
-	usbi_dbg("reported kernel version is %s", uts.release);
+	usbi_dbg(ctx, "reported kernel version is %s", uts.release);
 
 	return 0;
 }
@@ -371,7 +371,7 @@ static int op_init(struct libusb_context *ctx)
 		return LIBUSB_ERROR_OTHER;
 	}
 
-	usbi_dbg("found usbfs at %s", usbfs_path);
+	usbi_dbg(ctx, "found usbfs at %s", usbfs_path);
 
 	if (!max_iso_packet_len) {
 		if (kernel_version_ge(&kversion, 5, 2, 0))
@@ -382,14 +382,14 @@ static int op_init(struct libusb_context *ctx)
 			max_iso_packet_len = 8192;
 	}
 
-	usbi_dbg("max iso packet length is (likely) %u bytes", max_iso_packet_len);
+	usbi_dbg(ctx, "max iso packet length is (likely) %u bytes", max_iso_packet_len);
 
 	if (sysfs_available == -1) {
 		struct statfs statfsbuf;
 
 		r = statfs(SYSFS_MOUNT_PATH, &statfsbuf);
 		if (r == 0 && statfsbuf.f_type == SYSFS_MAGIC) {
-			usbi_dbg("sysfs is available");
+			usbi_dbg(ctx, "sysfs is available");
 			sysfs_available = 1;
 		} else {
 			usbi_warn(ctx, "sysfs not mounted");
@@ -441,7 +441,7 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 
 	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY ||
 	    option == LIBUSB_OPTION_WEAK_AUTHORITY) {
-		usbi_dbg("no enumeration will be performed");
+		usbi_dbg(ctx, "no enumeration will be performed");
 		no_enumeration = 1;
 		return LIBUSB_SUCCESS;
 	}
@@ -589,7 +589,7 @@ int linux_get_device_address(struct libusb_context *ctx, int detached,
 	int sysfs_val;
 	int r;
 
-	usbi_dbg("getting address for device: %s detached: %d", sys_name, detached);
+	usbi_dbg(ctx, "getting address for device: %s detached: %d", sys_name, detached);
 	/* can't use sysfs to read the bus and device number if the
 	 * device has been detached */
 	if (!sysfs_available || detached || !sys_name) {
@@ -618,7 +618,7 @@ int linux_get_device_address(struct libusb_context *ctx, int detached,
 		return LIBUSB_SUCCESS;
 	}
 
-	usbi_dbg("scan %s", sys_name);
+	usbi_dbg(ctx, "scan %s", sys_name);
 
 	r = read_sysfs_attr(ctx, sys_name, "busnum", UINT8_MAX, &sysfs_val);
 	if (r < 0)
@@ -630,7 +630,7 @@ int linux_get_device_address(struct libusb_context *ctx, int detached,
 		return r;
 	*devaddr = (uint8_t)sysfs_val;
 
-	usbi_dbg("bus=%u dev=%u", *busnum, *devaddr);
+	usbi_dbg(ctx, "bus=%u dev=%u", *busnum, *devaddr);
 
 	return LIBUSB_SUCCESS;
 }
@@ -1073,14 +1073,14 @@ retry:
 	usbi_mutex_unlock(&ctx->usb_devs_lock);
 
 	if (!dev->parent_dev && add_parent) {
-		usbi_dbg("parent_dev %s not enumerated yet, enumerating now",
+		usbi_dbg(ctx, "parent_dev %s not enumerated yet, enumerating now",
 			 parent_sysfs_dir);
 		sysfs_scan_device(ctx, parent_sysfs_dir);
 		add_parent = 0;
 		goto retry;
 	}
 
-	usbi_dbg("dev %p (%s) has parent %p (%s) port %u", dev, sysfs_dir,
+	usbi_dbg(ctx, "dev %p (%s) has parent %p (%s) port %u", dev, sysfs_dir,
 		 dev->parent_dev, parent_sysfs_dir, dev->port_number);
 
 	free(parent_sysfs_dir);
@@ -1099,17 +1099,17 @@ int linux_enumerate_device(struct libusb_context *ctx,
 	 * will be reused. instead we should add a simple sysfs attribute with
 	 * a session ID. */
 	session_id = busnum << 8 | devaddr;
-	usbi_dbg("busnum %u devaddr %u session_id %lu", busnum, devaddr, session_id);
+	usbi_dbg(ctx, "busnum %u devaddr %u session_id %lu", busnum, devaddr, session_id);
 
 	dev = usbi_get_device_by_session_id(ctx, session_id);
 	if (dev) {
 		/* device already exists in the context */
-		usbi_dbg("session_id %lu already exists", session_id);
+		usbi_dbg(ctx, "session_id %lu already exists", session_id);
 		libusb_unref_device(dev);
 		return LIBUSB_SUCCESS;
 	}
 
-	usbi_dbg("allocating new device for %u/%u (session %lu)",
+	usbi_dbg(ctx, "allocating new device for %u/%u (session %lu)",
 		 busnum, devaddr, session_id);
 	dev = usbi_alloc_device(ctx, session_id);
 	if (!dev)
@@ -1158,7 +1158,7 @@ void linux_device_disconnected(uint8_t busnum, uint8_t devaddr)
 			usbi_disconnect_device(dev);
 			libusb_unref_device(dev);
 		} else {
-			usbi_dbg("device not found for session %lx", session_id);
+			usbi_dbg(ctx, "device not found for session %lx", session_id);
 		}
 	}
 	usbi_mutex_static_unlock(&active_contexts_lock);
@@ -1190,7 +1190,7 @@ static int usbfs_scan_busdir(struct libusb_context *ctx, uint8_t busnum)
 	int r = LIBUSB_ERROR_IO;
 
 	sprintf(dirpath, USB_DEVTMPFS_PATH "/%03u", busnum);
-	usbi_dbg("%s", dirpath);
+	usbi_dbg(ctx, "%s", dirpath);
 	dir = opendir(dirpath);
 	if (!dir) {
 		usbi_err(ctx, "opendir '%s' failed, errno=%d", dirpath, errno);
@@ -1206,12 +1206,12 @@ static int usbfs_scan_busdir(struct libusb_context *ctx, uint8_t busnum)
 			continue;
 
 		if (!parse_u8(entry->d_name, &devaddr)) {
-			usbi_dbg("unknown dir entry %s", entry->d_name);
+			usbi_dbg(ctx, "unknown dir entry %s", entry->d_name);
 			continue;
 		}
 
 		if (linux_enumerate_device(ctx, busnum, devaddr, NULL)) {
-			usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
+			usbi_dbg(ctx, "failed to enumerate dir entry %s", entry->d_name);
 			continue;
 		}
 
@@ -1249,12 +1249,12 @@ static int usbfs_get_device_list(struct libusb_context *ctx)
 
 			r = linux_enumerate_device(ctx, busnum, devaddr, NULL);
 			if (r < 0) {
-				usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
+				usbi_dbg(ctx, "failed to enumerate dir entry %s", entry->d_name);
 				continue;
 			}
 		} else {
 			if (!parse_u8(entry->d_name, &busnum)) {
-				usbi_dbg("unknown dir entry %s", entry->d_name);
+				usbi_dbg(ctx, "unknown dir entry %s", entry->d_name);
 				continue;
 			}
 
@@ -1289,7 +1289,7 @@ static int sysfs_get_device_list(struct libusb_context *ctx)
 		num_devices++;
 
 		if (sysfs_scan_device(ctx, entry->d_name)) {
-			usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
+			usbi_dbg(ctx, "failed to enumerate dir entry %s", entry->d_name);
 			continue;
 		}
 
@@ -1329,7 +1329,7 @@ static int initialize_handle(struct libusb_device_handle *handle, int fd)
 	r = ioctl(fd, IOCTL_USBFS_GET_CAPABILITIES, &hpriv->caps);
 	if (r < 0) {
 		if (errno == ENOTTY)
-			usbi_dbg("getcap not available");
+			usbi_dbg(HANDLE_CTX(handle), "getcap not available");
 		else
 			usbi_err(HANDLE_CTX(handle), "getcap failed, errno=%d", errno);
 		hpriv->caps = USBFS_CAP_BULK_CONTINUATION;
@@ -1363,7 +1363,7 @@ static int op_wrap_sys_device(struct libusb_context *ctx,
 
 	/* Session id is unused as we do not add the device to the list of
 	 * connected devices. */
-	usbi_dbg("allocating new device for fd %d", fd);
+	usbi_dbg(ctx, "allocating new device for fd %d", fd);
 	dev = usbi_alloc_device(ctx, 0);
 	if (!dev)
 		return LIBUSB_ERROR_NO_MEM;
@@ -1399,7 +1399,7 @@ static int op_open(struct libusb_device_handle *handle)
 			 * hasn't processed remove event yet */
 			usbi_mutex_static_lock(&linux_hotplug_lock);
 			if (usbi_atomic_load(&handle->dev->attached)) {
-				usbi_dbg("open failed with no device, but device still attached");
+				usbi_dbg(HANDLE_CTX(handle), "open failed with no device, but device still attached");
 				linux_device_disconnected(handle->dev->bus_number,
 							  handle->dev->device_address);
 			}
@@ -1869,11 +1869,11 @@ static int discard_urbs(struct usbi_transfer *itransfer, int first, int last_plu
 			continue;
 
 		if (errno == EINVAL) {
-			usbi_dbg("URB not found --> assuming ready to be reaped");
+			usbi_dbg(TRANSFER_CTX(transfer), "URB not found --> assuming ready to be reaped");
 			if (i == (last_plus_one - 1))
 				ret = LIBUSB_ERROR_NOT_FOUND;
 		} else if (errno == ENODEV) {
-			usbi_dbg("Device not found for URB --> assuming ready to be reaped");
+			usbi_dbg(TRANSFER_CTX(transfer), "Device not found for URB --> assuming ready to be reaped");
 			ret = LIBUSB_ERROR_NO_DEVICE;
 		} else {
 			usbi_warn(TRANSFER_CTX(transfer), "unrecognised discard errno %d", errno);
@@ -1964,7 +1964,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 		last_urb_partial = 1;
 		num_urbs++;
 	}
-	usbi_dbg("need %d urbs for new transfer with length %d", num_urbs, transfer->length);
+	usbi_dbg(TRANSFER_CTX(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
 	urbs = calloc(num_urbs, sizeof(*urbs));
 	if (!urbs)
 		return LIBUSB_ERROR_NO_MEM;
@@ -2029,7 +2029,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 		/* if the first URB submission fails, we can simply free up and
 		 * return failure immediately. */
 		if (i == 0) {
-			usbi_dbg("first URB failed, easy peasy");
+			usbi_dbg(TRANSFER_CTX(transfer), "first URB failed, easy peasy");
 			free(urbs);
 			tpriv->urbs = NULL;
 			return r;
@@ -2063,7 +2063,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 
 		discard_urbs(itransfer, 0, i);
 
-		usbi_dbg("reporting successful submission but waiting for %d "
+		usbi_dbg(TRANSFER_CTX(transfer), "reporting successful submission but waiting for %d "
 			 "discards before reporting error", i);
 		return 0;
 	}
@@ -2114,7 +2114,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 	/* usbfs limits the number of iso packets per URB */
 	num_urbs = (num_packets + (MAX_ISO_PACKETS_PER_URB - 1)) / MAX_ISO_PACKETS_PER_URB;
 
-	usbi_dbg("need %d urbs for new transfer with length %d", num_urbs, transfer->length);
+	usbi_dbg(TRANSFER_CTX(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
 
 	urbs = calloc(num_urbs, sizeof(*urbs));
 	if (!urbs)
@@ -2185,7 +2185,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		/* if the first URB submission fails, we can simply free up and
 		 * return failure immediately. */
 		if (i == 0) {
-			usbi_dbg("first URB failed, easy peasy");
+			usbi_dbg(TRANSFER_CTX(transfer), "first URB failed, easy peasy");
 			free_iso_urbs(tpriv);
 			return r;
 		}
@@ -2210,7 +2210,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		tpriv->num_retired = num_urbs - i;
 		discard_urbs(itransfer, 0, i);
 
-		usbi_dbg("reporting successful submission but waiting for %d "
+		usbi_dbg(TRANSFER_CTX(transfer), "reporting successful submission but waiting for %d "
 			 "discards before reporting error", i);
 		return 0;
 	}
@@ -2340,14 +2340,14 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	int urb_idx = urb - tpriv->urbs;
 
 	usbi_mutex_lock(&itransfer->lock);
-	usbi_dbg("handling completion status %d of bulk urb %d/%d", urb->status,
+	usbi_dbg(TRANSFER_CTX(transfer), "handling completion status %d of bulk urb %d/%d", urb->status,
 		 urb_idx + 1, tpriv->num_urbs);
 
 	tpriv->num_retired++;
 
 	if (tpriv->reap_action != NORMAL) {
 		/* cancelled, submit_fail, or completed early */
-		usbi_dbg("abnormal reap: urb status %d", urb->status);
+		usbi_dbg(TRANSFER_CTX(transfer), "abnormal reap: urb status %d", urb->status);
 
 		/* even though we're in the process of cancelling, it's possible that
 		 * we may receive some data in these URBs that we don't want to lose.
@@ -2368,9 +2368,9 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		if (urb->actual_length > 0) {
 			unsigned char *target = transfer->buffer + itransfer->transferred;
 
-			usbi_dbg("received %d bytes of surplus data", urb->actual_length);
+			usbi_dbg(TRANSFER_CTX(transfer), "received %d bytes of surplus data", urb->actual_length);
 			if (urb->buffer != target) {
-				usbi_dbg("moving surplus data from offset %zu to offset %zu",
+				usbi_dbg(TRANSFER_CTX(transfer), "moving surplus data from offset %zu to offset %zu",
 					 (unsigned char *)urb->buffer - transfer->buffer,
 					 target - transfer->buffer);
 				memmove(target, urb->buffer, urb->actual_length);
@@ -2379,7 +2379,7 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		}
 
 		if (tpriv->num_retired == tpriv->num_urbs) {
-			usbi_dbg("abnormal reap: last URB handled, reporting");
+			usbi_dbg(TRANSFER_CTX(transfer), "abnormal reap: last URB handled, reporting");
 			if (tpriv->reap_action != COMPLETED_EARLY &&
 			    tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 				tpriv->reap_status = LIBUSB_TRANSFER_ERROR;
@@ -2403,17 +2403,17 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		break;
 	case -ENODEV:
 	case -ESHUTDOWN:
-		usbi_dbg("device removed");
+		usbi_dbg(TRANSFER_CTX(transfer), "device removed");
 		tpriv->reap_status = LIBUSB_TRANSFER_NO_DEVICE;
 		goto cancel_remaining;
 	case -EPIPE:
-		usbi_dbg("detected endpoint stall");
+		usbi_dbg(TRANSFER_CTX(transfer), "detected endpoint stall");
 		if (tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 			tpriv->reap_status = LIBUSB_TRANSFER_STALL;
 		goto cancel_remaining;
 	case -EOVERFLOW:
 		/* overflow can only ever occur in the last urb */
-		usbi_dbg("overflow, actual_length=%d", urb->actual_length);
+		usbi_dbg(TRANSFER_CTX(transfer), "overflow, actual_length=%d", urb->actual_length);
 		if (tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 			tpriv->reap_status = LIBUSB_TRANSFER_OVERFLOW;
 		goto completed;
@@ -2422,7 +2422,7 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	case -EILSEQ:
 	case -ECOMM:
 	case -ENOSR:
-		usbi_dbg("low-level bus error %d", urb->status);
+		usbi_dbg(TRANSFER_CTX(transfer), "low-level bus error %d", urb->status);
 		tpriv->reap_action = ERROR;
 		goto cancel_remaining;
 	default:
@@ -2434,10 +2434,10 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	/* if we've reaped all urbs or we got less data than requested then we're
 	 * done */
 	if (tpriv->num_retired == tpriv->num_urbs) {
-		usbi_dbg("all URBs in transfer reaped --> complete!");
+		usbi_dbg(TRANSFER_CTX(transfer), "all URBs in transfer reaped --> complete!");
 		goto completed;
 	} else if (urb->actual_length < urb->buffer_length) {
-		usbi_dbg("short transfer %d/%d --> complete!",
+		usbi_dbg(TRANSFER_CTX(transfer), "short transfer %d/%d --> complete!",
 			 urb->actual_length, urb->buffer_length);
 		if (tpriv->reap_action == NORMAL)
 			tpriv->reap_action = COMPLETED_EARLY;
@@ -2493,7 +2493,7 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("handling completion status %d of iso urb %d/%d", urb->status,
+	usbi_dbg(TRANSFER_CTX(transfer), "handling completion status %d of iso urb %d/%d", urb->status,
 		 urb_idx, num_urbs);
 
 	/* copy isochronous results back in */
@@ -2512,15 +2512,15 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 			break;
 		case -ENODEV:
 		case -ESHUTDOWN:
-			usbi_dbg("packet %d - device removed", i);
+			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - device removed", i);
 			lib_desc->status = LIBUSB_TRANSFER_NO_DEVICE;
 			break;
 		case -EPIPE:
-			usbi_dbg("packet %d - detected endpoint stall", i);
+			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - detected endpoint stall", i);
 			lib_desc->status = LIBUSB_TRANSFER_STALL;
 			break;
 		case -EOVERFLOW:
-			usbi_dbg("packet %d - overflow error", i);
+			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - overflow error", i);
 			lib_desc->status = LIBUSB_TRANSFER_OVERFLOW;
 			break;
 		case -ETIME:
@@ -2529,7 +2529,7 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		case -ECOMM:
 		case -ENOSR:
 		case -EXDEV:
-			usbi_dbg("packet %d - low-level USB error %d", i, urb_desc->status);
+			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - low-level USB error %d", i, urb_desc->status);
 			lib_desc->status = LIBUSB_TRANSFER_ERROR;
 			break;
 		default:
@@ -2544,10 +2544,10 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 	tpriv->num_retired++;
 
 	if (tpriv->reap_action != NORMAL) { /* cancelled or submit_fail */
-		usbi_dbg("CANCEL: urb status %d", urb->status);
+		usbi_dbg(TRANSFER_CTX(transfer), "CANCEL: urb status %d", urb->status);
 
 		if (tpriv->num_retired == num_urbs) {
-			usbi_dbg("CANCEL: last URB handled, reporting");
+			usbi_dbg(TRANSFER_CTX(transfer), "CANCEL: last URB handled, reporting");
 			free_iso_urbs(tpriv);
 			if (tpriv->reap_action == CANCELLED) {
 				usbi_mutex_unlock(&itransfer->lock);
@@ -2567,7 +2567,7 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 	case -ECONNRESET:
 		break;
 	case -ESHUTDOWN:
-		usbi_dbg("device removed");
+		usbi_dbg(TRANSFER_CTX(transfer), "device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;
 	default:
@@ -2578,7 +2578,7 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 
 	/* if we've reaped all urbs then we're done */
 	if (tpriv->num_retired == num_urbs) {
-		usbi_dbg("all URBs in transfer reaped --> complete!");
+		usbi_dbg(TRANSFER_CTX(transfer), "all URBs in transfer reaped --> complete!");
 		free_iso_urbs(tpriv);
 		usbi_mutex_unlock(&itransfer->lock);
 		return usbi_handle_transfer_completion(itransfer, status);
@@ -2596,7 +2596,7 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 	int status;
 
 	usbi_mutex_lock(&itransfer->lock);
-	usbi_dbg("handling completion status %d", urb->status);
+	usbi_dbg(ITRANSFER_CTX(itransfer), "handling completion status %d", urb->status);
 
 	itransfer->transferred += urb->actual_length;
 
@@ -2619,15 +2619,15 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 		break;
 	case -ENODEV:
 	case -ESHUTDOWN:
-		usbi_dbg("device removed");
+		usbi_dbg(ITRANSFER_CTX(itransfer), "device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;
 	case -EPIPE:
-		usbi_dbg("unsupported control request");
+		usbi_dbg(ITRANSFER_CTX(itransfer), "unsupported control request");
 		status = LIBUSB_TRANSFER_STALL;
 		break;
 	case -EOVERFLOW:
-		usbi_dbg("overflow, actual_length=%d", urb->actual_length);
+		usbi_dbg(ITRANSFER_CTX(itransfer), "overflow, actual_length=%d", urb->actual_length);
 		status = LIBUSB_TRANSFER_OVERFLOW;
 		break;
 	case -ETIME:
@@ -2635,7 +2635,7 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 	case -EILSEQ:
 	case -ECOMM:
 	case -ENOSR:
-		usbi_dbg("low-level bus error %d", urb->status);
+		usbi_dbg(ITRANSFER_CTX(itransfer), "low-level bus error %d", urb->status);
 		status = LIBUSB_TRANSFER_ERROR;
 		break;
 	default:
@@ -2672,7 +2672,7 @@ static int reap_for_handle(struct libusb_device_handle *handle)
 	itransfer = urb->usercontext;
 	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
 
-	usbi_dbg("urb type=%u status=%d transferred=%d", urb->type, urb->status, urb->actual_length);
+	usbi_dbg(HANDLE_CTX(handle), "urb type=%u status=%d transferred=%d", urb->type, urb->status, urb->actual_length);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -129,7 +129,7 @@ obsd_get_device_list(struct libusb_context * ctx,
 	char *udevname;
 	int fd, addr, i, j;
 
-	usbi_dbg(" ");
+	usbi_dbg(ctx, " ");
 
 	for (i = 0; i < 8; i++) {
 		snprintf(busnode, sizeof(busnode), USBDEV "%d", i);
@@ -238,7 +238,7 @@ obsd_open(struct libusb_device_handle *handle)
 			return _errno_to_libusb(errno);
 		dpriv->fd = fd;
 
-		usbi_dbg("open %s: fd %d", devnode, dpriv->fd);
+		usbi_dbg(HANDLE_CTX(handle), "open %s: fd %d", devnode, dpriv->fd);
 	}
 
 	return (LIBUSB_SUCCESS);
@@ -250,7 +250,7 @@ obsd_close(struct libusb_device_handle *handle)
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 
 	if (dpriv->devname) {
-		usbi_dbg("close: fd %d", dpriv->fd);
+		usbi_dbg(HANDLE_CTX(handle), "close: fd %d", dpriv->fd);
 
 		close(dpriv->fd);
 		dpriv->fd = -1;
@@ -265,7 +265,7 @@ obsd_get_active_config_descriptor(struct libusb_device *dev,
 
 	len = MIN(len, (size_t)UGETW(dpriv->cdesc->wTotalLength));
 
-	usbi_dbg("len %zu", len);
+	usbi_dbg(DEVICE_CTX(dev), "len %zu", len);
 
 	memcpy(buf, dpriv->cdesc, len);
 
@@ -288,7 +288,7 @@ obsd_get_config_descriptor(struct libusb_device *dev, uint8_t idx,
 	udf.udf_size = len;
 	udf.udf_data = buf;
 
-	usbi_dbg("index %d, len %zu", udf.udf_config_index, len);
+	usbi_dbg(DEVICE_CTX(dev), "index %d, len %zu", udf.udf_config_index, len);
 
 	if (ioctl(fd, USB_DEVICE_GET_FDESC, &udf) < 0) {
 		err = errno;
@@ -307,7 +307,7 @@ obsd_get_configuration(struct libusb_device_handle *handle, uint8_t *config)
 
 	*config = dpriv->cdesc->bConfigurationValue;
 
-	usbi_dbg("bConfigurationValue %u", *config);
+	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %u", *config);
 
 	return (LIBUSB_SUCCESS);
 }
@@ -320,7 +320,7 @@ obsd_set_configuration(struct libusb_device_handle *handle, int config)
 	if (dpriv->devname == NULL)
 		return (LIBUSB_ERROR_NOT_SUPPORTED);
 
-	usbi_dbg("bConfigurationValue %d", config);
+	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %d", config);
 
 	if (ioctl(dpriv->fd, USB_SET_CONFIG, &config) < 0)
 		return _errno_to_libusb(errno);
@@ -367,7 +367,7 @@ obsd_set_interface_altsetting(struct libusb_device_handle *handle, uint8_t iface
 	if (dpriv->devname == NULL)
 		return (LIBUSB_ERROR_NOT_SUPPORTED);
 
-	usbi_dbg("iface %u, setting %u", iface, altsetting);
+	usbi_dbg(HANDLE_CTX(handle), "iface %u, setting %u", iface, altsetting);
 
 	memset(&intf, 0, sizeof(intf));
 
@@ -389,7 +389,7 @@ obsd_clear_halt(struct libusb_device_handle *handle, unsigned char endpoint)
 	if ((fd = _bus_open(handle->dev->bus_number)) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg(" ");
+	usbi_dbg(HANDLE_CTX(handle), " ");
 
 	req.ucr_addr = handle->dev->device_address;
 	req.ucr_request.bmRequestType = UT_WRITE_ENDPOINT;
@@ -413,7 +413,7 @@ obsd_destroy_device(struct libusb_device *dev)
 {
 	struct device_priv *dpriv = usbi_get_device_priv(dev);
 
-	usbi_dbg(" ");
+	usbi_dbg(DEVICE_CTX(dev), " ");
 
 	free(dpriv->cdesc);
 	free(dpriv->devname);
@@ -425,7 +425,7 @@ obsd_submit_transfer(struct usbi_transfer *itransfer)
 	struct libusb_transfer *transfer;
 	int err = 0;
 
-	usbi_dbg(" ");
+	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
 
 	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
 
@@ -468,7 +468,7 @@ obsd_cancel_transfer(struct usbi_transfer *itransfer)
 {
 	UNUSED(itransfer);
 
-	usbi_dbg(" ");
+	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
 
 	return (LIBUSB_ERROR_NOT_SUPPORTED);
 }
@@ -482,7 +482,7 @@ obsd_handle_transfer_completion(struct usbi_transfer *itransfer)
 int
 _errno_to_libusb(int err)
 {
-	usbi_dbg("error: %s (%d)", strerror(err), err);
+	usbi_dbg(NULL, "error: %s (%d)", strerror(err), err);
 
 	switch (err) {
 	case EIO:
@@ -512,7 +512,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 	if ((fd = _bus_open(dev->bus_number)) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg("fd %d, addr %d", fd, dev->device_address);
+	usbi_dbg(DEVICE_CTX(dev), "fd %d, addr %d", fd, dev->device_address);
 
 	udc.udc_bus = dev->bus_number;
 	udc.udc_addr = dev->device_address;
@@ -523,7 +523,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 		return _errno_to_libusb(errno);
 	}
 
-	usbi_dbg("active bLength %d", udc.udc_desc.bLength);
+	usbi_dbg(DEVICE_CTX(dev), "active bLength %d", udc.udc_desc.bLength);
 
 	len = UGETW(udc.udc_desc.wTotalLength);
 	buf = malloc((size_t)len);
@@ -536,7 +536,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 	udf.udf_size = len;
 	udf.udf_data = buf;
 
-	usbi_dbg("index %d, len %d", udf.udf_config_index, len);
+	usbi_dbg(DEVICE_CTX(dev), "index %d, len %d", udf.udf_config_index, len);
 
 	if (ioctl(fd, USB_DEVICE_GET_FDESC, &udf) < 0) {
 		err = errno;
@@ -565,7 +565,7 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 	setup = (struct libusb_control_setup *)transfer->buffer;
 
-	usbi_dbg("type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
+	usbi_dbg(ITRANSFER_CTX(itransfer), "type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
 	    setup->bmRequestType, setup->bRequest,
 	    libusb_le16_to_cpu(setup->wValue),
 	    libusb_le16_to_cpu(setup->wIndex),
@@ -610,7 +610,7 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 
 	itransfer->transferred = req.ucr_actlen;
 
-	usbi_dbg("transferred %d", itransfer->transferred);
+	usbi_dbg(ITRANSFER_CTX(itransfer), "transferred %d", itransfer->transferred);
 
 	return (0);
 }
@@ -630,7 +630,7 @@ _access_endpoint(struct libusb_transfer *transfer)
 	endpt = UE_GET_ADDR(transfer->endpoint);
 	mode = IS_XFERIN(transfer) ? O_RDONLY : O_WRONLY;
 
-	usbi_dbg("endpoint %d mode %d", endpt, mode);
+	usbi_dbg(TRANSFER_CTX(transfer), "endpoint %d mode %d", endpt, mode);
 
 	if (hpriv->endpoints[endpt] < 0) {
 		/* Pick the right endpoint node */

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -90,7 +90,7 @@ static int sunos_get_link(di_devlink_t devlink, void *arg)
 		char *content = (char *)di_devlink_content(devlink);
 		char *start = strstr(content, "/devices/");
 		start += strlen("/devices");
-		usbi_dbg("%s", start);
+		usbi_dbg(NULL, "%s", start);
 
 		/* line content must have minor node */
 		if (start == NULL ||
@@ -101,7 +101,7 @@ static int sunos_get_link(di_devlink_t devlink, void *arg)
 
 	p = di_devlink_path(devlink);
 	q = strrchr(p, '/');
-	usbi_dbg("%s", q);
+	usbi_dbg(NULL, "%s", q);
 
 	*(larg->linkpp) = strndup(p, strlen(p) - strlen(q));
 
@@ -118,7 +118,7 @@ static int sunos_physpath_to_devlink(
 	*link_path = NULL;
 	larg.linkpp = link_path;
 	if ((hdl = di_devlink_init(NULL, 0)) == NULL) {
-		usbi_dbg("di_devlink_init failure");
+		usbi_dbg(NULL, "di_devlink_init failure");
 		return (-1);
 	}
 
@@ -131,7 +131,7 @@ static int sunos_physpath_to_devlink(
 	(void) di_devlink_fini(&hdl);
 
 	if (*link_path == NULL) {
-		usbi_dbg("there is no devlink for this path");
+		usbi_dbg(NULL, "there is no devlink for this path");
 		return (-1);
 	}
 
@@ -167,13 +167,13 @@ sunos_usb_ioctl(struct libusb_device *dev, int cmd)
 		return (-1);
 	}
 	end++;
-	usbi_dbg("unitaddr: %s", end);
+	usbi_dbg(DEVICE_CTX(dev), "unitaddr: %s", end);
 
 	nvlist_alloc(&nvlist, NV_UNIQUE_NAME_TYPE, KM_NOSLEEP);
 	nvlist_add_int32(nvlist, "port", dev->port_number);
 	//find the hub path
 	snprintf(path_arg, sizeof(path_arg), "/devices%s:hubd", hubpath);
-	usbi_dbg("ioctl hub path: %s", path_arg);
+	usbi_dbg(DEVICE_CTX(dev), "ioctl hub path: %s", path_arg);
 
 	fd = open(path_arg, O_RDONLY);
 	if (fd < 0) {
@@ -193,15 +193,15 @@ sunos_usb_ioctl(struct libusb_device *dev, int cmd)
 	iocdata.c_nodename = (char *)"hub";
 	iocdata.c_unitaddr = end;
 	iocdata.cpyout_buf = &devctl_ap_state;
-	usbi_dbg("%p, %" PRIuPTR, iocdata.nvl_user, iocdata.nvl_usersz);
+	usbi_dbg(DEVICE_CTX(dev), "%p, %" PRIuPTR, iocdata.nvl_user, iocdata.nvl_usersz);
 
 	errno = 0;
 	if (ioctl(fd, DEVCTL_AP_GETSTATE, &iocdata) == -1) {
 		usbi_err(DEVICE_CTX(dev), "ioctl failed: fd %d, cmd %x, errno %d (%s)",
 			 fd, DEVCTL_AP_GETSTATE, errno, strerror(errno));
 	} else {
-		usbi_dbg("dev rstate: %d", devctl_ap_state.ap_rstate);
-		usbi_dbg("dev ostate: %d", devctl_ap_state.ap_ostate);
+		usbi_dbg(DEVICE_CTX(dev), "dev rstate: %d", devctl_ap_state.ap_rstate);
+		usbi_dbg(DEVICE_CTX(dev), "dev ostate: %d", devctl_ap_state.ap_ostate);
 	}
 
 	errno = 0;
@@ -227,7 +227,7 @@ sunos_kernel_driver_active(struct libusb_device_handle *dev_handle, uint8_t inte
 
 	UNUSED(interface);
 
-	usbi_dbg("%s", dpriv->ugenpath);
+	usbi_dbg(HANDLE_CTX(dev_handle), "%s", dpriv->ugenpath);
 
 	return (dpriv->ugenpath == NULL);
 }
@@ -236,7 +236,7 @@ sunos_kernel_driver_active(struct libusb_device_handle *dev_handle, uint8_t inte
  * Private functions
  */
 static int _errno_to_libusb(int);
-static int sunos_usb_get_status(int fd);
+static int sunos_usb_get_status(struct libusb_context *ctx, int fd);
 
 static string_list_t *
 sunos_new_string_list(void)
@@ -358,7 +358,7 @@ sunos_detach_kernel_driver(struct libusb_device_handle *dev_handle,
 
 	dpriv = usbi_get_device_priv(dev_handle->dev);
 	snprintf(path_arg, sizeof(path_arg), "\'\"%s\"\'", dpriv->phypath);
-	usbi_dbg("%s", path_arg);
+	usbi_dbg(HANDLE_CTX(dev_handle), "%s", path_arg);
 
 	list = sunos_new_string_list();
 	if (list == NULL)
@@ -418,7 +418,7 @@ sunos_attach_kernel_driver(struct libusb_device_handle *dev_handle,
 
 	dpriv = usbi_get_device_priv(dev_handle->dev);
 	snprintf(path_arg, sizeof(path_arg), "\'\"%s\"\'", dpriv->phypath);
-	usbi_dbg("%s", path_arg);
+	usbi_dbg(HANDLE_CTX(dev_handle), "%s", path_arg);
 
 	list = sunos_new_string_list();
 	if (list == NULL)
@@ -474,7 +474,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
 	    "usb-raw-cfg-descriptors", &rdata);
 	if (proplen <= 0) {
-		usbi_dbg("can't find raw config descriptors");
+		usbi_dbg(DEVICE_CTX(dev), "can't find raw config descriptors");
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -501,7 +501,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 		snprintf(match_str, sizeof(match_str), "^usb/%x.%x",
 		    dev->device_descriptor.idVendor,
 		    dev->device_descriptor.idProduct);
-		usbi_dbg("match is %s", match_str);
+		usbi_dbg(DEVICE_CTX(dev), "match is %s", match_str);
 		sunos_physpath_to_devlink(dpriv->phypath, match_str,  &dpriv->ugenpath);
 		di_devfs_path_free(phypath);
 
@@ -514,7 +514,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	/* address */
 	n = di_prop_lookup_ints(DDI_DEV_T_ANY, node, "assigned-address", &addr);
 	if (n != 1 || *addr == 0) {
-		usbi_dbg("can't get address");
+		usbi_dbg(DEVICE_CTX(dev), "can't get address");
 	} else {
 		dev->device_address = *addr;
 	}
@@ -530,7 +530,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 		dev->speed = LIBUSB_SPEED_SUPER;
 	}
 
-	usbi_dbg("vid=%x pid=%x, path=%s, bus_nmber=0x%x, port_number=%d, speed=%d",
+	usbi_dbg(DEVICE_CTX(dev), "vid=%x pid=%x, path=%s, bus_nmber=0x%x, port_number=%d, speed=%d",
 	    dev->device_descriptor.idVendor, dev->device_descriptor.idProduct,
 	    dpriv->phypath, dev->bus_number, dev->port_number, dev->speed);
 
@@ -571,7 +571,7 @@ sunos_add_devices(di_devlink_t link, void *arg)
 	dn = myself;
 	/* find the root hub */
 	while (di_prop_lookup_ints(DDI_DEV_T_ANY, dn, "root-hub", &j) != 0) {
-		usbi_dbg("find_root_hub:%s", di_devfs_path(dn));
+		usbi_dbg(NULL, "find_root_hub:%s", di_devfs_path(dn));
 		n = di_prop_lookup_ints(DDI_DEV_T_ANY, dn,
 				"assigned-address", &addr_prop);
 		session_id |= ((addr_prop[0] & 0xff) << i++ * 8);
@@ -586,13 +586,13 @@ sunos_add_devices(di_devlink_t link, void *arg)
 	session_id |= (bdf << i * 8);
 	bus_number = (PCI_REG_DEV_G(reg) << 3) | PCI_REG_FUNC_G(reg);
 
-	usbi_dbg("device bus address=%s:%x, name:%s",
+	usbi_dbg(NULL, "device bus address=%s:%x, name:%s",
 	    di_bus_addr(myself), bus_number, di_node_name(dn));
-	usbi_dbg("session id org:%" PRIx64, session_id);
+	usbi_dbg(NULL, "session id org:%" PRIx64, session_id);
 
 	/* dn is the usb device */
 	for (dn = di_child_node(myself); dn != DI_NODE_NIL; dn = di_sibling_node(dn)) {
-		usbi_dbg("device path:%s", di_devfs_path(dn));
+		usbi_dbg(NULL, "device path:%s", di_devfs_path(dn));
 		/* skip hub devices, because its driver can not been unload */
 		if (di_prop_lookup_ints(DDI_DEV_T_ANY, dn, "usb-port-count", &addr_prop) != -1)
 			continue;
@@ -600,18 +600,18 @@ sunos_add_devices(di_devlink_t link, void *arg)
 		n = di_prop_lookup_ints(DDI_DEV_T_ANY, dn,
 		    "assigned-address", &addr_prop);
 		if ((n != 1) || (addr_prop[0] == 0)) {
-			usbi_dbg("cannot get valid usb_addr");
+			usbi_dbg(NULL, "cannot get valid usb_addr");
 			continue;
 		}
 
 		sid = (session_id << 8) | (addr_prop[0] & 0xff) ;
-		usbi_dbg("session id %" PRIX64, sid);
+		usbi_dbg(NULL, "session id %" PRIX64, sid);
 
 		dev = usbi_get_device_by_session_id(nargs->ctx, sid);
 		if (dev == NULL) {
 			dev = usbi_alloc_device(nargs->ctx, sid);
 			if (dev == NULL) {
-				usbi_dbg("can't alloc device");
+				usbi_dbg(NULL, "can't alloc device");
 				continue;
 			}
 			devpriv = usbi_get_device_priv(dev);
@@ -619,21 +619,21 @@ sunos_add_devices(di_devlink_t link, void *arg)
 
 			if (sunos_fill_in_dev_info(dn, dev) != LIBUSB_SUCCESS) {
 				libusb_unref_device(dev);
-				usbi_dbg("get information fail");
+				usbi_dbg(NULL, "get information fail");
 				continue;
 			}
 			if (usbi_sanitize_device(dev) < 0) {
 				libusb_unref_device(dev);
-				usbi_dbg("sanatize failed: ");
+				usbi_dbg(NULL, "sanatize failed: ");
 				return (DI_WALK_TERMINATE);
 			}
 		} else {
 			devpriv = usbi_get_device_priv(dev);
-			usbi_dbg("Dev %s exists", devpriv->ugenpath);
+			usbi_dbg(NULL, "Dev %s exists", devpriv->ugenpath);
 		}
 
 		if (discovered_devs_append(*(nargs->discdevs), dev) == NULL) {
-			usbi_dbg("cannot append device");
+			usbi_dbg(NULL, "cannot append device");
 		}
 
 		/*
@@ -642,7 +642,7 @@ sunos_add_devices(di_devlink_t link, void *arg)
 		 */
 		libusb_unref_device(dev);
 
-		usbi_dbg("Device %s %s id=0x%" PRIx64 ", devcount:%" PRIuPTR
+		usbi_dbg(NULL, "Device %s %s id=0x%" PRIx64 ", devcount:%" PRIuPTR
 		    ", bdf=%" PRIx64,
 		    devpriv->ugenpath, di_devfs_path(dn), (uint64_t)sid,
 		    (*nargs->discdevs)->len, bdf);
@@ -690,13 +690,13 @@ sunos_get_device_list(struct libusb_context * ctx,
 	args.discdevs = discdevs;
 	args.last_ugenpath = NULL;
 	if ((root_node = di_init("/", DINFOCPYALL)) == DI_NODE_NIL) {
-		usbi_dbg("di_int() failed: errno %d (%s)", errno, strerror(errno));
+		usbi_dbg(ctx, "di_int() failed: errno %d (%s)", errno, strerror(errno));
 		return (LIBUSB_ERROR_IO);
 	}
 
 	if ((devlink_hdl = di_devlink_init(NULL, 0)) == NULL) {
 		di_fini(root_node);
-		usbi_dbg("di_devlink_init() failed: errno %d (%s)", errno, strerror(errno));
+		usbi_dbg(ctx, "di_devlink_init() failed: errno %d (%s)", errno, strerror(errno));
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -705,7 +705,7 @@ sunos_get_device_list(struct libusb_context * ctx,
 	/* walk each node to find USB devices */
 	if (di_walk_node(root_node, DI_WALK_SIBFIRST, &args,
 	    sunos_walk_minor_node_link) == -1) {
-		usbi_dbg("di_walk_node() failed: errno %d (%s)", errno, strerror(errno));
+		usbi_dbg(ctx, "di_walk_node() failed: errno %d (%s)", errno, strerror(errno));
 		di_fini(root_node);
 
 		return (LIBUSB_ERROR_IO);
@@ -714,7 +714,7 @@ sunos_get_device_list(struct libusb_context * ctx,
 	di_fini(root_node);
 	di_devlink_fini(&devlink_hdl);
 
-	usbi_dbg("%zu devices", (*discdevs)->len);
+	usbi_dbg(ctx, "%zu devices", (*discdevs)->len);
 
 	return ((*discdevs)->len);
 }
@@ -729,7 +729,7 @@ sunos_usb_open_ep0(sunos_dev_handle_priv_t *hpriv, sunos_dev_priv_t *dpriv)
 	}
 	snprintf(filename, PATH_MAX, "%s/cntrl0", dpriv->ugenpath);
 
-	usbi_dbg("opening %s", filename);
+	usbi_dbg(NULL, "opening %s", filename);
 	hpriv->eps[0].datafd = open(filename, O_RDWR);
 	if (hpriv->eps[0].datafd < 0) {
 		return(_errno_to_libusb(errno));
@@ -836,20 +836,20 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 	uint8_t	ep_index;
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg("open ep 0x%02x", ep_addr);
+	usbi_dbg(HANDLE_CTX(hdl), "open ep 0x%02x", ep_addr);
 	hpriv = usbi_get_device_handle_priv(hdl);
 	ep_index = sunos_usb_ep_index(ep_addr);
 	/* ep already opened */
 	if ((hpriv->eps[ep_index].datafd > 0) &&
 	    (hpriv->eps[ep_index].statfd > 0)) {
-		usbi_dbg("ep 0x%02x already opened, return success",
+		usbi_dbg(HANDLE_CTX(hdl), "ep 0x%02x already opened, return success",
 			ep_addr);
 
 		return (0);
 	}
 
 	if (sunos_find_interface(hdl, ep_addr, &ifc) < 0) {
-		usbi_dbg("can't find interface for endpoint 0x%02x",
+		usbi_dbg(HANDLE_CTX(hdl), "can't find interface for endpoint 0x%02x",
 		    ep_addr);
 
 		return (EACCES);
@@ -896,7 +896,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 	}
 	/* Open the xfer endpoint first */
 	if ((fd = open(filename, mode)) == -1) {
-		usbi_dbg("can't open %s: errno %d (%s)", filename, errno,
+		usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", filename, errno,
 		    strerror(errno));
 
 		return (errno);
@@ -917,7 +917,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 		/* Open the status endpoint with RDWR */
 		if ((fdstat = open(statfilename, O_RDWR)) == -1) {
-			usbi_dbg("can't open %s RDWR: errno %d (%s)",
+			usbi_dbg(HANDLE_CTX(hdl), "can't open %s RDWR: errno %d (%s)",
 				statfilename, errno, strerror(errno));
 
 			return (errno);
@@ -925,7 +925,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 			count = write(fdstat, &control, sizeof(control));
 			if (count != 1) {
 				/* this should have worked */
-				usbi_dbg("can't write to %s: errno %d (%s)",
+				usbi_dbg(HANDLE_CTX(hdl), "can't write to %s: errno %d (%s)",
 					statfilename, errno, strerror(errno));
 				(void) close(fdstat);
 
@@ -934,7 +934,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 		}
 	} else {
 		if ((fdstat = open(statfilename, O_RDONLY)) == -1) {
-			usbi_dbg("can't open %s: errno %d (%s)", statfilename, errno,
+			usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", statfilename, errno,
 				strerror(errno));
 
 			return (errno);
@@ -943,7 +943,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 	/* Re-open the xfer endpoint */
 	if ((fd = open(filename, mode)) == -1) {
-		usbi_dbg("can't open %s: errno %d (%s)", filename, errno,
+		usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", filename, errno,
 			strerror(errno));
 		(void) close(fdstat);
 
@@ -952,7 +952,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 	hpriv->eps[ep_index].datafd = fd;
 	hpriv->eps[ep_index].statfd = fdstat;
-	usbi_dbg("ep=0x%02x datafd=%d, statfd=%d", ep_addr, fd, fdstat);
+	usbi_dbg(HANDLE_CTX(hdl), "ep=0x%02x datafd=%d, statfd=%d", ep_addr, fd, fdstat);
 
 	return (0);
 }
@@ -981,7 +981,7 @@ sunos_open(struct libusb_device_handle *handle)
 	}
 
 	if ((ret = sunos_usb_open_ep0(hpriv, dpriv)) != LIBUSB_SUCCESS) {
-		usbi_dbg("fail: %d", ret);
+		usbi_dbg(HANDLE_CTX(handle), "fail: %d", ret);
 		return (ret);
 	}
 
@@ -993,7 +993,7 @@ sunos_close(struct libusb_device_handle *handle)
 {
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg(" ");
+	usbi_dbg(HANDLE_CTX(handle), " ");
 
 	hpriv = usbi_get_device_handle_priv(handle);
 
@@ -1016,14 +1016,14 @@ sunos_get_active_config_descriptor(struct libusb_device *dev,
 	 * has ever been changed through setCfg.
 	 */
 	if ((node = di_init(dpriv->phypath, DINFOCPYALL)) == DI_NODE_NIL) {
-		usbi_dbg("di_int() failed: errno %d (%s)", errno,
+		usbi_dbg(DEVICE_CTX(dev), "di_int() failed: errno %d (%s)", errno,
 			strerror(errno));
 		return (LIBUSB_ERROR_IO);
 	}
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
 	    "usb-raw-cfg-descriptors", &rdata);
 	if (proplen <= 0) {
-		usbi_dbg("can't find raw config descriptors");
+		usbi_dbg(DEVICE_CTX(dev), "can't find raw config descriptors");
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -1040,7 +1040,7 @@ sunos_get_active_config_descriptor(struct libusb_device *dev,
 	cfg = (struct libusb_config_descriptor *)dpriv->raw_cfgdescr;
 	len = MIN(len, libusb_le16_to_cpu(cfg->wTotalLength));
 	memcpy(buf, dpriv->raw_cfgdescr, len);
-	usbi_dbg("path:%s len %zu", dpriv->phypath, len);
+	usbi_dbg(DEVICE_CTX(dev), "path:%s len %zu", dpriv->phypath, len);
 
 	return (len);
 }
@@ -1061,7 +1061,7 @@ sunos_get_configuration(struct libusb_device_handle *handle, uint8_t *config)
 
 	*config = dpriv->cfgvalue;
 
-	usbi_dbg("bConfigurationValue %u", *config);
+	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %u", *config);
 
 	return (LIBUSB_SUCCESS);
 }
@@ -1072,7 +1072,7 @@ sunos_set_configuration(struct libusb_device_handle *handle, int config)
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(handle->dev);
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg("bConfigurationValue %d", config);
+	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %d", config);
 	hpriv = usbi_get_device_handle_priv(handle);
 
 	if (dpriv->ugenpath == NULL)
@@ -1092,7 +1092,7 @@ sunos_claim_interface(struct libusb_device_handle *handle, uint8_t iface)
 {
 	UNUSED(handle);
 
-	usbi_dbg("iface %u", iface);
+	usbi_dbg(HANDLE_CTX(handle), "iface %u", iface);
 
 	return (LIBUSB_SUCCESS);
 }
@@ -1102,7 +1102,7 @@ sunos_release_interface(struct libusb_device_handle *handle, uint8_t iface)
 {
 	sunos_dev_handle_priv_t *hpriv = usbi_get_device_handle_priv(handle);
 
-	usbi_dbg("iface %u", iface);
+	usbi_dbg(HANDLE_CTX(handle), "iface %u", iface);
 
 	/* XXX: can we release it? */
 	hpriv->altsetting[iface] = 0;
@@ -1117,7 +1117,7 @@ sunos_set_interface_altsetting(struct libusb_device_handle *handle, uint8_t ifac
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(handle->dev);
 	sunos_dev_handle_priv_t *hpriv = usbi_get_device_handle_priv(handle);
 
-	usbi_dbg("iface %u, setting %u", iface, altsetting);
+	usbi_dbg(HANDLE_CTX(handle), "iface %u, setting %u", iface, altsetting);
 
 	if (dpriv->ugenpath == NULL)
 		return (LIBUSB_ERROR_NOT_FOUND);
@@ -1169,7 +1169,7 @@ sunos_async_callback(union sigval arg)
 
 		ret = aio_error(aiocb);
 		if (ret != 0) {
-			xfer->status = sunos_usb_get_status(hpriv->eps[ep].statfd);
+			xfer->status = sunos_usb_get_status(TRANSFER_CTX(xfer), hpriv->eps[ep].statfd);
 		} else {
 			xfer->actual_length =
 			    LIBUSB_TRANSFER_TO_USBI_TRANSFER(xfer)->transferred =
@@ -1178,7 +1178,7 @@ sunos_async_callback(union sigval arg)
 
 		usb_dump_data(xfer->buffer, xfer->actual_length);
 
-		usbi_dbg("ret=%d, len=%d, actual_len=%d", ret, xfer->length,
+		usbi_dbg(TRANSFER_CTX(xfer), "ret=%d, len=%d, actual_len=%d", ret, xfer->length,
 		    xfer->actual_length);
 
 		/* async notification */
@@ -1195,7 +1195,7 @@ sunos_do_async_io(struct libusb_transfer *transfer)
 	uint8_t ep;
 	struct sunos_transfer_priv *tpriv;
 
-	usbi_dbg(" ");
+	usbi_dbg(TRANSFER_CTX(transfer), " ");
 
 	tpriv = usbi_get_transfer_priv(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
 	hpriv = usbi_get_device_handle_priv(transfer->dev_handle);
@@ -1225,12 +1225,12 @@ sunos_do_async_io(struct libusb_transfer *transfer)
 
 /* return the number of bytes read/written */
 static ssize_t
-usb_do_io(int fd, int stat_fd, void *data, size_t size, int flag, int *status)
+usb_do_io(struct libusb_context *ctx, int fd, int stat_fd, void *data, size_t size, int flag, int *status)
 {
 	int error;
 	ssize_t ret = -1;
 
-	usbi_dbg("usb_do_io(): datafd=%d statfd=%d size=0x%zx flag=%s",
+	usbi_dbg(ctx, "usb_do_io(): datafd=%d statfd=%d size=0x%zx flag=%s",
 	    fd, stat_fd, size, flag? "WRITE":"READ");
 
 	switch (flag) {
@@ -1246,17 +1246,17 @@ usb_do_io(int fd, int stat_fd, void *data, size_t size, int flag, int *status)
 		break;
 	}
 
-	usbi_dbg("usb_do_io(): amount=%zd", ret);
+	usbi_dbg(ctx, "usb_do_io(): amount=%zd", ret);
 
 	if (ret < 0) {
 		int save_errno = errno;
 
-		usbi_dbg("TID=%x io %s errno %d (%s)", pthread_self(),
+		usbi_dbg(ctx, "TID=%x io %s errno %d (%s)", pthread_self(),
 		    flag?"WRITE":"READ", errno, strerror(errno));
 
 		/* sunos_usb_get_status will do a read and overwrite errno */
-		error = sunos_usb_get_status(stat_fd);
-		usbi_dbg("io status=%d errno %d (%s)", error,
+		error = sunos_usb_get_status(ctx, stat_fd);
+		usbi_dbg(ctx, "io status=%d errno %d (%s)", error,
 			save_errno, strerror(save_errno));
 
 		if (status) {
@@ -1286,26 +1286,26 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
 	wLength = transfer->length - LIBUSB_CONTROL_SETUP_SIZE;
 
 	if (hpriv->eps[0].datafd == -1) {
-		usbi_dbg("ep0 not opened");
+		usbi_dbg(TRANSFER_CTX(transfer), "ep0 not opened");
 
 		return (LIBUSB_ERROR_NOT_FOUND);
 	}
 
 	if ((data[0] & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
-		usbi_dbg("IN request");
-		ret = usb_do_io(hpriv->eps[0].datafd,
+		usbi_dbg(TRANSFER_CTX(transfer), "IN request");
+		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd,
 		    hpriv->eps[0].statfd, data, LIBUSB_CONTROL_SETUP_SIZE,
 		    WRITE, &status);
 	} else {
-		usbi_dbg("OUT request");
-		ret = usb_do_io(hpriv->eps[0].datafd, hpriv->eps[0].statfd,
+		usbi_dbg(TRANSFER_CTX(transfer), "OUT request");
+		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd, hpriv->eps[0].statfd,
 		    transfer->buffer, transfer->length, WRITE,
 		    (int *)&transfer->status);
 	}
 
 	setup_ret = ret;
 	if (ret < (ssize_t)LIBUSB_CONTROL_SETUP_SIZE) {
-		usbi_dbg("error sending control msg: %zd", ret);
+		usbi_dbg(TRANSFER_CTX(transfer), "error sending control msg: %zd", ret);
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -1315,8 +1315,8 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
 	/* Read the remaining bytes for IN request */
 	if ((wLength) && ((data[0] & LIBUSB_ENDPOINT_DIR_MASK) ==
 	    LIBUSB_ENDPOINT_IN)) {
-		usbi_dbg("DATA: %d", transfer->length - (int)setup_ret);
-		ret = usb_do_io(hpriv->eps[0].datafd,
+		usbi_dbg(TRANSFER_CTX(transfer), "DATA: %d", transfer->length - (int)setup_ret);
+		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd,
 			hpriv->eps[0].statfd,
 			transfer->buffer + LIBUSB_CONTROL_SETUP_SIZE,
 			wLength, READ, (int *)&transfer->status);
@@ -1325,7 +1325,7 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
 	if (ret >= 0) {
 		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->transferred = ret;
 	}
-	usbi_dbg("Done: ctrl data bytes %zd", ret);
+	usbi_dbg(TRANSFER_CTX(transfer), "Done: ctrl data bytes %zd", ret);
 
 	/**
 	 * Sync transfer handling.
@@ -1345,13 +1345,13 @@ sunos_clear_halt(struct libusb_device_handle *handle, unsigned char endpoint)
 {
 	int ret;
 
-	usbi_dbg("endpoint=0x%02x", endpoint);
+	usbi_dbg(HANDLE_CTX(handle), "endpoint=0x%02x", endpoint);
 
 	ret = libusb_control_transfer(handle, LIBUSB_ENDPOINT_OUT |
 	    LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD,
 	    LIBUSB_REQUEST_CLEAR_FEATURE, 0, endpoint, NULL, 0, 1000);
 
-	usbi_dbg("ret=%d", ret);
+	usbi_dbg(HANDLE_CTX(handle), "ret=%d", ret);
 
 	return (ret);
 }
@@ -1361,7 +1361,7 @@ sunos_destroy_device(struct libusb_device *dev)
 {
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(dev);
 
-	usbi_dbg("destroy everything");
+	usbi_dbg(DEVICE_CTX(dev), "destroy everything");
 	free(dpriv->raw_cfgdescr);
 	free(dpriv->ugenpath);
 	free(dpriv->phypath);
@@ -1387,7 +1387,7 @@ sunos_submit_transfer(struct usbi_transfer *itransfer)
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		/* sync transfer */
-		usbi_dbg("CTRL transfer: %d", transfer->length);
+		usbi_dbg(ITRANSFER_CTX(itransfer), "CTRL transfer: %d", transfer->length);
 		err = solaris_submit_ctrl_on_default(transfer);
 		break;
 
@@ -1395,9 +1395,9 @@ sunos_submit_transfer(struct usbi_transfer *itransfer)
 		/* fallthru */
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
 		if (transfer->type == LIBUSB_TRANSFER_TYPE_BULK)
-			usbi_dbg("BULK transfer: %d", transfer->length);
+			usbi_dbg(ITRANSFER_CTX(itransfer), "BULK transfer: %d", transfer->length);
 		else
-			usbi_dbg("INTR transfer: %d", transfer->length);
+			usbi_dbg(ITRANSFER_CTX(itransfer), "INTR transfer: %d", transfer->length);
 		err = sunos_do_async_io(transfer);
 		break;
 
@@ -1407,9 +1407,9 @@ sunos_submit_transfer(struct usbi_transfer *itransfer)
 		/* fallthru */
 	case LIBUSB_TRANSFER_TYPE_BULK_STREAM:
 		if (transfer->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS)
-			usbi_dbg("ISOC transfer: %d", transfer->length);
+			usbi_dbg(ITRANSFER_CTX(itransfer), "ISOC transfer: %d", transfer->length);
 		else
-			usbi_dbg("BULK STREAM transfer: %d", transfer->length);
+			usbi_dbg(ITRANSFER_CTX(itransfer), "BULK STREAM transfer: %d", transfer->length);
 		err = LIBUSB_ERROR_NOT_SUPPORTED;
 		break;
 	}
@@ -1435,7 +1435,7 @@ sunos_cancel_transfer(struct usbi_transfer *itransfer)
 
 	ret = aio_cancel(hpriv->eps[ep].datafd, aiocb);
 
-	usbi_dbg("aio->fd=%d fd=%d ret = %d, %s", aiocb->aio_fildes,
+	usbi_dbg(ITRANSFER_CTX(itransfer), "aio->fd=%d fd=%d ret = %d, %s", aiocb->aio_fildes,
 	    hpriv->eps[ep].datafd, ret, (ret == AIO_CANCELED)?
 	    strerror(0):strerror(errno));
 
@@ -1461,7 +1461,7 @@ sunos_handle_transfer_completion(struct usbi_transfer *itransfer)
 int
 _errno_to_libusb(int err)
 {
-	usbi_dbg("error: %s (%d)", strerror(err), err);
+	usbi_dbg(NULL, "error: %s (%d)", strerror(err), err);
 
 	switch (err) {
 	case EIO:
@@ -1486,96 +1486,96 @@ _errno_to_libusb(int err)
  * Returns: ugen's last cmd status
  */
 static int
-sunos_usb_get_status(int fd)
+sunos_usb_get_status(struct libusb_context *ctx, int fd)
 {
 	int status;
 	ssize_t ret;
 
-	usbi_dbg("sunos_usb_get_status(): fd=%d", fd);
+	usbi_dbg(ctx, "sunos_usb_get_status(): fd=%d", fd);
 
 	ret = read(fd, &status, sizeof(status));
 	if (ret == sizeof(status)) {
 		switch (status) {
 		case USB_LC_STAT_NOERROR:
-			usbi_dbg("No Error");
+			usbi_dbg(ctx, "No Error");
 			break;
 		case USB_LC_STAT_CRC:
-			usbi_dbg("CRC Timeout Detected\n");
+			usbi_dbg(ctx, "CRC Timeout Detected\n");
 			break;
 		case USB_LC_STAT_BITSTUFFING:
-			usbi_dbg("Bit Stuffing Violation\n");
+			usbi_dbg(ctx, "Bit Stuffing Violation\n");
 			break;
 		case USB_LC_STAT_DATA_TOGGLE_MM:
-			usbi_dbg("Data Toggle Mismatch\n");
+			usbi_dbg(ctx, "Data Toggle Mismatch\n");
 			break;
 		case USB_LC_STAT_STALL:
-			usbi_dbg("End Point Stalled\n");
+			usbi_dbg(ctx, "End Point Stalled\n");
 			break;
 		case USB_LC_STAT_DEV_NOT_RESP:
-			usbi_dbg("Device is Not Responding\n");
+			usbi_dbg(ctx, "Device is Not Responding\n");
 			break;
 		case USB_LC_STAT_PID_CHECKFAILURE:
-			usbi_dbg("PID Check Failure\n");
+			usbi_dbg(ctx, "PID Check Failure\n");
 			break;
 		case USB_LC_STAT_UNEXP_PID:
-			usbi_dbg("Unexpected PID\n");
+			usbi_dbg(ctx, "Unexpected PID\n");
 			break;
 		case USB_LC_STAT_DATA_OVERRUN:
-			usbi_dbg("Data Exceeded Size\n");
+			usbi_dbg(ctx, "Data Exceeded Size\n");
 			break;
 		case USB_LC_STAT_DATA_UNDERRUN:
-			usbi_dbg("Less data received\n");
+			usbi_dbg(ctx, "Less data received\n");
 			break;
 		case USB_LC_STAT_BUFFER_OVERRUN:
-			usbi_dbg("Buffer Size Exceeded\n");
+			usbi_dbg(ctx, "Buffer Size Exceeded\n");
 			break;
 		case USB_LC_STAT_BUFFER_UNDERRUN:
-			usbi_dbg("Buffer Underrun\n");
+			usbi_dbg(ctx, "Buffer Underrun\n");
 			break;
 		case USB_LC_STAT_TIMEOUT:
-			usbi_dbg("Command Timed Out\n");
+			usbi_dbg(ctx, "Command Timed Out\n");
 			break;
 		case USB_LC_STAT_NOT_ACCESSED:
-			usbi_dbg("Not Accessed by h/w\n");
+			usbi_dbg(ctx, "Not Accessed by h/w\n");
 			break;
 		case USB_LC_STAT_UNSPECIFIED_ERR:
-			usbi_dbg("Unspecified Error\n");
+			usbi_dbg(ctx, "Unspecified Error\n");
 			break;
 		case USB_LC_STAT_NO_BANDWIDTH:
-			usbi_dbg("No Bandwidth\n");
+			usbi_dbg(ctx, "No Bandwidth\n");
 			break;
 		case USB_LC_STAT_HW_ERR:
-			usbi_dbg("Host Controller h/w Error\n");
+			usbi_dbg(ctx, "Host Controller h/w Error\n");
 			break;
 		case USB_LC_STAT_SUSPENDED:
-			usbi_dbg("Device was Suspended\n");
+			usbi_dbg(ctx, "Device was Suspended\n");
 			break;
 		case USB_LC_STAT_DISCONNECTED:
-			usbi_dbg("Device was Disconnected\n");
+			usbi_dbg(ctx, "Device was Disconnected\n");
 			break;
 		case USB_LC_STAT_INTR_BUF_FULL:
-			usbi_dbg("Interrupt buffer was full\n");
+			usbi_dbg(ctx, "Interrupt buffer was full\n");
 			break;
 		case USB_LC_STAT_INVALID_REQ:
-			usbi_dbg("Request was Invalid\n");
+			usbi_dbg(ctx, "Request was Invalid\n");
 			break;
 		case USB_LC_STAT_INTERRUPTED:
-			usbi_dbg("Request was Interrupted\n");
+			usbi_dbg(ctx, "Request was Interrupted\n");
 			break;
 		case USB_LC_STAT_NO_RESOURCES:
-			usbi_dbg("No resources available for "
+			usbi_dbg(ctx, "No resources available for "
 			    "request\n");
 			break;
 		case USB_LC_STAT_INTR_POLLING_FAILED:
-			usbi_dbg("Failed to Restart Poll");
+			usbi_dbg(ctx, "Failed to Restart Poll");
 			break;
 		default:
-			usbi_dbg("Error Not Determined %d\n",
+			usbi_dbg(ctx, "Error Not Determined %d\n",
 			    status);
 			break;
 		}
 	} else {
-		usbi_dbg("read stat error: %s",strerror(errno));
+		usbi_dbg(ctx, "read stat error: %s",strerror(errno));
 		status = -1;
 	}
 

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -152,7 +152,7 @@ static bool htab_create(struct libusb_context *ctx)
 	// Create a mutex
 	usbi_mutex_init(&htab_mutex);
 
-	usbi_dbg("using %lu entries hash table", HTAB_SIZE);
+	usbi_dbg(ctx, "using %lu entries hash table", HTAB_SIZE);
 	htab_filled = 0;
 
 	// allocate memory and zero out.
@@ -221,7 +221,7 @@ unsigned long htab_hash(const char *str)
 		if ((htab_table[idx].used == hval) && (strcmp(str, htab_table[idx].str) == 0))
 			goto out_unlock; // existing hash
 
-		usbi_dbg("hash collision ('%s' vs '%s')", str, htab_table[idx].str);
+		usbi_dbg(NULL, "hash collision ('%s' vs '%s')", str, htab_table[idx].str);
 
 		// Second hash function, as suggested in [Knuth]
 		hval2 = 1UL + hval % (HTAB_SIZE - 2);
@@ -283,7 +283,7 @@ enum libusb_transfer_status usbd_status_to_libusb_transfer_status(USBD_STATUS st
 	case USBD_STATUS_DEVICE_GONE:
 		return LIBUSB_TRANSFER_NO_DEVICE;
 	default:
-		usbi_dbg("USBD_STATUS 0x%08lx translated to LIBUSB_TRANSFER_ERROR", ULONG_CAST(status));
+		usbi_dbg(NULL, "USBD_STATUS 0x%08lx translated to LIBUSB_TRANSFER_ERROR", ULONG_CAST(status));
 		return LIBUSB_TRANSFER_ERROR;
 	}
 }
@@ -298,7 +298,7 @@ void windows_force_sync_completion(struct usbi_transfer *itransfer, ULONG size)
 	struct windows_transfer_priv *transfer_priv = usbi_get_transfer_priv(itransfer);
 	OVERLAPPED *overlapped = &transfer_priv->overlapped;
 
-	usbi_dbg("transfer %p, length %lu", transfer, ULONG_CAST(size));
+	usbi_dbg(TRANSFER_CTX(transfer), "transfer %p, length %lu", transfer, ULONG_CAST(size));
 
 	overlapped->Internal = (ULONG_PTR)STATUS_SUCCESS;
 	overlapped->InternalHigh = (ULONG_PTR)size;
@@ -401,11 +401,11 @@ static enum windows_version get_windows_version(void)
 	arch = is_x64() ? "64-bit" : "32-bit";
 
 	if (vi.wServicePackMinor)
-		usbi_dbg("Windows %s SP%u.%u %s", w, vi.wServicePackMajor, vi.wServicePackMinor, arch);
+		usbi_dbg(NULL, "Windows %s SP%u.%u %s", w, vi.wServicePackMajor, vi.wServicePackMinor, arch);
 	else if (vi.wServicePackMajor)
-		usbi_dbg("Windows %s SP%u %s", w, vi.wServicePackMajor, arch);
+		usbi_dbg(NULL, "Windows %s SP%u %s", w, vi.wServicePackMajor, arch);
 	else
-		usbi_dbg("Windows %s %s", w, arch);
+		usbi_dbg(NULL, "Windows %s %s", w, arch);
 
 	return winver;
 }
@@ -425,7 +425,7 @@ static unsigned __stdcall windows_iocp_thread(void *arg)
 	struct usbi_transfer *itransfer;
 	bool found;
 
-	usbi_dbg("I/O completion thread started");
+	usbi_dbg(ctx, "I/O completion thread started");
 
 	while (true) {
 		overlapped = NULL;
@@ -471,18 +471,18 @@ static unsigned __stdcall windows_iocp_thread(void *arg)
 		usbi_mutex_unlock(&ctx->open_devs_lock);
 
 		if (!found) {
-			usbi_dbg("ignoring overlapped %p for handle %p (device %u.%u)",
+			usbi_dbg(ctx, "ignoring overlapped %p for handle %p (device %u.%u)",
 				overlapped, dev_handle, dev_handle->dev->bus_number, dev_handle->dev->device_address);
 			continue;
 		}
 
 		itransfer = (struct usbi_transfer *)((unsigned char *)transfer_priv + PTR_ALIGN(sizeof(*transfer_priv)));
-		usbi_dbg("transfer %p completed, length %lu",
+		usbi_dbg(ctx, "transfer %p completed, length %lu",
 			 USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer), ULONG_CAST(num_bytes));
 		usbi_signal_transfer_completion(itransfer);
 	}
 
-	usbi_dbg("I/O completion thread exiting");
+	usbi_dbg(ctx, "I/O completion thread exiting");
 
 	return 0;
 }
@@ -519,7 +519,7 @@ static int windows_init(struct libusb_context *ctx)
 
 		r = usbdk_backend.init(ctx);
 		if (r == LIBUSB_SUCCESS) {
-			usbi_dbg("UsbDk backend is available");
+			usbi_dbg(ctx, "UsbDk backend is available");
 			usbdk_available = true;
 		} else {
 			usbi_info(ctx, "UsbDk backend is not available");
@@ -600,7 +600,7 @@ static int windows_set_option(struct libusb_context *ctx, enum libusb_option opt
 			usbi_err(ctx, "UsbDk backend not available");
 			return LIBUSB_ERROR_NOT_FOUND;
 		}
-		usbi_dbg("switching context %p to use UsbDk backend", ctx);
+		usbi_dbg(ctx, "switching context %p to use UsbDk backend", ctx);
 		priv->backend = &usbdk_backend;
 		return LIBUSB_SUCCESS;
 	}
@@ -790,7 +790,7 @@ static int windows_handle_transfer_completion(struct usbi_transfer *itransfer)
 	else
 		result = GetLastError();
 
-	usbi_dbg("handling transfer %p completion with errcode %lu, length %lu",
+	usbi_dbg(ctx, "handling transfer %p completion with errcode %lu, length %lu",
 		 USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer), ULONG_CAST(result), ULONG_CAST(bytes_transferred));
 
 	switch (result) {
@@ -798,25 +798,25 @@ static int windows_handle_transfer_completion(struct usbi_transfer *itransfer)
 		status = backend->copy_transfer_data(itransfer, bytes_transferred);
 		break;
 	case ERROR_GEN_FAILURE:
-		usbi_dbg("detected endpoint stall");
+		usbi_dbg(ctx, "detected endpoint stall");
 		status = LIBUSB_TRANSFER_STALL;
 		break;
 	case ERROR_SEM_TIMEOUT:
-		usbi_dbg("detected semaphore timeout");
+		usbi_dbg(ctx, "detected semaphore timeout");
 		status = LIBUSB_TRANSFER_TIMED_OUT;
 		break;
 	case ERROR_OPERATION_ABORTED:
 		istatus = backend->copy_transfer_data(itransfer, bytes_transferred);
 		if (istatus != LIBUSB_TRANSFER_COMPLETED)
-			usbi_dbg("failed to copy partial data in aborted operation: %d", (int)istatus);
+			usbi_dbg(ctx, "failed to copy partial data in aborted operation: %d", (int)istatus);
 
-		usbi_dbg("detected operation aborted");
+		usbi_dbg(ctx, "detected operation aborted");
 		status = LIBUSB_TRANSFER_CANCELLED;
 		break;
 	case ERROR_FILE_NOT_FOUND:
 	case ERROR_DEVICE_NOT_CONNECTED:
 	case ERROR_NO_SUCH_DEVICE:
-		usbi_dbg("detected device removed");
+		usbi_dbg(ctx, "detected device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;
 	default:

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -416,7 +416,7 @@ static int get_interface_details_filter(struct libusb_context *ctx, HDEVINFO *de
 				// libusb0.sys is connected to this device instance.
 				// If the the device interface guid is {F9F3FF14-AE21-48A0-8A25-8011A7A931D9} then it's a filter.
 				sprintf(filter_path, "\\\\.\\libusb0-%04u", (unsigned int)libusb0_symboliclink_index);
-				usbi_dbg("assigned libusb0 symbolic link %s", filter_path);
+				usbi_dbg(ctx, "assigned libusb0 symbolic link %s", filter_path);
 			} else {
 				// libusb0.sys was connected to this device instance at one time; but not anymore.
 			}
@@ -474,14 +474,14 @@ static int get_interface_by_endpoint(struct libusb_config_descriptor *conf_desc,
 			intf_desc = &intf->altsetting[j];
 			for (k = 0; k < intf_desc->bNumEndpoints; k++) {
 				if (intf_desc->endpoint[k].bEndpointAddress == ep) {
-					usbi_dbg("found endpoint %02X on interface %d", intf_desc->bInterfaceNumber, i);
+					usbi_dbg(NULL, "found endpoint %02X on interface %d", intf_desc->bInterfaceNumber, i);
 					return intf_desc->bInterfaceNumber;
 				}
 			}
 		}
 	}
 
-	usbi_dbg("endpoint %02X not found on any interface", ep);
+	usbi_dbg(NULL, "endpoint %02X not found on any interface", ep);
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
@@ -527,7 +527,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 	safe_free(priv->usb_interface[iface].endpoint);
 
 	if (if_desc->bNumEndpoints == 0) {
-		usbi_dbg("no endpoints found for interface %u", iface);
+		usbi_dbg(HANDLE_CTX(dev_handle), "no endpoints found for interface %u", iface);
 		libusb_free_config_descriptor(conf_desc);
 		priv->usb_interface[iface].current_altsetting = altsetting;
 		return LIBUSB_SUCCESS;
@@ -542,7 +542,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 	priv->usb_interface[iface].nb_endpoints = if_desc->bNumEndpoints;
 	for (i = 0; i < if_desc->bNumEndpoints; i++) {
 		priv->usb_interface[iface].endpoint[i] = if_desc->endpoint[i].bEndpointAddress;
-		usbi_dbg("(re)assigned endpoint %02X to interface %u", priv->usb_interface[iface].endpoint[i], iface);
+		usbi_dbg(HANDLE_CTX(dev_handle), "(re)assigned endpoint %02X to interface %u", priv->usb_interface[iface].endpoint[i], iface);
 	}
 	libusb_free_config_descriptor(conf_desc);
 
@@ -612,7 +612,7 @@ static int auto_claim(struct libusb_transfer *transfer, int *interface_number, i
 			// Must claim an interface of the same API type
 			if ((priv->usb_interface[current_interface].apib->id == api_type)
 					&& (libusb_claim_interface(transfer->dev_handle, current_interface) == LIBUSB_SUCCESS)) {
-				usbi_dbg("auto-claimed interface %d for control request", current_interface);
+				usbi_dbg(TRANSFER_CTX(transfer), "auto-claimed interface %d for control request", current_interface);
 				if (handle_priv->autoclaim_count[current_interface] != 0)
 					usbi_err(TRANSFER_CTX(transfer), "program assertion failed - autoclaim_count was nonzero");
 				handle_priv->autoclaim_count[current_interface]++;
@@ -649,9 +649,9 @@ static void auto_release(struct usbi_transfer *itransfer)
 		if (handle_priv->autoclaim_count[transfer_priv->interface_number] == 0) {
 			r = libusb_release_interface(dev_handle, transfer_priv->interface_number);
 			if (r == LIBUSB_SUCCESS)
-				usbi_dbg("auto-released interface %d", transfer_priv->interface_number);
+				usbi_dbg(ITRANSFER_CTX(itransfer), "auto-released interface %d", transfer_priv->interface_number);
 			else
-				usbi_dbg("failed to auto-release interface %d (%s)",
+				usbi_dbg(ITRANSFER_CTX(itransfer), "failed to auto-release interface %d (%s)",
 					transfer_priv->interface_number, libusb_error_name((enum libusb_error)r));
 		}
 	}
@@ -792,7 +792,7 @@ static void cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handl
 			continue;
 		}
 
-		usbi_dbg("cached config descriptor %u (bConfigurationValue=%u, %u bytes)",
+		usbi_dbg(ctx, "cached config descriptor %u (bConfigurationValue=%u, %u bytes)",
 			i, cd_data->bConfigurationValue, cd_data->wTotalLength);
 
 		// Cache the descriptor
@@ -909,7 +909,7 @@ static int init_root_hub(struct libusb_device *dev)
 	}
 
 	num_ports = hub_info.u.HubInformation.HubDescriptor.bNumberOfPorts;
-	usbi_dbg("root hub '%s' reports %lu ports", priv->dev_id, ULONG_CAST(num_ports));
+	usbi_dbg(ctx, "root hub '%s' reports %lu ports", priv->dev_id, ULONG_CAST(num_ports));
 
 	if (windows_version >= WINDOWS_8) {
 		// Windows 8 and later is better at reporting the speed capabilities of the root hub,
@@ -1044,7 +1044,7 @@ make_descriptors:
 static int init_device(struct libusb_device *dev, struct libusb_device *parent_dev,
 	uint8_t port_number, DEVINST devinst)
 {
-	struct libusb_context *ctx;
+	struct libusb_context *ctx = NULL;
 	struct libusb_device *tmp_dev;
 	struct winusb_device_priv *priv, *parent_priv, *tmp_priv;
 	USB_NODE_CONNECTION_INFORMATION_EX conn_info;
@@ -1143,7 +1143,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 
 			priv->active_config = conn_info.CurrentConfigurationValue;
 			if (priv->active_config == 0) {
-				usbi_dbg("0x%x:0x%x found %u configurations (not configured)",
+				usbi_dbg(ctx, "0x%x:0x%x found %u configurations (not configured)",
 					dev->device_descriptor.idVendor,
 					dev->device_descriptor.idProduct,
 					dev->device_descriptor.bNumConfigurations);
@@ -1166,7 +1166,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 				dev->device_descriptor.bNumConfigurations);
 			priv->active_config = 1;
 		} else {
-			usbi_dbg("found %u configurations (current config: %u)", dev->device_descriptor.bNumConfigurations, priv->active_config);
+			usbi_dbg(ctx, "found %u configurations (current config: %u)", dev->device_descriptor.bNumConfigurations, priv->active_config);
 		}
 
 		// Cache as many config descriptors as we can
@@ -1217,7 +1217,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 
 	priv->initialized = true;
 
-	usbi_dbg("(bus: %u, addr: %u, depth: %u, port: %u): '%s'",
+	usbi_dbg(ctx, "(bus: %u, addr: %u, depth: %u, port: %u): '%s'",
 		dev->bus_number, dev->device_address, priv->depth, dev->port_number, priv->dev_id);
 
 	return LIBUSB_SUCCESS;
@@ -1286,7 +1286,7 @@ static int enumerate_hcd_root_hub(struct libusb_context *ctx, const char *dev_id
 
 	if (dev->bus_number == 0) {
 		// Only do this once
-		usbi_dbg("assigning HCD '%s' bus number %u", dev_id, bus_number);
+		usbi_dbg(ctx, "assigning HCD '%s' bus number %u", dev_id, bus_number);
 		dev->bus_number = bus_number;
 
 		if (sscanf(dev_id, "PCI\\VEN_%04hx&DEV_%04hx%*s", &dev->device_descriptor.idVendor, &dev->device_descriptor.idProduct) != 2)
@@ -1330,10 +1330,10 @@ static void get_api_type(HDEVINFO *dev_info, SP_DEVINFO_DATA *dev_info_data,
 				if (lookup[k].list[l] == 0)
 					lookup[k].list[l] = LIST_SEPARATOR;
 			}
-			usbi_dbg("%s(s): %s", lookup[k].designation, lookup[k].list);
+			usbi_dbg(NULL, "%s(s): %s", lookup[k].designation, lookup[k].list);
 		} else {
 			if (GetLastError() != ERROR_INVALID_DATA)
-				usbi_dbg("could not access %s: %s", lookup[k].designation, windows_error_str(0));
+				usbi_dbg(NULL, "could not access %s: %s", lookup[k].designation, windows_error_str(0));
 			lookup[k].list[0] = 0;
 		}
 	}
@@ -1342,7 +1342,7 @@ static void get_api_type(HDEVINFO *dev_info, SP_DEVINFO_DATA *dev_info_data,
 		for (k = 0; k < 3; k++) {
 			j = get_sub_api(lookup[k].list, i);
 			if (j >= 0) {
-				usbi_dbg("matched %s name against %s", lookup[k].designation,
+				usbi_dbg(NULL, "matched %s name against %s", lookup[k].designation,
 					(i != USB_API_WINUSBX) ? usb_api_backend[i].designation : usb_api_backend[i].driver_name_list[j]);
 				*api = i;
 				*sub_api = j;
@@ -1378,7 +1378,7 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	if (priv->usb_interface[interface_number].path != NULL) {
 		if (api == USB_API_HID) {
 			// HID devices can have multiple collections (COL##) for each MI_## interface
-			usbi_dbg("interface[%d] already set - ignoring HID collection: %s",
+			usbi_dbg(ctx, "interface[%d] already set - ignoring HID collection: %s",
 				interface_number, device_id);
 			return LIBUSB_ERROR_ACCESS;
 		}
@@ -1386,7 +1386,7 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 		safe_free(priv->usb_interface[interface_number].path);
 	}
 
-	usbi_dbg("interface[%d] = %s", interface_number, dev_interface_path);
+	usbi_dbg(ctx, "interface[%d] = %s", interface_number, dev_interface_path);
 	priv->usb_interface[interface_number].path = dev_interface_path;
 	priv->usb_interface[interface_number].apib = &usb_api_backend[api];
 	priv->usb_interface[interface_number].sub_api = sub_api;
@@ -1415,14 +1415,14 @@ static int set_hid_interface(struct libusb_context *ctx, struct libusb_device *d
 
 	for (i = 0; i < priv->hid->nb_interfaces; i++) {
 		if ((priv->usb_interface[i].path != NULL) && strcmp(priv->usb_interface[i].path, dev_interface_path) == 0) {
-			usbi_dbg("interface[%u] already set to %s", i, dev_interface_path);
+			usbi_dbg(ctx, "interface[%u] already set to %s", i, dev_interface_path);
 			return LIBUSB_ERROR_ACCESS;
 		}
 	}
 
 	priv->usb_interface[priv->hid->nb_interfaces].path = dev_interface_path;
 	priv->usb_interface[priv->hid->nb_interfaces].apib = &usb_api_backend[USB_API_HID];
-	usbi_dbg("interface[%u] = %s", priv->hid->nb_interfaces, dev_interface_path);
+	usbi_dbg(ctx, "interface[%u] = %s", priv->hid->nb_interfaces, dev_interface_path);
 	priv->hid->nb_interfaces++;
 	return LIBUSB_SUCCESS;
 }
@@ -1518,7 +1518,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 //#define ENUM_DEBUG
 #if defined(ENABLE_LOGGING) && defined(ENUM_DEBUG)
 		const char * const passname[] = {"HUB", "DEV", "HCD", "GEN", "HID", "EXT"};
-		usbi_dbg("#### PROCESSING %ss %s", passname[MIN(pass, EXT_PASS)], guid_to_string(guid_list[pass], guid_string));
+		usbi_dbg(ctx, "#### PROCESSING %ss %s", passname[MIN(pass, EXT_PASS)], guid_to_string(guid_list[pass], guid_string));
 #endif
 		if ((pass == HID_PASS) && (guid_list[HID_PASS] == NULL))
 			continue;
@@ -1570,7 +1570,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 			}
 
 #ifdef ENUM_DEBUG
-			usbi_dbg("PRO: %s", dev_id);
+			usbi_dbg(ctx, "PRO: %s", dev_id);
 #endif
 
 			// Set API to use or get additional data from generic pass
@@ -1593,7 +1593,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						break;
 				}
 				if (j == nb_usb_enumerators) {
-					usbi_dbg("found new PnP enumerator string '%s'", enumerator);
+					usbi_dbg(ctx, "found new PnP enumerator string '%s'", enumerator);
 					if (nb_usb_enumerators < ARRAYSIZE(usb_enumerator)) {
 						usb_enumerator[nb_usb_enumerators] = _strdup(enumerator);
 						if (usb_enumerator[nb_usb_enumerators] != NULL) {
@@ -1661,7 +1661,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 								break;
 						}
 						if (j == nb_guids) {
-							usbi_dbg("extra GUID: %s", guid_string);
+							usbi_dbg(ctx, "extra GUID: %s", guid_string);
 							guid_list[nb_guids++] = if_guid;
 						} else {
 							// Duplicate, ignore
@@ -1703,7 +1703,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						libusb_unref_device(dev);
 					}
 
-					usbi_dbg("unlisted ancestor for '%s' (non USB HID, newly connected, etc.) - ignoring", dev_id);
+					usbi_dbg(ctx, "unlisted ancestor for '%s' (non USB HID, newly connected, etc.) - ignoring", dev_id);
 					continue;
 				}
 
@@ -1722,7 +1722,7 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 				dev = usbi_get_device_by_session_id(ctx, session_id);
 				if (dev == NULL) {
 				alloc_device:
-					usbi_dbg("allocating new device for session [%lX]", session_id);
+					usbi_dbg(ctx, "allocating new device for session [%lX]", session_id);
 					dev = usbi_alloc_device(ctx, session_id);
 					if (dev == NULL)
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
@@ -1735,17 +1735,17 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
 					}
 				} else {
-					usbi_dbg("found existing device for session [%lX]", session_id);
+					usbi_dbg(ctx, "found existing device for session [%lX]", session_id);
 
 					priv = usbi_get_device_priv(dev);
 					if (strcmp(priv->dev_id, dev_id) != 0) {
-						usbi_dbg("device instance ID for session [%lX] changed", session_id);
+						usbi_dbg(ctx, "device instance ID for session [%lX] changed", session_id);
 						usbi_disconnect_device(dev);
 						libusb_unref_device(dev);
 						goto alloc_device;
 					}
 					if (!IsEqualGUID(&priv->class_guid, &dev_info_data.ClassGuid)) {
-						usbi_dbg("device class GUID for session [%lX] changed", session_id);
+						usbi_dbg(ctx, "device class GUID for session [%lX] changed", session_id);
 						usbi_disconnect_device(dev);
 						libusb_unref_device(dev);
 						goto alloc_device;
@@ -1824,10 +1824,10 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 			default: // HID_PASS and later
 				if (parent_priv->apib->id == USB_API_HID || parent_priv->apib->id == USB_API_COMPOSITE) {
 					if (parent_priv->apib->id == USB_API_HID) {
-						usbi_dbg("setting HID interface for [%lX]:", parent_dev->session_data);
+						usbi_dbg(ctx, "setting HID interface for [%lX]:", parent_dev->session_data);
 						r = set_hid_interface(ctx, parent_dev, dev_interface_path);
 					} else {
-						usbi_dbg("setting composite interface for [%lX]:", parent_dev->session_data);
+						usbi_dbg(ctx, "setting composite interface for [%lX]:", parent_dev->session_data);
 						r = set_composite_interface(ctx, parent_dev, dev_interface_path, dev_id, api, sub_api);
 					}
 					switch (r) {
@@ -2338,10 +2338,10 @@ cleanup_winusb:
 			KLIB_VERSION LibK_Version;
 
 			pLibK_GetVersion(&LibK_Version);
-			usbi_dbg("libusbK DLL found, version: %d.%d.%d.%d", LibK_Version.Major, LibK_Version.Minor,
+			usbi_dbg(ctx, "libusbK DLL found, version: %d.%d.%d.%d", LibK_Version.Major, LibK_Version.Minor,
 				LibK_Version.Micro, LibK_Version.Nano);
 		} else {
-			usbi_dbg("libusbK DLL found, version unknown");
+			usbi_dbg(ctx, "libusbK DLL found, version unknown");
 		}
 
 		pLibK_GetProcAddress = (LibK_GetProcAddress_t)GetProcAddress(hlibusbK, "LibK_GetProcAddress");
@@ -2520,7 +2520,7 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		endpoint_address = (i == -1) ? 0 : priv->usb_interface[iface].endpoint[i];
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			PIPE_TRANSFER_TIMEOUT, sizeof(ULONG), &timeout))
-			usbi_dbg("failed to set PIPE_TRANSFER_TIMEOUT for control endpoint %02X", endpoint_address);
+			usbi_dbg(HANDLE_CTX(dev_handle), "failed to set PIPE_TRANSFER_TIMEOUT for control endpoint %02X", endpoint_address);
 
 		if ((i == -1) || (sub_api == SUB_API_LIBUSB0))
 			continue; // Other policies don't apply to control endpoint or libusb0
@@ -2529,27 +2529,27 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		handle_priv->interface_handle[iface].zlp[endpoint_address] = WINUSB_ZLP_UNSET;
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			SHORT_PACKET_TERMINATE, sizeof(UCHAR), &policy))
-			usbi_dbg("failed to disable SHORT_PACKET_TERMINATE for endpoint %02X", endpoint_address);
+			usbi_dbg(HANDLE_CTX(dev_handle), "failed to disable SHORT_PACKET_TERMINATE for endpoint %02X", endpoint_address);
 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			IGNORE_SHORT_PACKETS, sizeof(UCHAR), &policy))
-			usbi_dbg("failed to disable IGNORE_SHORT_PACKETS for endpoint %02X", endpoint_address);
+			usbi_dbg(HANDLE_CTX(dev_handle), "failed to disable IGNORE_SHORT_PACKETS for endpoint %02X", endpoint_address);
 
 		policy = true;
 		/* ALLOW_PARTIAL_READS must be enabled due to likely libusbK bug. See:
 		   https://sourceforge.net/mailarchive/message.php?msg_id=29736015 */
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			ALLOW_PARTIAL_READS, sizeof(UCHAR), &policy))
-			usbi_dbg("failed to enable ALLOW_PARTIAL_READS for endpoint %02X", endpoint_address);
+			usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable ALLOW_PARTIAL_READS for endpoint %02X", endpoint_address);
 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			AUTO_CLEAR_STALL, sizeof(UCHAR), &policy))
-			usbi_dbg("failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
+			usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
 
 		if (sub_api == SUB_API_LIBUSBK) {
 			if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 				ISO_ALWAYS_START_ASAP, sizeof(UCHAR), &policy))
-				usbi_dbg("failed to enable ISO_ALWAYS_START_ASAP for endpoint %02X", endpoint_address);
+				usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable ISO_ALWAYS_START_ASAP for endpoint %02X", endpoint_address);
 		}
 	}
 
@@ -2667,7 +2667,7 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 		}
 		handle_priv->interface_handle[iface].dev_handle = handle_priv->interface_handle[0].dev_handle;
 	}
-	usbi_dbg("claimed interface %u", iface);
+	usbi_dbg(ctx, "claimed interface %u", iface);
 	handle_priv->active_interface = iface;
 
 	return LIBUSB_SUCCESS;
@@ -2701,7 +2701,7 @@ static int get_valid_interface(struct libusb_device_handle *dev_handle, int api_
 	int i;
 
 	if ((api_id < USB_API_WINUSBX) || (api_id > USB_API_HID)) {
-		usbi_dbg("unsupported API ID");
+		usbi_dbg(HANDLE_CTX(dev_handle), "unsupported API ID");
 		return -1;
 	}
 
@@ -2727,7 +2727,7 @@ static int check_valid_interface(struct libusb_device_handle *dev_handle, unsign
 		return -1;
 
 	if ((api_id < USB_API_WINUSBX) || (api_id > USB_API_HID)) {
-		usbi_dbg("unsupported API ID");
+		usbi_dbg(HANDLE_CTX(dev_handle), "unsupported API ID");
 		return -1;
 	}
 
@@ -2792,7 +2792,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 			return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("will use interface %d", current_interface);
+	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);
 
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, handle_priv->interface_handle[current_interface].dev_handle);
@@ -2894,7 +2894,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, handle_priv->interface_handle[current_interface].dev_handle);
@@ -2928,10 +2928,10 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		}
 
 		if (IS_XFERIN(transfer)) {
-			usbi_dbg("reading %d iso packets", transfer->num_iso_packets);
+			usbi_dbg(TRANSFER_CTX(transfer), "reading %d iso packets", transfer->num_iso_packets);
 			ret = WinUSBX[sub_api].IsoReadPipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, overlapped, iso_context);
 		} else {
-			usbi_dbg("writing %d iso packets", transfer->num_iso_packets);
+			usbi_dbg(TRANSFER_CTX(transfer), "writing %d iso packets", transfer->num_iso_packets);
 			ret = WinUSBX[sub_api].IsoWritePipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, overlapped, iso_context);
 		}
 
@@ -3084,14 +3084,14 @@ static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itran
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, handle_priv->interface_handle[current_interface].dev_handle);
 	overlapped = get_transfer_priv_overlapped(itransfer);
 
 	if (IS_XFERIN(transfer)) {
-		usbi_dbg("reading %d bytes", transfer->length);
+		usbi_dbg(TRANSFER_CTX(transfer), "reading %d bytes", transfer->length);
 		ret = WinUSBX[sub_api].ReadPipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, NULL, overlapped);
 	} else {
 		// Set SHORT_PACKET_TERMINATE if ZLP requested.
@@ -3111,7 +3111,7 @@ static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itran
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 
-		usbi_dbg("writing %d bytes", transfer->length);
+		usbi_dbg(TRANSFER_CTX(transfer), "writing %d bytes", transfer->length);
 		ret = WinUSBX[sub_api].WritePipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, NULL, overlapped);
 	}
 
@@ -3140,7 +3140,7 @@ static int winusbx_clear_halt(int sub_api, struct libusb_device_handle *dev_hand
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("matched endpoint %02X with interface %d", endpoint, current_interface);
+	usbi_dbg(HANDLE_CTX(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 
 	if (!WinUSBX[sub_api].ResetPipe(winusb_handle, endpoint)) {
@@ -3162,7 +3162,7 @@ static int winusbx_cancel_transfer(int sub_api, struct usbi_transfer *itransfer)
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
-	usbi_dbg("will use interface %d", current_interface);
+	usbi_dbg(TRANSFER_CTX(transfer), "will use interface %d", current_interface);
 
 	handle = handle_priv->interface_handle[current_interface].api_handle;
 	if (!WinUSBX[sub_api].AbortPipe(handle, transfer->endpoint)) {
@@ -3196,7 +3196,7 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 		winusb_handle = handle_priv->interface_handle[i].api_handle;
 		if (HANDLE_VALID(winusb_handle)) {
 			for (j = 0; j < priv->usb_interface[i].nb_endpoints; j++) {
-				usbi_dbg("resetting ep %02X", priv->usb_interface[i].endpoint[j]);
+				usbi_dbg(HANDLE_CTX(dev_handle), "resetting ep %02X", priv->usb_interface[i].endpoint[j]);
 				if (!WinUSBX[sub_api].AbortPipe(winusb_handle, priv->usb_interface[i].endpoint[j]))
 					usbi_err(HANDLE_CTX(dev_handle), "AbortPipe (pipe address %02X) failed: %s",
 						priv->usb_interface[i].endpoint[j], windows_error_str(0));
@@ -3532,28 +3532,28 @@ static int _hid_get_descriptor(struct libusb_device *dev, HANDLE hid_handle, int
 
 	switch (type) {
 	case LIBUSB_DT_DEVICE:
-		usbi_dbg("LIBUSB_DT_DEVICE");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_DEVICE");
 		return _hid_get_device_descriptor(priv->hid, data, size);
 	case LIBUSB_DT_CONFIG:
-		usbi_dbg("LIBUSB_DT_CONFIG");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_CONFIG");
 		if (!_index)
 			return _hid_get_config_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_STRING:
-		usbi_dbg("LIBUSB_DT_STRING");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_STRING");
 		return _hid_get_string_descriptor(priv->hid, _index, data, size, hid_handle);
 	case LIBUSB_DT_HID:
-		usbi_dbg("LIBUSB_DT_HID");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_HID");
 		if (!_index)
 			return _hid_get_hid_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_REPORT:
-		usbi_dbg("LIBUSB_DT_REPORT");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_REPORT");
 		if (!_index)
 			return _hid_get_report_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_PHYSICAL:
-		usbi_dbg("LIBUSB_DT_PHYSICAL");
+		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_PHYSICAL");
 		if (HidD_GetPhysicalDescriptor(hid_handle, data, (ULONG)*size))
 			return LIBUSB_COMPLETED;
 		return LIBUSB_ERROR_OTHER;
@@ -3595,7 +3595,7 @@ static int _hid_get_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		return LIBUSB_ERROR_NO_MEM;
 
 	buf[0] = (uint8_t)id; // Must be set always
-	usbi_dbg("report ID: 0x%02X", buf[0]);
+	usbi_dbg(DEVICE_CTX(dev), "report ID: 0x%02X", buf[0]);
 
 	// NB: The size returned by DeviceIoControl doesn't include report IDs when not in use (0)
 	if (!DeviceIoControl(hid_handle, ioctl_code, buf, expected_size + 1,
@@ -3643,7 +3643,7 @@ static int _hid_set_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
-	usbi_dbg("report ID: 0x%02X", id);
+	usbi_dbg(DEVICE_CTX(dev), "report ID: 0x%02X", id);
 	// When report IDs are not used (i.e. when id == 0), we must add
 	// a null report ID. Otherwise, we just use original data buffer
 	if (id == 0)
@@ -3802,7 +3802,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 
 		// Set the maximum available input buffer size
 		for (i = 32; HidD_SetNumInputBuffers(hid_handle, i); i *= 2);
-		usbi_dbg("set maximum input buffer size to %d", i / 2);
+		usbi_dbg(HANDLE_CTX(dev_handle), "set maximum input buffer size to %d", i / 2);
 
 		// Get the maximum input and output report size
 		if (!HidD_GetPreparsedData(hid_handle, &preparsed_data) || !preparsed_data) {
@@ -3819,7 +3819,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 		size[1] = capabilities.NumberOutputValueCaps;
 		size[2] = capabilities.NumberFeatureValueCaps;
 		for (j = HidP_Input; j <= HidP_Feature; j++) {
-			usbi_dbg("%lu HID %s report value(s) found", ULONG_CAST(size[j]), type[j]);
+			usbi_dbg(HANDLE_CTX(dev_handle), "%lu HID %s report value(s) found", ULONG_CAST(size[j]), type[j]);
 			priv->hid->uses_report_ids[j] = false;
 			if (size[j] > 0) {
 				value_caps = calloc(size[j], sizeof(HIDP_VALUE_CAPS));
@@ -3829,7 +3829,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 					nb_ids[0] = 0;
 					nb_ids[1] = 0;
 					for (i = 0; i < (int)size[j]; i++) {
-						usbi_dbg("  Report ID: 0x%02X", value_caps[i].ReportID);
+						usbi_dbg(HANDLE_CTX(dev_handle), "  Report ID: 0x%02X", value_caps[i].ReportID);
 						if (value_caps[i].ReportID != 0)
 							nb_ids[1]++;
 						else
@@ -3922,7 +3922,7 @@ static int hid_claim_interface(int sub_api, struct libusb_device_handle *dev_han
 
 	handle_priv->interface_handle[iface].dev_handle = INTERFACE_CLAIMED;
 
-	usbi_dbg("claimed interface %u", iface);
+	usbi_dbg(HANDLE_CTX(dev_handle), "claimed interface %u", iface);
 	handle_priv->active_interface = iface;
 
 	return LIBUSB_SUCCESS;
@@ -3993,7 +3993,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 			return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("will use interface %d", current_interface);
+	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);
 
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, hid_handle);
@@ -4088,7 +4088,7 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, hid_handle);
@@ -4111,7 +4111,7 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 
 	if (direction_in) {
 		transfer_priv->hid_dest = transfer->buffer;
-		usbi_dbg("reading %d bytes (report ID: 0x00)", length);
+		usbi_dbg(TRANSFER_CTX(transfer), "reading %d bytes (report ID: 0x00)", length);
 		ret = ReadFile(hid_handle, transfer_priv->hid_buffer, length + 1, NULL, overlapped);
 	} else {
 		if (!priv->hid->uses_report_ids[1])
@@ -4120,7 +4120,7 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 			// We could actually do without the calloc and memcpy in this case
 			memcpy(transfer_priv->hid_buffer, transfer->buffer, transfer->length);
 
-		usbi_dbg("writing %d bytes (report ID: 0x%02X)", length, transfer_priv->hid_buffer[0]);
+		usbi_dbg(TRANSFER_CTX(transfer), "writing %d bytes (report ID: 0x%02X)", length, transfer_priv->hid_buffer[0]);
 		ret = WriteFile(hid_handle, transfer_priv->hid_buffer, length, NULL, overlapped);
 	}
 
@@ -4170,7 +4170,7 @@ static int hid_clear_halt(int sub_api, struct libusb_device_handle *dev_handle, 
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg("matched endpoint %02X with interface %d", endpoint, current_interface);
+	usbi_dbg(HANDLE_CTX(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
 
 	// No endpoint selection with Microsoft's implementation, so we try to flush the
@@ -4267,7 +4267,7 @@ static int composite_open(int sub_api, struct libusb_device_handle *dev_handle)
 		// open HID devices with a U2F usage unless running as administrator. We ignore this
 		// failure and proceed without the HID device opened.
 		if (r == LIBUSB_ERROR_ACCESS) {
-			usbi_dbg("ignoring access denied error while opening HID interface of composite device");
+			usbi_dbg(HANDLE_CTX(dev_handle), "ignoring access denied error while opening HID interface of composite device");
 			r = LIBUSB_SUCCESS;
 		}
 	}
@@ -4376,7 +4376,7 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 
 	// Try and target a specific interface if the control setup indicates such
 	if ((iface >= 0) && (iface < USB_MAXINTERFACES)) {
-		usbi_dbg("attempting control transfer targeted to interface %d", iface);
+		usbi_dbg(TRANSFER_CTX(transfer), "attempting control transfer targeted to interface %d", iface);
 		if ((priv->usb_interface[iface].path != NULL)
 				&& (priv->usb_interface[iface].apib->submit_control_transfer != NULL)) {
 			r = priv->usb_interface[iface].apib->submit_control_transfer(priv->usb_interface[iface].sub_api, itransfer);
@@ -4392,10 +4392,10 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 			if ((priv->usb_interface[iface].path != NULL)
 					&& (priv->usb_interface[iface].apib->submit_control_transfer != NULL)) {
 				if ((pass == 0) && (priv->usb_interface[iface].restricted_functionality)) {
-					usbi_dbg("trying to skip restricted interface #%d (HID keyboard or mouse?)", iface);
+					usbi_dbg(TRANSFER_CTX(transfer), "trying to skip restricted interface #%d (HID keyboard or mouse?)", iface);
 					continue;
 				}
-				usbi_dbg("using interface %d", iface);
+				usbi_dbg(TRANSFER_CTX(transfer), "using interface %d", iface);
 				r = priv->usb_interface[iface].apib->submit_control_transfer(priv->usb_interface[iface].sub_api, itransfer);
 				// If not supported on this API, it may be supported on another, so don't give up yet!!
 				if (r == LIBUSB_ERROR_NOT_SUPPORTED)

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -96,7 +96,7 @@ struct windows_usb_api_backend {
 extern const struct windows_usb_api_backend usb_api_backend[USB_API_MAX];
 
 #define PRINT_UNSUPPORTED_API(fname)				\
-	usbi_dbg("unsupported API call for '%s' "		\
+	usbi_dbg(NULL, "unsupported API call for '%s' "		\
 		"(unrecognized device driver)", #fname)
 
 #define CHECK_SUPPORTED_API(apip, fname)			\

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -36,7 +36,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 {
 	int *completed = transfer->user_data;
 	*completed = 1;
-	usbi_dbg("actual_length=%d", transfer->actual_length);
+	usbi_dbg(TRANSFER_CTX(transfer), "actual_length=%d", transfer->actual_length);
 	/* caller interprets result and frees transfer */
 }
 

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11640
+#define LIBUSB_NANO 11641


### PR DESCRIPTION
This commit should fix a performance issue caused by the disconnection of the first context
allocated from the default context. usbi_dbg now takes the explicit context instead of
relying on the default context (which may not exist) in most cases.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>