### PR TITLE
Improve WinUSB performance by enabling RAW_IO when possible

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2230,6 +2230,7 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 		/* Handle all backend-specific options here */
 	case LIBUSB_OPTION_USE_USBDK:
 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+	case LIBUSB_OPTION_WINUSB_RAW_IO:
 		if (usbi_backend.set_option)
 			return usbi_backend.set_option(ctx, option, ap);
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2123,10 +2123,16 @@ enum libusb_option {
 	 * Only valid on Linux.
 	 */
 	LIBUSB_OPTION_NO_DEVICE_DISCOVERY = 2,
-
 #define LIBUSB_OPTION_WEAK_AUTHORITY LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 
-	LIBUSB_OPTION_MAX = 3
+	/** Use WinUSB RAW_IO policy on Windows.
+	 * Improves performance by allowing the backend to queue multiple transfer
+	 * requests, the same way it works by default on other platforms.
+	 * This requires transfer sizes to be a multiple of maximum packet size.
+	 */
+	LIBUSB_OPTION_WINUSB_RAW_IO = 3,
+
+	LIBUSB_OPTION_MAX = 4
 };
 
 int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -614,6 +614,10 @@ static int windows_set_option(struct libusb_context *ctx, enum libusb_option opt
 		usbi_dbg(ctx, "switching context %p to use UsbDk backend", ctx);
 		priv->backend = &usbdk_backend;
 		return LIBUSB_SUCCESS;
+	} else if (option == LIBUSB_OPTION_WINUSB_RAW_IO) {
+		usbi_dbg(ctx, "enabling RAW_IO for context %p", ctx);
+		priv->use_raw_io = true;
+		return LIBUSB_SUCCESS;
 	}
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -340,6 +340,7 @@ struct windows_context_priv {
 	const struct windows_backend *backend;
 	HANDLE completion_port;
 	HANDLE completion_port_thread;
+	BOOL use_raw_io;
 };
 
 union windows_device_priv {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2505,6 +2505,8 @@ static void winusbx_close(int sub_api, struct libusb_device_handle *dev_handle)
 
 static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle *dev_handle, uint8_t iface)
 {
+	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct windows_context_priv *ctx_priv = usbi_get_context_priv(ctx);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev_handle->dev);
 	HANDLE winusb_handle = handle_priv->interface_handle[iface].api_handle;
@@ -2546,6 +2548,12 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			AUTO_CLEAR_STALL, sizeof(UCHAR), &policy))
 			usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
+
+		if (ctx_priv->use_raw_io) {
+			if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
+				RAW_IO, sizeof(UCHAR), &policy))
+				usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable RAW_IO for endpoint %02X", endpoint_address);
+		}
 
 		if (sub_api == SUB_API_LIBUSBK) {
 			if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,


### PR DESCRIPTION
Related issues:
* https://github.com/libusb/libusb/issues/149
* https://github.com/libusb/libusb/issues/490

Without RAW_IO, WinUSB backend only submits one transfer request at a time. The duration to switch transfers causes lost data when capturing from devices with small internal buffer, such as FX2 based devices.

<s>The problem with enabling RAW_IO unconditionally is that it requires transfer size to be divisible by maximum packet size. This patch enables it only if the transfer size is divisible by 512, which is divisible by all USB maximum size values (16, 32, 64, 512).</s>

Updated version of patch enables RAW_IO only if option `LIBUSB_OPTION_WINUSB_RAW_IO` is enabled.
