### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -66,7 +66,7 @@ visit: http://log.libusb.info
 * Windows: Fix enumeration problems on Windows 8 and later
 * Windows: Major rework of poll() emulation
 * Windows: Numerous HID API fixes
-* Windows: Support cancelation of individual transfers (Vista and later)
+* Windows: Support cancellation of individual transfers (Vista and later)
 * Various other bug fixes and improvements
 
 2016-10-01: v1.0.21

--- a/android/README
+++ b/android/README
@@ -51,7 +51,7 @@ the package is built.
 Runtime Permissions:
 --------------------
 
-The Runtime Permissions on Android can be transfered from Java to Native
+The Runtime Permissions on Android can be transferred from Java to Native
 over the following approach:
 
   JAVA:
@@ -85,7 +85,7 @@ over the following approach:
           libusb_init(&ctx);
           libusb_wrap_sys_device(NULL, (intptr_t)fileDescriptor, &devh);
       }
-      /* From this point you can regulary use all libusb functions as usual */
+      /* From this point you can regularly use all libusb functions as usual */
 
    About LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
 

--- a/examples/ezusb.c
+++ b/examples/ezusb.c
@@ -195,7 +195,7 @@ static bool ezusb_cpucs(libusb_device_handle *device, uint32_t addr, bool doRun)
 }
 
 /*
- * Send an FX3 jumpt to address command
+ * Send an FX3 jump to address command
  * Returns false on error.
  */
 static bool ezusb_fx3_jump(libusb_device_handle *device, uint32_t addr)

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -220,7 +220,7 @@ static int display_ps3_status(libusb_device_handle *handle)
 			printf("\tRIGHT 3 pressed\n");
 			break;
 		case 0x08:
-			printf("\tSTART presed\n");
+			printf("\tSTART pressed\n");
 			break;
 		case 0x10:
 			printf("\tUP pressed\n");
@@ -246,7 +246,7 @@ static int display_ps3_status(libusb_device_handle *handle)
 			printf("\tLEFT 1 pressed\n");
 			break;
 		case 0x08:
-			printf("\tRIGHT 1 presed\n");
+			printf("\tRIGHT 1 pressed\n");
 			break;
 		case 0x10:
 			printf("\tTRIANGLE pressed\n");

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1544,7 +1544,7 @@ int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
 	}
 	/*
 	 * We must release the flying transfers lock here, because with
-	 * some backends the submit_transfer method is synchroneous.
+	 * some backends the submit_transfer method is synchronous.
 	 */
 	usbi_mutex_unlock(&ctx->flying_transfers_lock);
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1620,7 +1620,7 @@ static int darwin_set_interface_altsetting(struct libusb_device_handle *dev_hand
 
   /* If a device only supports a default setting for the specified interface, then a STALL
      (kIOUSBPipeStalled) may be returned. Ref: USB 2.0 specs 9.4.10.
-     Mimick the behaviour in e.g. the Linux kernel: in such case, reset all endpoints
+     Mimic the behaviour in e.g. the Linux kernel: in such case, reset all endpoints
      of the interface (as would have been done per 9.1.1.5) and return success. */
 
   /* For some reason we need to reclaim the interface after the pipe error */

--- a/libusb/os/haiku_usb_backend.cpp
+++ b/libusb/os/haiku_usb_backend.cpp
@@ -301,7 +301,7 @@ USBDeviceHandle::SetAltSetting(uint8 inumber, uint8 alt)
 	}
 	command.alternate.alternate_info = alt;
 	if (ioctl(fRawFD, B_USB_RAW_COMMAND_SET_ALT_INTERFACE, &command, sizeof(command)) ||
-			command.alternate.status != B_USB_RAW_STATUS_SUCCESS) { //IF IOCTL FAILS DEVICE DISONNECTED PROBABLY
+			command.alternate.status != B_USB_RAW_STATUS_SUCCESS) { //IF IOCTL FAILS DEVICE DISCONNECTED PROBABLY
 		usbi_err(NULL, "Error setting alternate interface");
 		return _errno_to_libusb(command.alternate.status);
 	}

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -133,7 +133,7 @@ static libusb_testlib_result test_default_context_change(void)
 		/* Enable debug output on new context, to be sure to use the context */
 		libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 
-		/* Enable debug outout on the default context. This should work even before
+		/* Enable debug output on the default context. This should work even before
 		 * the context has been created. */
 		libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 


### PR DESCRIPTION
Found via `codespell -q 3`