### PR TITLE
windows: Fix type mismatch in winusbx_copy_transfer_data

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3234,7 +3234,11 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 
 	if (transfer->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS) {
 		struct winusb_device_priv *priv = usbi_get_device_priv(transfer->dev_handle->dev);
-		CHECK_WINUSBX_AVAILABLE(sub_api);
+
+		if (sub_api == SUB_API_NOTSET)
+			sub_api = priv->sub_api;
+		if (WinUSBX[sub_api].hDll == NULL)
+			return LIBUSB_TRANSFER_ERROR;
 
 		// for isochronous, need to copy the individual iso packet actual_lengths and statuses
 		if ((sub_api == SUB_API_LIBUSBK) || (sub_api == SUB_API_LIBUSB0)) {


### PR DESCRIPTION
We cannot use the CHECK_WINUSBX_AVAILABLE macro since it may return with the wrong error type/value (#1100).
