### PR TITLE
Fuzzing: Add CIFuzz

### DIFF
--- a/.github/cifuzz.yml
+++ b/.github/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libusb'
+        dry-run: false
+        language: c
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libusb'
+        fuzz-seconds: 600
+        dry-run: false
+        language: c
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Adds CIFuzz to libusb's OSS-fuzz integration. In short, CIFuzz is a service offered by OSS-fuzz to run libusb's fuzzers during the CI to prevent bugs from being introduced.
In this PR the fuzz time is set to 600 seconds but can be changed.

More about CIFuzz can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/