### PR TITLE
core: add libusb_init_context to allow setting options during context creation

### DIFF
--- a/examples/dpfp.c
+++ b/examples/dpfp.c
@@ -601,7 +601,7 @@ int main(void)
 {
 	int r;
 
-	r = libusb_init(NULL);
+	r = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (r < 0) {
 		fprintf(stderr, "failed to initialise libusb %d - %s\n", r, libusb_strerror(r));
 		exit(1);

--- a/examples/fxload.c
+++ b/examples/fxload.c
@@ -172,9 +172,9 @@ int main(int argc, char*argv[])
 	}
 
 	/* open the device using libusb */
-	status = libusb_init(NULL);
+	status = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (status < 0) {
-		logerror("libusb_init() failed: %s\n", libusb_error_name(status));
+		logerror("libusb_init_context() failed: %s\n", libusb_error_name(status));
 		return -1;
 	}
 	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, verbose);

--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
 	product_id = (argc > 2) ? (int)strtol (argv[2], NULL, 0) : 0x5005;
 	class_id   = (argc > 3) ? (int)strtol (argv[3], NULL, 0) : LIBUSB_HOTPLUG_MATCH_ANY;
 
-	rc = libusb_init (NULL);
+	rc = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (rc < 0)
 	{
 		printf("failed to initialise libusb: %s\n", libusb_error_name(rc));

--- a/examples/listdevs.c
+++ b/examples/listdevs.c
@@ -55,7 +55,7 @@ int main(void)
 	int r;
 	ssize_t cnt;
 
-	r = libusb_init(NULL);
+	r = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (r < 0)
 		return r;
 

--- a/examples/sam3u_benchmark.c
+++ b/examples/sam3u_benchmark.c
@@ -191,7 +191,7 @@ int main(void)
 	(void)signal(SIGINT, sig_hdlr);
 #endif
 
-	rc = libusb_init(NULL);
+	rc = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (rc < 0) {
 		fprintf(stderr, "Error initializing libusb: %s\n", libusb_error_name(rc));
 		exit(1);

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	r = libusb_init(NULL);
+	r = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (r < 0)
 		return r;
 

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -1113,7 +1113,7 @@ int main(int argc, char** argv)
 
 	version = libusb_get_version();
 	printf("Using libusb v%d.%d.%d.%d\n\n", version->major, version->minor, version->micro, version->nano);
-	r = libusb_init(NULL);
+	r = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);
 	if (r < 0)
 		return r;
 

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -122,6 +122,8 @@ EXPORTS
   libusb_hotplug_register_callback@36 = libusb_hotplug_register_callback
   libusb_init
   libusb_init@4 = libusb_init
+  libusb_init_context
+  libusb_init_context@12 = libusb_init_context
   libusb_interrupt_event_handler
   libusb_interrupt_event_handler@4 = libusb_interrupt_event_handler
   libusb_interrupt_transfer

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1409,8 +1409,14 @@ enum libusb_option {
 	LIBUSB_OPTION_MAX = 3
 };
 
+/** \ingroup libusb_lib
+ * Structure used for setting options through \ref libusb_init_context.
+ *
+ */
 struct libusb_init_option {
+  /** Which option to set */
   enum libusb_option option;
+  /** An integer value used by the option (if applicable). */
   union {
     int64_t ival;
   } value;

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11760
+#define LIBUSB_NANO 11682

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11682
+#define LIBUSB_NANO 11762

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -32,7 +32,7 @@ static libusb_testlib_result test_init_and_exit(void)
 		libusb_context *ctx = NULL;
 		int r;
 
-		r = libusb_init(&ctx);
+		r = libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0);
 		if (r != LIBUSB_SUCCESS) {
 			libusb_testlib_logf(
 				"Failed to init libusb on iteration %d: %d",
@@ -51,7 +51,7 @@ static libusb_testlib_result test_get_device_list(void)
 	libusb_context *ctx;
 	int r;
 
-	r = libusb_init(&ctx);
+	r = libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0);
 	if (r != LIBUSB_SUCCESS) {
 		libusb_testlib_logf("Failed to init libusb: %d", r);
 		return TEST_STATUS_FAILURE;
@@ -83,7 +83,7 @@ static libusb_testlib_result test_many_device_lists(void)
 	libusb_device **device_lists[LIST_COUNT];
 	int r;
 
-	r = libusb_init(&ctx);
+	r = libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0);
 	if (r != LIBUSB_SUCCESS) {
 		libusb_testlib_logf("Failed to init libusb: %d", r);
 		return TEST_STATUS_FAILURE;
@@ -123,22 +123,25 @@ static libusb_testlib_result test_default_context_change(void)
 		libusb_context *ctx = NULL;
 		int r;
 
+
+		/* Enable debug output on new context, to be sure to use the context */
+		struct libusb_init_option options[] = {
+		  {
+		    .option = LIBUSB_OPTION_LOG_LEVEL,
+		    .value = {.ival = LIBUSB_LOG_LEVEL_DEBUG},
+		  },
+		};
+		int num_options = 1;
+
 		/* First create a new context */
-		r = libusb_init(&ctx);
+		r = libusb_init_context(&ctx, options, num_options);
 		if (r != LIBUSB_SUCCESS) {
 			libusb_testlib_logf("Failed to init libusb: %d", r);
 			return TEST_STATUS_FAILURE;
 		}
 
-		/* Enable debug output on new context, to be sure to use the context */
-		libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
-
-		/* Enable debug output on the default context. This should work even before
-		 * the context has been created. */
-		libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
-
 		/* Now create a reference to the default context */
-		r = libusb_init(NULL);
+		r = libusb_init_context(/*ctx=*/NULL, options, num_options);
 		if (r != LIBUSB_SUCCESS) {
 			libusb_testlib_logf("Failed to init libusb: %d", r);
 			libusb_exit(ctx);

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -16,7 +16,7 @@ static void *test_init_and_exit(void * arg)
 		libusb_context *ctx = NULL;
 		int r;
 
-		r = libusb_init(&ctx);
+		r = libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0);
 		if (r != LIBUSB_SUCCESS) {
 			printf("Failed to init libusb on iteration %d: %d", i, r);
 			return NULL;


### PR DESCRIPTION
The new initialization function addresses some shortcomings of the libusb_set_option()
interface. Namely, it allows setting the no-enumeration option (and others) on only the
contexts where it is requested. The old initialization function (libusb_init()) is
deprecated and will be removed in a future release. For now it translates to a call to
libusb_init_context() with no options specified.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>