### PR TITLE
git hooks: Only apply to master branch

### DIFF
--- a/.private/post-rewrite.sh
+++ b/.private/post-rewrite.sh
@@ -18,6 +18,10 @@ if [ -n "$LIBUSB_SKIP_NANO" ]; then
   exit 0
 fi
 
+if [ "$(git branch --show-current)" != "master" ]; then
+  exit 0
+fi
+
 case "$1" in
   amend)
     # Check if a .amend exists. If none, create one and warn user to re-commit.

--- a/.private/pre-commit.sh
+++ b/.private/pre-commit.sh
@@ -38,6 +38,10 @@ fi
 
 eval $TYPE_CMD || { echo "git command not found. Aborting." >&2; exit 1; }
 
+if [ "$(git branch --show-current)" != "master" ]; then
+  exit 0
+fi
+
 NANO=`git log --oneline | wc -l`
 NANO=`expr $NANO + $BRANCH_OFFSET`
 # Amended commits need to have the nano corrected. Current versions of git hooks


### PR DESCRIPTION
Consider this an RFC. I know there is LIBUSB_SKIP_NANO but it is easy to forget. For me it would be natural to develop and prepare stuff on separate branches, and only use master to stage things to push.