### PR TITLE
core: Update note about LIBUSB_TRANSFER_ADD_ZERO_PACKET availability

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -312,7 +312,8 @@ if (cfg != desired)
  * - libusb is able to send a packet of zero length to an endpoint simply by
  * submitting a transfer of zero length.
  * - The \ref libusb_transfer_flags::LIBUSB_TRANSFER_ADD_ZERO_PACKET
- * "LIBUSB_TRANSFER_ADD_ZERO_PACKET" flag is currently only supported on Linux.
+ * "LIBUSB_TRANSFER_ADD_ZERO_PACKET" flag is currently supported on Linux,
+ * Darwin and Windows (WinUSB).
  */
 
 /**


### PR DESCRIPTION
Maybe we should also clarify the surrounding text, it is not clear to me. And is it a caveat?

Is this what is meant, that there are two alternatives? "The user can either include own logic to add an explicit zero length transfer when it is needed, or use the LIBUSB_TRANSFER_ADD_ZERO_PACKET flag on the normal data transfer."