### PR TITLE
windows: Pass on returned isochronous packet status on libusbK

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3260,7 +3260,14 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 				 * Both representation are guaranteed to have the same length in bytes.*/
 				PUSBD_ISO_PACKET_DESCRIPTOR usbd_iso_packet_desc = (PUSBD_ISO_PACKET_DESCRIPTOR)transfer->iso_packet_desc;
 				for (i = 0; i < transfer->num_iso_packets; i++) {
-					unsigned int packet_length = (i < transfer->num_iso_packets - 1) ? (usbd_iso_packet_desc[i + 1].Offset - usbd_iso_packet_desc[i].Offset) : usbd_iso_packet_desc[i].Length;
+					unsigned int packet_length;
+					if (i < transfer->num_iso_packets - 1 && usbd_iso_packet_desc[i + 1].Offset != 0)
+						packet_length = (usbd_iso_packet_desc[i + 1].Offset - usbd_iso_packet_desc[i].Offset);
+					else
+						packet_length = usbd_iso_packet_desc[i].Length;
+					if (i < transfer->num_iso_packets - 1 && usbd_iso_packet_desc[i + 1].Offset == 0)
+						usbi_err(TRANSFER_CTX(transfer), "packet %d has Offset 0, packet %d length set to %d",
+							 i + 1, i, packet_length);
 					unsigned int actual_length = usbd_iso_packet_desc[i].Length;
 					USBD_STATUS status = usbd_iso_packet_desc[i].Status;
 

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3252,8 +3252,7 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 					// Copy the requested value back for consistency with other platforms.
 					transfer->iso_packet_desc[i].actual_length = transfer->iso_packet_desc[i].length;
 				}
-				// TODO translate USDB_STATUS codes http://msdn.microsoft.com/en-us/library/ff539136(VS.85).aspx to libusb_transfer_status
-				//transfer->iso_packet_desc[i].status = transfer_priv->iso_context->IsoPackets[i].status;
+				transfer->iso_packet_desc[i].status = usbd_status_to_libusb_transfer_status(iso_context->IsoPackets[i].status);
 			}
 		} else if (sub_api == SUB_API_WINUSB) {
 			if (IS_XFERIN(transfer)) {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2849,7 +2849,7 @@ static int winusbx_set_interface_altsetting(int sub_api, struct libusb_device_ha
 static void WINAPI winusbx_native_iso_transfer_continue_stream_callback(struct libusb_transfer *transfer)
 {
 	// If this callback is invoked, this means that we attempted to set ContinueStream
-	// to TRUE when calling Read/WriteIsochPipeAsap in winusbx_do_iso_transfer.
+	// to TRUE when calling Read/WriteIsochPipeAsap in winusbx_submit_iso_transfer().
 	// The role of this callback is to fallback to ContinueStream = FALSE if the transfer
 	// did not succeed.
 


### PR DESCRIPTION
There was a pending TODO for libusbK, and AFAICS the desired solution was already applied for WinUSB.

The second commit should not be part of this but  included for now just for testing. If you see "Offset 0" in the log (or huge/negative packet lengths before applying this) you are hitting the same issue as me. This could indicate a serious issue we have to deal with later.