### PR TITLE
Keep LIBUSB_OPTION_WEAK_AUTHORITY as a macro with same value

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2223,7 +2223,6 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 		/* Handle all backend-specific options here */
 	case LIBUSB_OPTION_USE_USBDK:
 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
-	case LIBUSB_OPTION_WEAK_AUTHORITY:
 		if (usbi_backend.set_option)
 			return usbi_backend.set_option(ctx, option, ap);
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2111,17 +2111,15 @@ enum libusb_option {
 	 * This is typically needed on Android, where access to USB devices
 	 * is limited.
 	 *
+	 * For LIBUSB_API_VERSION 0x01000108 it was called LIBUSB_OPTION_WEAK_AUTHORITY
+	 *
 	 * Only valid on Linux.
 	 */
 	LIBUSB_OPTION_NO_DEVICE_DISCOVERY = 2,
 
-	/** Flag that libusb has weak authority.
-	 *
-	 * (Deprecated) alias for LIBUSB_OPTION_NO_DEVICE_DISCOVERY
-	 */
-	LIBUSB_OPTION_WEAK_AUTHORITY = 3,
+#define LIBUSB_OPTION_WEAK_AUTHORITY LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 
-	LIBUSB_OPTION_MAX = 4
+	LIBUSB_OPTION_MAX = 3
 };
 
 int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -136,7 +136,7 @@ typedef SSIZE_T ssize_t;
  * Internally, LIBUSB_API_VERSION is defined as follows:
  * (libusb major << 24) | (libusb minor << 16) | (16 bit incremental)
  */
-#define LIBUSB_API_VERSION 0x01000108
+#define LIBUSB_API_VERSION 0x01000109
 
 /* The following is kept for compatibility, but will be deprecated in the future */
 #define LIBUSBX_API_VERSION LIBUSB_API_VERSION

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -439,8 +439,7 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	UNUSED(ctx);
 	UNUSED(ap);
 
-	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY ||
-	    option == LIBUSB_OPTION_WEAK_AUTHORITY) {
+	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY) {
 		usbi_dbg(ctx, "no enumeration will be performed");
 		no_enumeration = 1;
 		return LIBUSB_SUCCESS;


### PR DESCRIPTION
and bump LIBUSB_API_VERSION.

Alternatively we could omit the macro and get rid of LIBUSB_OPTION_WEAK_AUTHORITY for good, the hard way.