### PR TITLE
core: Unlock and clear default ctx in all error paths in libusb_init

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2333,10 +2333,8 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 		libusb_version_internal.micro, libusb_version_internal.nano, libusb_version_internal.rc);
 
 	r = usbi_io_init(_ctx);
-	if (r < 0) {
-		usbi_mutex_static_unlock(&default_context_lock);
+	if (r < 0)
 		goto err_free_ctx;
-	}
 
 	usbi_mutex_static_lock(&active_contexts_lock);
 	list_add(&_ctx->list, &active_contexts_list);
@@ -2362,21 +2360,22 @@ err_io_exit:
 	list_del(&_ctx->list);
 	usbi_mutex_static_unlock(&active_contexts_lock);
 
-	if (!ctx) {
-		usbi_default_context = NULL;
-		default_context_refcnt = 0;
-	}
-
-	usbi_mutex_static_unlock(&default_context_lock);
-
 	usbi_hotplug_exit(_ctx);
 	usbi_io_exit(_ctx);
 
 err_free_ctx:
+	if (!ctx) {
+		/* clear default context that was not fully initialized */
+		usbi_default_context = NULL;
+		default_context_refcnt = 0;
+	}
+
 	usbi_mutex_destroy(&_ctx->open_devs_lock);
 	usbi_mutex_destroy(&_ctx->usb_devs_lock);
 
 	free(_ctx);
+
+	usbi_mutex_static_unlock(&default_context_lock);
 
 	return r;
 }


### PR DESCRIPTION
Commit 32a22069428cda9d63aa666e92fb8882a83d4515 reordered and refactored `libusb_init`. This resulted in moving code outside the default ctx lock that was unrelated to it. But this resulted in broken error path cleanup logic that leaves the default ctx as locked, half initialized and freed in case a `libusb_set_option` or the `usbi_io_init` call fails.

Undo part of the previous reordering to unlock and clear the default ctx in all error paths in `libusb_init`.