### PR TITLE
git hooks: Remove "source" bashism

### DIFF
--- a/.private/post-rewrite.sh
+++ b/.private/post-rewrite.sh
@@ -6,7 +6,7 @@
 # .git/hooks/ with the following content:
 # #!/bin/sh
 # if [ -x .private/post-rewrite.sh ]; then
-#   source .private/post-rewrite.sh
+#   . .private/post-rewrite.sh
 # fi
 #
 # NOTE: These versioning hooks are intended to be used *INTERNALLY* by the

--- a/.private/pre-commit.sh
+++ b/.private/pre-commit.sh
@@ -8,7 +8,7 @@
 # .git/hooks/ with the following content:
 # #!/bin/sh
 # if [ -x .private/pre-commit.sh ]; then
-#   source .private/pre-commit.sh
+#   . .private/pre-commit.sh
 # fi
 #
 # NOTE: These versioning hooks are intended to be used *INTERNALLY* by the


### PR DESCRIPTION
"source" is not supported in Bourne shell

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>