### PR TITLE
Windows: Add ability to claim multiple associated interfaces for a WINUSBX composite function

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1137,3 +1137,188 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	data[di] = 0;
 	return di;
 }
+
+static int parse_iad_array(struct libusb_context *ctx,
+	struct libusb_interface_association_descriptor_array *iad_array,
+	const uint8_t *buffer, int size)
+{
+	uint8_t i;
+	struct usbi_descriptor_header header;
+	int consumed = 0;
+	const uint8_t *buf = buffer;
+	struct libusb_interface_association_descriptor *iad;
+
+	if (size < LIBUSB_DT_CONFIG_SIZE) {
+		usbi_err(ctx, "short config descriptor read %d/%d",
+			 size, LIBUSB_DT_CONFIG_SIZE);
+		return LIBUSB_ERROR_IO;
+	}
+
+	//first pass. iterate through desc list, count number of IAD's
+	iad_array->length = 0;
+	while (consumed < size) {
+		parse_descriptor(buf, "bb", &header);
+		if (header.bDescriptorType == LIBUSB_DT_INTERFACE_ASSOCIATION)
+			iad_array->length++;
+		buf += header.bLength;
+		consumed += header.bLength;
+	}
+
+	iad_array->iad = NULL;
+	if (iad_array->length > 0) {
+		iad = calloc(iad_array->length, sizeof(*iad));
+		if (!iad)
+			return LIBUSB_ERROR_NO_MEM;
+
+		iad_array->iad = iad;
+
+		//second pass. iterate through desc list, fill IAD structures
+		consumed = 0;
+		i = 0;
+		while (consumed < size) {
+		   parse_descriptor(buffer, "bb", &header);
+		   if (header.bDescriptorType == LIBUSB_DT_INTERFACE_ASSOCIATION)
+			  parse_descriptor(buffer, "bbbbbbbb", &iad[i++]);
+		   buffer += header.bLength;
+		   consumed += header.bLength;
+		}
+	}
+
+	return LIBUSB_SUCCESS;
+}
+
+static int raw_desc_to_iad_array(struct libusb_context *ctx, const uint8_t *buf,
+		int size, struct libusb_interface_association_descriptor_array **iad_array)
+{
+	struct libusb_interface_association_descriptor_array *_iad_array
+		= calloc(1, sizeof(*_iad_array));
+	int r;
+
+	if (!_iad_array)
+		return LIBUSB_ERROR_NO_MEM;
+
+	r = parse_iad_array(ctx, _iad_array, buf, size);
+	if (r < 0) {
+		usbi_err(ctx, "parse_iad_array failed with error %d", r);
+		free(_iad_array);
+		return r;
+	}
+
+	*iad_array = _iad_array;
+	return LIBUSB_SUCCESS;
+}
+
+/** \ingroup libusb_desc
+ * Get an array of interface association descriptors (IAD) for a given
+ * configuration.
+ * This is a non-blocking function which does not involve any requests being
+ * sent to the device.
+ *
+ * \param dev a device
+ * \param config_index the index of the configuration you wish to retrieve the
+ * IADs for.
+ * \param iad_array output location for the array of IADs. Only valid if 0 was
+ * returned. Must be freed with libusb_free_interface_association_descriptors()
+ * after use. It's possible that a given configuration contains no IADs. In this
+ * case the iad_array is still output, but will have 'length' field set to 0, and
+ * iad field set to NULL.
+ * \returns 0 on success
+ * \returns LIBUSB_ERROR_NOT_FOUND if the configuration does not exist
+ * \returns another LIBUSB_ERROR code on error
+ * \see libusb_get_active_interface_association_descriptors()
+ */
+int API_EXPORTED libusb_get_interface_association_descriptors(libusb_device *dev,
+	uint8_t config_index, struct libusb_interface_association_descriptor_array **iad_array)
+{
+	union usbi_config_desc_buf _config;
+	uint16_t config_len;
+	uint8_t *buf;
+	int r;
+
+	if (!iad_array)
+		return LIBUSB_ERROR_INVALID_PARAM;
+
+	usbi_dbg(DEVICE_CTX(dev), "index %u", config_index);
+	if (config_index >= dev->device_descriptor.bNumConfigurations)
+		return LIBUSB_ERROR_NOT_FOUND;
+
+	r = get_config_descriptor(dev, config_index, _config.buf, sizeof(_config.buf));
+	if (r < 0)
+		return r;
+
+	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
+	buf = malloc(config_len);
+	if (!buf)
+		return LIBUSB_ERROR_NO_MEM;
+
+	r = get_config_descriptor(dev, config_index, buf, config_len);
+	if (r >= 0)
+		r = raw_desc_to_iad_array(DEVICE_CTX(dev), buf, r, iad_array);
+
+	free(buf);
+	return r;
+}
+
+/** \ingroup libusb_desc
+ * Get an array of interface association descriptors (IAD) for the currently
+ * active configuration.
+ * This is a non-blocking function which does not involve any requests being
+ * sent to the device.
+ *
+ * \param dev a device
+ * \param iad_array output location for the array of IADs. Only valid if 0 was
+ * returned. Must be freed with libusb_free_interface_association_descriptors()
+ * after use. It's possible that a given configuration contains no IADs. In this
+ * case the iad_array is still output, but will have 'length' field set to 0, and
+ * iad field set to NULL.
+ * \returns 0 on success
+ * \returns LIBUSB_ERROR_NOT_FOUND if the device is in unconfigured state
+ * \returns another LIBUSB_ERROR code on error
+ * \see libusb_get_interface_association_descriptors
+ */
+int API_EXPORTED libusb_get_active_interface_association_descriptors(libusb_device *dev,
+	struct libusb_interface_association_descriptor_array **iad_array)
+{
+	union usbi_config_desc_buf _config;
+	uint16_t config_len;
+	uint8_t *buf;
+	int r;
+
+	if (!iad_array)
+		return LIBUSB_ERROR_INVALID_PARAM;
+
+	r = get_active_config_descriptor(dev, _config.buf, sizeof(_config.buf));
+	if (r < 0)
+		return r;
+
+	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
+	buf = malloc(config_len);
+	if (!buf)
+		return LIBUSB_ERROR_NO_MEM;
+
+	r = get_active_config_descriptor(dev, buf, config_len);
+	if (r >= 0)
+		r = raw_desc_to_iad_array(DEVICE_CTX(dev), buf, r, iad_array);
+	free(buf);
+	return r;
+}
+
+/** \ingroup libusb_desc
+ * Free an array of interface association descriptors (IADs) obtained from
+ * libusb_get_interface_association_descriptors() or
+ * libusb_get_active_interface_association_descriptors().
+ * It is safe to call this function with a NULL iad_array parameter, in which
+ * case the function simply returns.
+ *
+ * \param iad_array the IAD array to free
+ */
+void API_EXPORTED libusb_free_interface_association_descriptors(
+	struct libusb_interface_association_descriptor_array *iad_array)
+{
+	if (!iad_array)
+		return;
+
+	if (iad_array->iad)
+		free((void*)iad_array->iad);
+	free(iad_array);
+}

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -40,6 +40,8 @@ EXPORTS
   libusb_free_container_id_descriptor@4 = libusb_free_container_id_descriptor
   libusb_free_device_list
   libusb_free_device_list@8 = libusb_free_device_list
