### PR TITLE
windows: Allow synchronous control transfer (for libusb0)

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2769,7 +2769,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	PWINUSB_SETUP_PACKET setup = (PWINUSB_SETUP_PACKET)transfer->buffer;
-	ULONG size;
+	ULONG size, transferred;
 	HANDLE winusb_handle;
 	OVERLAPPED *overlapped;
 	int current_interface;
@@ -2809,11 +2809,13 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 		}
 		windows_force_sync_completion(itransfer, 0);
 	} else {
-		if (!WinUSBX[sub_api].ControlTransfer(winusb_handle, *setup, transfer->buffer + LIBUSB_CONTROL_SETUP_SIZE, size, NULL, overlapped)) {
+		if (!WinUSBX[sub_api].ControlTransfer(winusb_handle, *setup, transfer->buffer + LIBUSB_CONTROL_SETUP_SIZE, size, &transferred, overlapped)) {
 			if (GetLastError() != ERROR_IO_PENDING) {
 				usbi_warn(TRANSFER_CTX(transfer), "ControlTransfer failed: %s", windows_error_str(0));
 				return LIBUSB_ERROR_IO;
 			}
+		} else {
+			windows_force_sync_completion(itransfer, transferred);
 		}
 	}
 


### PR DESCRIPTION
Some of the changes in commit 9c28ad2 rely on all transfers being, or
appearing as, asynchronous transfers.

However, the libusb0.sys backend of libusbk.dll performs all control
transfers synchronously and ignores any overlapped handed to it.

Therefore restore the possibility of synchronous execution of control
transfers.

Fixes #94

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>