### PR TITLE
linux_usbfs: fix maybe-uninitialized error

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1429,7 +1429,7 @@ static int op_get_configuration(struct libusb_device_handle *handle,
 	uint8_t *config)
 {
 	struct linux_device_priv *priv = usbi_get_device_priv(handle->dev);
-	int active_config;
+	int active_config = -1; /* to please compiler */
 	int r;
 
 	if (priv->sysfs_dir) {


### PR DESCRIPTION
Initialize `active_config` to an invalid value to avoid the following
compilation error:

```
os/linux_usbfs.c: In function ‘op_get_configuration’:
os/linux_usbfs.c:1452:12: error: ‘active_config’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1452 |  *config = (uint8_t)active_config;
```

Fixes #1063 

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>