### PR TITLE
windows: use sdk-defined GUIDs where possible

### DIFF
--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -24,7 +24,8 @@
 #define LIBUSB_WINDOWS_WINUSB_H
 
 #include <devioctl.h>
-#include <guiddef.h>
+#include <initguid.h>
+#include <usbiodef.h>
 
 #include "windows_common.h"
 
@@ -42,13 +43,8 @@
 // Additional return code for HID operations that completed synchronously
 #define LIBUSB_COMPLETED	(LIBUSB_SUCCESS + 1)
 
-// http://msdn.microsoft.com/en-us/library/ff545978.aspx
-// http://msdn.microsoft.com/en-us/library/ff545972.aspx
-// http://msdn.microsoft.com/en-us/library/ff545982.aspx
-static const GUID GUID_DEVINTERFACE_USB_HOST_CONTROLLER = {0x3ABF6F2D, 0x71C4, 0x462A, {0x8A, 0x92, 0x1E, 0x68, 0x61, 0xE6, 0xAF, 0x27}};
-static const GUID GUID_DEVINTERFACE_USB_HUB = {0xF18A0E88, 0xC30C, 0x11D0, {0x88, 0x15, 0x00, 0xA0, 0xC9, 0x06, 0xBE, 0xD8}};
-static const GUID GUID_DEVINTERFACE_USB_DEVICE = {0xA5DCBF10, 0x6530, 0x11D2, {0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED}};
-static const GUID GUID_DEVINTERFACE_LIBUSB0_FILTER = {0xF9F3FF14, 0xAE21, 0x48A0, {0x8A, 0x25, 0x80, 0x11, 0xA7, 0xA9, 0x31, 0xD9}};
+// libusb0 Filter Device Interface GUID
+DEFINE_GUID(GUID_DEVINTERFACE_LIBUSB0_FILTER, 0xF9F3FF14, 0xAE21, 0x48A0, 0x8A, 0x25, 0x80, 0x11, 0xA7, 0xA9, 0x31, 0xD9);
 
 // The following define MUST be == sizeof(USB_DESCRIPTOR_REQUEST)
 #define USB_DESCRIPTOR_REQUEST_SIZE	12U


### PR DESCRIPTION
changes the symbols to be extern declspec(selectany)

this is a followup to https://github.com/libusb/libusb/commit/9cb2e5c111a7fc1eec13dcf73667187b06f68628 (which thankfully made the variables static!)

I think this is "the windows way", but I can understand prefering `static` over `extern __declspec(selectany)`, but just wanted to make the PR in case you weren't aware that these GUIDs are defined by the sdk. Feel free to close if there's a problem using those headers...