### PR TITLE
Windows: Fix timeouts if only endpoint 0 exists

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -530,6 +530,10 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 		usbi_dbg(HANDLE_CTX(dev_handle), "no endpoints found for interface %u", iface);
 		libusb_free_config_descriptor(conf_desc);
 		priv->usb_interface[iface].current_altsetting = altsetting;
+
+		// Extra init may be required to configure endpoint 0
+		if (priv->apib->configure_endpoints)
+			r = priv->apib->configure_endpoints(SUB_API_NOTSET, dev_handle, iface);
 		return LIBUSB_SUCCESS;
 	}
 


### PR DESCRIPTION
The default timeouts of 5 seconds used by WinUSB are cleared in
configure_endpoints(). This was not called if not at least one extra
endpoint apart from endpoint 0 existed, so that in those cases the
default timeout of 5 seconds remained in place.
Fix this by calling configure_endpoints, even if no interface specific
endpoints were found, so that it can configure endpoint 0.

Signed-off-by: Julian Scheel <julian@jusst.de>