### PR TITLE
add interface bounds checking

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1430,6 +1430,10 @@ static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle,
         return rc;
       }
 
+      if (iface >= config->bNumInterfaces) {
+        usbi_err (HANDLE_CTX (dev_handle), "interface %d out of range for device", iface);
+        return LIBUSB_ERROR_NOT_FOUND;
+      }
       endpoint_desc = config->interface[iface].altsetting[alt_setting].endpoint + i - 1;
 
       cInterface->endpoint_addrs[i - 1] = endpoint_desc->bEndpointAddress;

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -523,6 +523,10 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 		return r;
 	}
 
+	if (iface >= conf_desc->bNumInterfaces) {
+		usbi_err(HANDLE_CTX(dev_handle), "interface %d out of range for device", iface);
+		return LIBUSB_ERROR_NOT_FOUND;
+	}
 	if_desc = &conf_desc->interface[iface].altsetting[altsetting];
 	safe_free(priv->usb_interface[iface].endpoint);
 


### PR DESCRIPTION
See https://github.com/libusb/libusb/issues/1039

This adds bounds checks to fields such as `priv->interfaces[]`, `config->interface[]`, `config->altsetting[]`

In each case, I attempted to use the field's actual size for the bound. For config, thats `bNumInterfaces`, and otherwise it's generally either `num_altsettings` or `USB_MAXINTERFACES`

I return `LIBUSB_ERROR_NOT_FOUND` in most cases if the iface index exceeds known bounds. For `sunos_usb.c` I just silently don't set `hpriv->altsetting`, because device releasing doesn't appear to do anything there anyway.

I have done basic tests on Darwin.