### PR TITLE
core: Unset device ctx if it has been destroyed

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2441,6 +2441,7 @@ void API_EXPORTED libusb_exit(libusb_context *ctx)
 	for_each_device(_ctx, dev) {
 		usbi_warn(_ctx, "device %d.%d still referenced",
 			dev->bus_number, dev->device_address);
+		DEVICE_CTX(dev) = NULL;
 	}
 
 	if (!list_empty(&_ctx->open_devs))


### PR DESCRIPTION
Devices can outlive their context in some cases (in particular with
python garbage collection). Guard against this happening by clearing the
ctx pointer so that it is not pointing to uninitialized memory.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2050638

This is now happening because the debug output in libusb_unref_device was changed to use the device ctx.