### PR TITLE
Update libusb-1.0.def

### DIFF
--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -155,7 +155,7 @@ EXPORTS
   libusb_set_interface_alt_setting
   libusb_set_interface_alt_setting@12 = libusb_set_interface_alt_setting
   libusb_set_option
-  _libusb_set_option = libusb_set_option
+  libusb_set_option@8 = libusb_set_option
   libusb_set_pollfd_notifiers
   libusb_set_pollfd_notifiers@16 = libusb_set_pollfd_notifiers
   libusb_setlocale


### PR DESCRIPTION
This fixes issue #944 C++ symbol for libusb_set_option not exported correctly.
As per the report in issue #944, original commit is correct but subsequent edits cause the regression.
https://github.com/libusb/libusb/blob/v1.0.22-rc1/libusb/libusb-1.0.def#L156

Signed-off-by: Xiaofan Chen xiaofanc@gmail.com