### PR TITLE
Fix crash (segv) in libusb_init if backend.init failes

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2342,13 +2342,14 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 	list_add(&_ctx->list, &active_contexts_list);
 	usbi_mutex_static_unlock(&active_contexts_lock);
 
+	usbi_hotplug_init(_ctx);
+
 	if (usbi_backend.init) {
 		r = usbi_backend.init(_ctx);
 		if (r)
 			goto err_io_exit;
 	}
 
-	usbi_hotplug_init(_ctx);
 
 	if (ctx)
 		*ctx = _ctx;


### PR DESCRIPTION
If backend.init fails. the control goes to err_io_exit which tries to clean up hotplug related lists that arent initialized.

Moving hotplug_init before makes sure the lists are valid so if backend.init fails they get cleaned up without errors.

Also adding mutx_unlock to a few more error scenarios