### PR TITLE
Windows: Fix ssize_t unconditionally defined

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -31,8 +31,11 @@
 #define inline __inline
 #endif
 /* ssize_t is also not available */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
+#endif /* _SSIZE_T_DEFINED */
 #endif /* _MSC_VER */
 
 #include <limits.h>


### PR DESCRIPTION
The standard procedure to define ssize_t on Windows is to wrap it around
a check for the _SSIZE_T_DEFINED macro.

If not done, it makes it impossible to use the libusb.h header along
with other headers (from other libraries) that also attempt to define
ssize_t.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>