### PR TITLE
Simplify clock_gettime() conditionalization and fallback on macOS

### DIFF
--- a/Xcode/config.h
+++ b/Xcode/config.h
@@ -8,12 +8,6 @@
 /* Define to 1 to enable message logging. */
 #define ENABLE_LOGGING 1
 
-/* On 10.12 and later, use newly available clock_*() functions */
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
-/* Define to 1 if you have the `clock_gettime' function. */
-#define HAVE_CLOCK_GETTIME 1
-#endif
-
 /* On 10.6 and later, use newly available pthread_threadid_np() function */
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 /* Define to 1 if you have the 'pthread_threadid_np' function. */

--- a/configure.ac
+++ b/configure.ac
@@ -211,29 +211,9 @@ esac
 dnl headers not available on all platforms but required on others
 AC_CHECK_HEADERS([sys/time.h])
 
-if test "x$platform" = xposix; then
-	dnl check availability of clock_gettime()
-	if test "x$backend" = xdarwin; then
-		dnl need to verify that OS X target is 10.12 or later for clock_gettime()
-		AC_MSG_CHECKING([whether OS X target version is 10.12 or later])
-		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-				#include <AvailabilityMacros.h>
-				#if MAC_OS_X_VERSION_MIN_REQUIRED < 101200
-				# error "Target OS X version is too old"
-				#endif
-			], [])],
-			[AC_MSG_RESULT([yes])
-			 osx_10_12_or_later=yes],
-			[AC_MSG_RESULT([no])
-			 osx_10_12_or_later=])
-		if test "x$osx_10_12_or_later" = xyes; then
-			AC_CHECK_FUNCS([clock_gettime], [have_clock_gettime=yes], [have_clock_gettime=])
-		else
-			AC_MSG_NOTICE([clock_gettime() is not available on target OS X version])
-		fi
-	else
-		AC_CHECK_FUNCS([clock_gettime], [have_clock_gettime=yes], [AC_MSG_ERROR([clock_gettime() is required on this platform])])
-	fi
+dnl check availability of clock_gettime(), except don't bother on Darwin, because the result is not used.
+if test "x$platform" = xposix && test "x$backend" != xdarwin; then
+	AC_CHECK_FUNCS([clock_gettime], [have_clock_gettime=yes], [AC_MSG_ERROR([clock_gettime() is required on this platform])])
 
 	if test "x$have_clock_gettime" = xyes; then
 		dnl the clock_gettime() function needs certain clock IDs defined

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -533,7 +533,7 @@ static inline void usbi_localize_device_descriptor(struct libusb_device_descript
 	desc->bcdDevice = libusb_le16_to_cpu(desc->bcdDevice);
 }
 
-#ifdef HAVE_CLOCK_GETTIME
+#if defined(HAVE_CLOCK_GETTIME) && !defined(__APPLE__)
 static inline void usbi_get_monotonic_time(struct timespec *tp)
 {
 	ASSERT_EQ(clock_gettime(CLOCK_MONOTONIC, tp), 0);


### PR DESCRIPTION
Removed the logic in configure.ac (for Darwin only) that detected if the clock_gettime() function exists.  Instead, just use the preprocessor to introspect the macOS SDK and deployment target and call clock_gettime() if they are new enough.

Also replaced the fallback code for older macOS with mach_absolute_time() and gettimeofday(), which are simplier because they do not need setup and teardown carefully balanced and their usage is in one place instead of spread in multiple places in the file.