### PR TITLE
configure.ac: link with -latomic if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,7 @@ if test "x$platform" = xposix; then
 	AC_SEARCH_LIBS([pthread_create], [pthread],
 		[test "x$ac_cv_search_pthread_create" != "xnone required" && AC_SUBST(THREAD_LIBS, [-lpthread])],
 		[], [])
+	AC_SEARCH_LIBS([__atomic_fetch_add_4], [atomic])
 elif test "x$platform" = xwindows; then
 	AC_DEFINE([PLATFORM_WINDOWS], [1], [Define to 1 if compiling for a Windows platform.])
 else


### PR DESCRIPTION
libusb unconditionally uses `atomic_fetch_add` since version 1.0.25 (https://github.com/libusb/libusb/commit/1a08aa84d96397a3840a75abe66051f5360c2c84 and https://github.com/libusb/libusb/commit/eed8a371ea53939096ba94d44001e0637d042572) but some architectures (e.g. sparc) needs to link with `-latomic` to be able to use it. So check if `-latomic` is needed and update `libusb-1.0.pc` accordingly to avoid the following build failure with openocd:

```
/home/buildroot/autobuild/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/10.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/buildroot/autobuild/instance-0/output-1/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libusb-1.0.so: undefined reference to `__atomic_fetch_add_4'
collect2: error: ld returned 1 exit status
```

Fixes:
 - http://autobuild.buildroot.org/results/4a27a769bb3cdf78643c3049b87d792178d6512c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>