### PR TITLE
darwin: use the IO registry to detect if a kernel driver is attached to an interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,7 @@ case $backend in
 darwin)
 	AC_CHECK_FUNCS([pthread_threadid_np])
 	LIBS="${LIBS} -lobjc -Wl,-framework,IOKit -Wl,-framework,CoreFoundation -Wl,-framework,Security"
+	AC_CHECK_HEADERS([IOKit/usb/IOUSBHostFamilyDefinitions.h])
 	;;
 haiku)
 	LIBS="${LIBS} -lbe"

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -30,6 +30,10 @@
 #include <IOKit/usb/IOUSBLib.h>
 #include <IOKit/IOCFPlugIn.h>
 
+#if defined(HAVE_IOKIT_USB_IOUSBHOSTFAMILYDEFINITIONS_H)
+#include <IOKit/usb/IOUSBHostFamilyDefinitions.h>
+#endif
+
 /* IOUSBInterfaceInferface */
 
 /* New in OS 10.12.0. */
@@ -142,6 +146,14 @@
 
 #error "IOUSBFamily is too old. Please upgrade your SDK and/or deployment target"
 
+#endif
+
+#if !defined(kIOUSBHostInterfaceClassName)
+#define kIOUSBHostInterfaceClassName "IOUSBHostInterface"
+#endif
+
+#if !defined(kUSBHostMatchingPropertyInterfaceNumber)
+#define kUSBHostMatchingPropertyInterfaceNumber "bInterfaceNumber"
 #endif
 
 #if !defined(IO_OBJECT_NULL)

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11642
+#define LIBUSB_NANO 11643


### PR DESCRIPTION
The implementation of libusb_kernel_driver_active was attempting to open the interface to
check if a driver is attached. This may have side effects (like configuring the device)
that may be unexpected to the user. This commit updates the code to find the interface's
IO registry entry (either IOUSBHostInterface or the legacy IOUSBInterface) and check if
the entry has a child entry. A child entry indicates that a driver is currently attached.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>