### PR TITLE
core: Suppress hotplug events during initial enumeration

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2346,13 +2346,14 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 	list_add(&_ctx->list, &active_contexts_list);
 	usbi_mutex_static_unlock(&active_contexts_lock);
 
-	usbi_hotplug_init(_ctx);
-
 	if (usbi_backend.init) {
 		r = usbi_backend.init(_ctx);
 		if (r)
 			goto err_io_exit;
 	}
+
+	/* Initialize hotplug after the initial enumeration is done. */
+	usbi_hotplug_init(_ctx);
 
 	if (ctx)
 		*ctx = _ctx;

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -171,6 +171,9 @@ void usbi_hotplug_exit(struct libusb_context *ctx)
 	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
 		return;
 
+	if (!usbi_atomic_load(&ctx->hotplug_ready))
+		return;
+
 	/* free all registered hotplug callbacks */
 	for_each_hotplug_cb_safe(ctx, hotplug_cb, next_cb) {
 		list_del(&hotplug_cb->list);


### PR DESCRIPTION
The initial enumeration should not result in hotplug events to be fired.
This is just a convenience though, API users still need to be prepared
to be notified a second time fora device that was plugged in between
libusb_init and libusb_hotplug_register_callback.

This regressed with commit 6929b8270170 ("Fix segmentation fault in
libusb_init() if usbi_backend.init() fails"). This commit avoids the
mentioned segmentation fault by avoiding to clean up the hotplug code if
it was not yet initialised.

Closes: #1082
Related: #989