### PR TITLE
Fix Windows HID backend missing byte

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -4205,8 +4205,6 @@ static enum libusb_transfer_status hid_copy_transfer_data(int sub_api, struct us
 				}
 
 				if (transfer_priv->hid_buffer[0] == 0) {
-					// Discard the 1 byte report ID prefix
-					length--;
 					memcpy(transfer_priv->hid_dest, transfer_priv->hid_buffer + 1, length);
 				} else {
 					memcpy(transfer_priv->hid_dest, transfer_priv->hid_buffer, length);


### PR DESCRIPTION
https://github.com/libusb/libusb/issues/902#issuecomment-810726897
Jonas' comment is correct, when the report id is zero, we should indeed skip the first byte of transfer_priv->hid_buffer, since it is not part of the actual report. But the report size should not change.