+  libusb_free_interface_association_descriptors
+  libusb_free_interface_association_descriptors@4 = libusb_free_interface_association_descriptors
   libusb_free_pollfds
   libusb_free_pollfds@4 = libusb_free_pollfds
   libusb_free_ss_endpoint_companion_descriptor
@@ -54,6 +56,8 @@ EXPORTS
   libusb_free_usb_2_0_extension_descriptor@4 = libusb_free_usb_2_0_extension_descriptor
   libusb_get_active_config_descriptor
   libusb_get_active_config_descriptor@8 = libusb_get_active_config_descriptor
+  libusb_get_active_interface_association_descriptors
+  libusb_get_active_interface_association_descriptors@8 = libusb_get_active_interface_association_descriptors
   libusb_get_bos_descriptor
   libusb_get_bos_descriptor@8 = libusb_get_bos_descriptor
   libusb_get_bus_number
@@ -76,6 +80,8 @@ EXPORTS
   libusb_get_device_list@8 = libusb_get_device_list
   libusb_get_device_speed
   libusb_get_device_speed@4 = libusb_get_device_speed
+  libusb_get_interface_association_descriptors
+  libusb_get_interface_association_descriptors@12 = libusb_get_interface_association_descriptors
   libusb_get_max_iso_packet_size
   libusb_get_max_iso_packet_size@8 = libusb_get_max_iso_packet_size
   libusb_get_max_packet_size

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -259,6 +259,9 @@ enum libusb_descriptor_type {
 	/** Endpoint descriptor. See libusb_endpoint_descriptor. */
 	LIBUSB_DT_ENDPOINT = 0x05,
 
+	/** Interface Association Descriptor. See libusb_interface_association_descriptor*/
+	LIBUSB_DT_INTERFACE_ASSOCIATION = 0x0b,
+
 	/** BOS descriptor */
 	LIBUSB_DT_BOS = 0x0f,
 
@@ -620,6 +623,64 @@ struct libusb_endpoint_descriptor {
 
 	/** Length of the extra descriptors, in bytes. Must be non-negative. */
 	int extra_length;
+};
+
+/** \ingroup libusb_desc
+ * A structure representing the standard USB interface association descriptor.
+ * This descriptor is documented in section 9.6.4 of the USB 3.0 specification.
+ * All multiple-byte fields are represented in host-endian format.
+ */
+struct libusb_interface_association_descriptor {
+	/** Size of this descriptor (in bytes) */
+	uint8_t  bLength;
+
+	/** Descriptor type. Will have value
+	* \ref libusb_descriptor_type::LIBUSB_DT_INTERFACE_ASSOCIATION
+	* LIBUSB_DT_INTERFACE_ASSOCIATION in this context. */
+	uint8_t  bDescriptorType;
+
+	/** Interface number of the first interface that is associated with this
+	* function*/
+	uint8_t  bFirstInterface;
+
+	/** Number of contiguous interfaces that are associated with this function */
+	uint8_t  bInterfaceCount;
+
+	/** USB-IF class code for this function.
+	* A value of zero is not allowed in this descriptor.
+	* If this field is FFH, the function class is vendor-specific.
+	* All other values are reserved for assignment by the USB-IF.
+	*/
+	uint8_t  bFunctionClass;
+
+	/** USB-IF subclass code for this function.
+	* If this field is not set to FFH, all values are reserved
+	* for assignment by the USB-IF
+	*/
+	uint8_t  bFunctionSubClass;
+
+	/** USB-IF protocol code for this function.
+	* These codes are qualified by the values of the bFunctionClass
+	* and bFunctionSubClass fields.
+	*/
+	uint8_t  bFunctionProtocol;
+
+	/* Index of string descriptor describing this function */
+	uint8_t  iFunction;
+};
+
+/** \ingroup libusb_desc
+ * Structure containing an array of 0 or more interface association
+ * descriptors
+ */
+struct libusb_interface_association_descriptor_array {
+	/** Array of interface association descriptors. The size of this array
+	 * is determined by the length field.
+	 */
+	const struct libusb_interface_association_descriptor *iad;
+
+	/** Number of interface association descriptors contained. Read-only. */
+	int length;
 };
 
 /** \ingroup libusb_desc
@@ -1420,6 +1481,13 @@ int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint);
+
+int LIBUSB_CALL libusb_get_interface_association_descriptors(libusb_device *dev,
+	uint8_t config_index, struct libusb_interface_association_descriptor_array **iad_array);
+int LIBUSB_CALL libusb_get_active_interface_association_descriptors(libusb_device *dev,
+	struct libusb_interface_association_descriptor_array **iad_array);
+void LIBUSB_CALL libusb_free_interface_association_descriptors(
+	struct libusb_interface_association_descriptor_array *iad_array);
 
 int LIBUSB_CALL libusb_wrap_sys_device(libusb_context *ctx, intptr_t sys_dev, libusb_device_handle **dev_handle);
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **dev_handle);

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -256,6 +256,14 @@ struct winusb_device_priv {
 		int current_altsetting;
 		bool restricted_functionality;  // indicates if the interface functionality is restricted
 						// by Windows (eg. HID keyboards or mice cannot do R/W)
+		bool is_associated_interface;  // indicates whether this interface is part of a grouped
+		                               // set of associated interfaces (defined by an IAD)
+		uint8_t first_associated_interface; // if 'is_associated_interface' is true, this is the index
+		                                    // of the first interface (bFirstInterface in IAD) for the
+		                                    // grouped set of associated interfaces
+		uint8_t num_associated_interfaces;  // if 'is_associated_interface' is true, this is the number
+		                                    // of interfaces within the associated group
+		                                    // (bInterfaceCount in IAD)
 	} usb_interface[USB_MAXINTERFACES];
 	struct hid_device_priv *hid;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1358,6 +1358,9 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
 	int interface_number;
 	const char *mi_str;
+	int iadi, iadintfi;
+	struct libusb_interface_association_descriptor_array *iad_array;
+	const struct libusb_interface_association_descriptor *iad;
 
 	// Because MI_## are not necessarily in sequential order (some composite
 	// devices will have only MI_00 & MI_03 for instance), we retrieve the actual
@@ -1394,6 +1397,29 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 		priv->hid = calloc(1, sizeof(struct hid_device_priv));
 		if (priv->hid == NULL)
 			return LIBUSB_ERROR_NO_MEM;
+	}
+
+	//For WINUSBX, set up associations for interfaces grouped by an IAD.
+	if ((api == USB_API_WINUSBX) && !libusb_get_active_interface_association_descriptors(dev, &iad_array)) {
+		for (iadi = 0; iadi < iad_array->length; iadi++) {
+			iad = &iad_array->iad[iadi];
+			if (iad->bFirstInterface == interface_number) {
+				priv->usb_interface[interface_number].is_associated_interface = true;
+				priv->usb_interface[interface_number].first_associated_interface = iad->bFirstInterface;
+				priv->usb_interface[interface_number].num_associated_interfaces = iad->bInterfaceCount;
+				for (iadintfi = 1; iadintfi < iad->bInterfaceCount; iadintfi++) {
+					usbi_dbg(ctx, "interface[%d] is associated with interface[%d]",
+							      interface_number + iadintfi, interface_number);
+					priv->usb_interface[interface_number + iadintfi].apib = &usb_api_backend[api];
+					priv->usb_interface[interface_number + iadintfi].sub_api = sub_api;
+					priv->usb_interface[interface_number + iadintfi].is_associated_interface = true;
+					priv->usb_interface[interface_number + iadintfi].first_associated_interface = iad->bFirstInterface;
+					priv->usb_interface[interface_number + iadintfi].num_associated_interfaces = iad->bInterfaceCount;
+				}
+				break;
+			}
+		}
+		libusb_free_interface_association_descriptors(iad_array);
 	}
 
 	return LIBUSB_SUCCESS;
@@ -2462,7 +2488,7 @@ static void winusbx_close(int sub_api, struct libusb_device_handle *dev_handle)
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev_handle->dev);
 	HANDLE handle;
-	int i;
+	int i, ai;
 
 	if (sub_api == SUB_API_NOTSET)
 		sub_api = priv->sub_api;
@@ -2471,17 +2497,42 @@ static void winusbx_close(int sub_api, struct libusb_device_handle *dev_handle)
 		return;
 
 	if (priv->apib->id == USB_API_COMPOSITE) {
-		// If this is a composite device, just free and close all WinUSB-like
-		// interfaces directly (each is independent and not associated with another)
+		// If this is a composite device, just free and close any WinUSB-like
+		// interfaces that are not part of an associated group
+		// (each is independent and not associated with another).
+		// For associated interface groupings, free interfaces that
+		// are NOT the first within that group (i.e. not bFirstInterface),
+		// then free & close bFirstInterface last.
 		for (i = 0; i < USB_MAXINTERFACES; i++) {
 			if (priv->usb_interface[i].apib->id == USB_API_WINUSBX) {
-				handle = handle_priv->interface_handle[i].api_handle;
-				if (HANDLE_VALID(handle))
-					WinUSBX[sub_api].Free(handle);
+				if (!priv->usb_interface[i].is_associated_interface) {
+					handle = handle_priv->interface_handle[i].api_handle;
+					if (HANDLE_VALID(handle))
+						WinUSBX[sub_api].Free(handle);
 
-				handle = handle_priv->interface_handle[i].dev_handle;
-				if (HANDLE_VALID(handle))
-					CloseHandle(handle);
+					handle = handle_priv->interface_handle[i].dev_handle;
+					if (HANDLE_VALID(handle))
+						CloseHandle(handle);
+				}
+				else {
+					if (i==priv->usb_interface[i].first_associated_interface) {
+						//first free all handles for all *other* associated interfaces
+						for (ai = 1; ai < priv->usb_interface[i].num_associated_interfaces; ai++) {
+							handle = handle_priv->interface_handle[i + ai].api_handle;
+							if (HANDLE_VALID(handle))
+								WinUSBX[sub_api].Free(handle);
+						}
+
+						//free & close bFirstInterface
+						handle = handle_priv->interface_handle[i].api_handle;
+						if (HANDLE_VALID(handle))
+							WinUSBX[sub_api].Free(handle);
+
+						handle = handle_priv->interface_handle[i].dev_handle;
+						if (HANDLE_VALID(handle))
+							CloseHandle(handle);
+					}
+				}
 			}
 		}
 	} else {
@@ -2562,6 +2613,7 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev_handle->dev);
 	bool is_using_usbccgp = (priv->apib->id == USB_API_COMPOSITE);
+	bool is_associated_interface = priv->usb_interface[iface].is_associated_interface;
 	HDEVINFO dev_info;
 	char *dev_interface_path = NULL;
 	char *dev_interface_path_guid_start;
@@ -2570,12 +2622,18 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 	HANDLE file_handle, winusb_handle;
 	DWORD err, _index;
 	int r;
+	uint8_t initialized_iface;
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
 	// If the device is composite, but using the default Windows composite parent driver (usbccgp)
 	// or if it's the first WinUSB-like interface, we get a handle through Initialize().
-	if ((is_using_usbccgp) || (iface == 0)) {
+	// If it's an associated interface, and is the first one (iface==bFirstInterface), we also
+	// want to get the handle through Initialize(). If it's an associated interface, and NOT
+	// the first one, we want to direct control to the 'else' where the handle will be obtained
+	// via GetAssociatedInterface().
+	if (((is_using_usbccgp) || (iface == 0)) &&
+	    (!is_associated_interface || (iface==priv->usb_interface[iface].first_associated_interface))) {
 		// composite device (independent interfaces) or interface 0
 		file_handle = handle_priv->interface_handle[iface].dev_handle;
 		if (!HANDLE_VALID(file_handle))
@@ -2636,21 +2694,32 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 		}
 		handle_priv->interface_handle[iface].api_handle = winusb_handle;
 	} else {
+		if (is_associated_interface) {
+			initialized_iface = priv->usb_interface[iface].first_associated_interface;
+			if (iface <= initialized_iface) {
+				usbi_err(ctx, "invalid associated index. iface=%u, initialized iface=%u", iface, initialized_iface);
+				return LIBUSB_ERROR_NOT_FOUND;
+			}
+		}
+		else
+			initialized_iface = 0;
+
 		// For all other interfaces, use GetAssociatedInterface()
-		winusb_handle = handle_priv->interface_handle[0].api_handle;
+		winusb_handle = handle_priv->interface_handle[initialized_iface].api_handle;
 		// It is a requirement for multiple interface devices on Windows that, to you
 		// must first claim the first interface before you claim the others
 		if (!HANDLE_VALID(winusb_handle)) {
-			file_handle = handle_priv->interface_handle[0].dev_handle;
+			file_handle = handle_priv->interface_handle[initialized_iface].dev_handle;
 			if (WinUSBX[sub_api].Initialize(file_handle, &winusb_handle)) {
-				handle_priv->interface_handle[0].api_handle = winusb_handle;
-				usbi_warn(ctx, "auto-claimed interface 0 (required to claim %u with WinUSB)", iface);
+				handle_priv->interface_handle[initialized_iface].api_handle = winusb_handle;
+				usbi_warn(ctx, "auto-claimed interface %u (required to claim %u with WinUSB)", initialized_iface, iface);
 			} else {
-				usbi_warn(ctx, "failed to auto-claim interface 0 (required to claim %u with WinUSB): %s", iface, windows_error_str(0));
+				usbi_warn(ctx, "failed to auto-claim interface %u (required to claim %u with WinUSB): %s",
+						initialized_iface, iface, windows_error_str(0));
 				return LIBUSB_ERROR_ACCESS;
 			}
 		}
-		if (!WinUSBX[sub_api].GetAssociatedInterface(winusb_handle, (UCHAR)(iface - 1),
+		if (!WinUSBX[sub_api].GetAssociatedInterface(winusb_handle, (UCHAR)(iface - 1 - initialized_iface),
 			&handle_priv->interface_handle[iface].api_handle)) {
 			handle_priv->interface_handle[iface].api_handle = INVALID_HANDLE_VALUE;
 			switch (GetLastError()) {
@@ -2665,7 +2734,7 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 				return LIBUSB_ERROR_ACCESS;
 			}
 		}
-		handle_priv->interface_handle[iface].dev_handle = handle_priv->interface_handle[0].dev_handle;
+		handle_priv->interface_handle[iface].dev_handle = handle_priv->interface_handle[initialized_iface].dev_handle;
 	}
 	usbi_dbg(ctx, "claimed interface %u", iface);
 	handle_priv->active_interface = iface;


### PR DESCRIPTION
On Windows 10, we have experienced issues when trying to claim / use multiple interfaces for a composite device (MI_XX) which is using the default USB composite parent driver (usbccgp) to manage the overall USB device.

It seems this is a well-known issue, as there is much discussion in this issue: https://github.com/libusb/libusb/issues/85
(As well as several other issues that link back to that one)

The advised workaround is to have WinUSB manage the whole device (replace usbccgp). While this resolves the issue for particular libusb applications (and the specific USB composite function they are using), it breaks use of any other non-WINUSBX functions (such as RNDIS, NCM, ACM, etc.).

This is an attempt at trying to resolve (at least a subset) of these issues, by making use of IADs that (may be) available for particular configurations.

The first commit (https://github.com/libusb/libusb/commit/912e6b66c72ca112c7ae3f576ac8abaa7770fde6) is not Windows-specific, but introduces the ability to retrieve an array of IAD's for a particular (or active) configuration. 

The second commit (https://github.com/libusb/libusb/commit/f3e1233a9508ca079fb2f7b91c266dd184047634) is Windows-specific, and makes use of the API introduced within the first commit to retrieve IADs and form sets of 'associated' interfaces (see commit message for more detail here).

This has been tested on Windows 10 in a few different composite device configurations:
1. Winusb managing entire device
2. usbccgp managing parent, child1=RNDIS (2 interfaces), child2=WINUSB(3 interfaces), child3=ACM(2 interfaces)
3. usbccgp managing parent, child1=WINUSB(3 interfaces), child2=NCM(2 interfaces), child3=ACM(2 interfaces)
4. usbccgp managing parent, child1=WINUSB(3 interfaces)

As I am very new to the project, I'll definitely need some help identifying some 'gotchas' for cases that I didn't consider, as well as further testing.

I'm very much looking forward to hearing feedback from everyone! Thank you in advance!
