### PR TITLE
windows: Link gcc helpers statically on MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ case $host in
 	platform=windows
 	test "x$enable_shared" = xyes && create_import_lib=yes
 	EXTRA_CFLAGS="-mwin32 -fno-omit-frame-pointer"
+	EXTRA_LDFLAGS="-static-libgcc"
 	;;
 *)
 	AC_MSG_RESULT([Null])
@@ -392,6 +393,8 @@ AM_CXXFLAGS="-std=${c_dialect}++11 ${EXTRA_CFLAGS} ${SHARED_CFLAGS} -Wmissing-de
 AC_SUBST(AM_CXXFLAGS)
 
 AC_SUBST(LT_LDFLAGS)
+
+AC_SUBST([EXTRA_LDFLAGS])
 
 dnl set name of html output directory for doxygen
 AC_SUBST(DOXYGEN_HTMLDIR, [api-1.0])

--- a/libusb/Makefile.am
+++ b/libusb/Makefile.am
@@ -80,7 +80,7 @@ all-local: .libs/libusb-1.0.dll.a
 endif
 endif
 
-libusb_1_0_la_LDFLAGS = $(LT_LDFLAGS)
+libusb_1_0_la_LDFLAGS = $(LT_LDFLAGS) $(EXTRA_LDFLAGS)
 libusb_1_0_la_SOURCES = libusbi.h version.h version_nano.h \
 	core.c descriptor.c hotplug.c io.c strerror.c sync.c \
 	$(PLATFORM_SRC) $(OS_SRC)


### PR DESCRIPTION
This has been tested to do what it should, only add -static-libgcc to the linker flags when building the final libusb.dll on MinGW. There are however an infinite number of ways to do this with autoconf, so style and consistency could be reviewed. I am adding EXTRA_LDFLAGS  instead of using (abusing?) LT_LDFLAGS which I suspect is used for non-libtool flags some other places. OTOH for instance EXTRA_CFLAGS is only used locally in configure.ac and put into AM_CFLAGS directly. I am not using AM_LDFLAGS if that is a thing, and I think that is fine since the extra flag should only be applied to the DLL linking. Maybe a more specific variable name could be used.