### PR TITLE
darwin: do not clear device data toggle for newer versions of macOS

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -3,8 +3,8 @@
  * I/O functions for libusb
  * Copyright © 2007-2009 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2001 Johannes Erdfelt <johannes@erdfelt.com>
- * Copyright © 2019 Nathan Hjelm <hjelmn@cs.umm.edu>
- * Copyright © 2019 Google LLC. All rights reserved.
+ * Copyright © 2019-2022 Nathan Hjelm <hjelmn@cs.unm.edu>
+ * Copyright © 2019-2022 Google LLC. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -311,7 +311,11 @@ if (r == 0 && actual_length == sizeof(data)) {
  * libusb_cancel_transfer() is asynchronous/non-blocking in itself. When the
  * cancellation actually completes, the transfer's callback function will
  * be invoked, and the callback function should check the transfer status to
- * determine that it was cancelled.
+ * determine that it was cancelled. On macOS and iOS it is not possible to
+ * cancel a single transfer. In this case cancelling one tranfer on an endpoint
+ * will cause all transfers on that endpoint to be cancelled. In some cases
+ * the call may cause the endpoint to stall. A call to \ref libusb_clear_halt
+ * may be needed.
  *
  * Freeing the transfer after it has been cancelled but before cancellation
  * has completed will result in undefined behaviour.

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -311,11 +311,11 @@ if (r == 0 && actual_length == sizeof(data)) {
  * libusb_cancel_transfer() is asynchronous/non-blocking in itself. When the
  * cancellation actually completes, the transfer's callback function will
  * be invoked, and the callback function should check the transfer status to
- * determine that it was cancelled. On macOS and iOS it is not possible to
- * cancel a single transfer. In this case cancelling one tranfer on an endpoint
- * will cause all transfers on that endpoint to be cancelled. In some cases
- * the call may cause the endpoint to stall. A call to \ref libusb_clear_halt
- * may be needed.
+ * determine that it was cancelled.
+ *
+ * On macOS and iOS it is not possible to cancel a single transfer. In this
+ * case cancelling one transfer on an endpoint will cause all transfers on
+ * that endpoint to be cancelled.
  *
  * Freeing the transfer after it has been cancelled but before cancellation
  * has completed will result in undefined behaviour.
@@ -1588,16 +1588,18 @@ int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
  *   \ref libusb_transfer_status::LIBUSB_TRANSFER_CANCELLED
  *   "LIBUSB_TRANSFER_CANCELLED" for each transfer that was cancelled.
 
- * - Calling this function also sends a \c ClearFeature(ENDPOINT_HALT) request
- *   for the transfer's endpoint. If the device does not handle this request
- *   correctly, the data toggle bits for the endpoint can be left out of sync
- *   between host and device, which can have unpredictable results when the
- *   next data is sent on the endpoint, including data being silently lost.
- *   A call to \ref libusb_clear_halt will not resolve this situation, since
- *   that function uses the same request. Therefore, if your program runs on
- *   Darwin and uses a device that does not correctly implement
- *   \c ClearFeature(ENDPOINT_HALT) requests, it may only be safe to cancel
- *   transfers when followed by a device reset using
+ * - When built for macOS versions prior to 10.5, this function sends a
+ *   \c ClearFeature(ENDPOINT_HALT) request for the transfer's endpoint.
+ *   (Prior to libusb 1.0.27, this request was sent on all Darwin systems.)
+ *   If the device does not handle this request correctly, the data toggle
+ *   bits for the endpoint can be left out of sync between host and device,
+ *   which can have unpredictable results when the next data is sent on
+ *   the endpoint, including data being silently lost. A call to
+ *   \ref libusb_clear_halt will not resolve this situation, since that
+ *   function uses the same request. Therefore, if your program runs on
+ *   macOS < 10.5 (or libusb < 1.0.27), and uses a device that does not
+ *   correctly implement \c ClearFeature(ENDPOINT_HALT) requests, it may
+ *   only be safe to cancel transfers when followed by a device reset using
  *   \ref libusb_reset_device.
  *
  * \param transfer the transfer to cancel

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2263,15 +2263,17 @@ static int darwin_abort_transfers (struct usbi_transfer *itransfer) {
   /* abort transactions */
 #if InterfaceVersion >= 550
   if (LIBUSB_TRANSFER_TYPE_BULK_STREAM == transfer->type)
-    (*(cInterface->interface))->AbortStreamsPipe (cInterface->interface, pipeRef, itransfer->stream_id);
+    kresult = (*(cInterface->interface))->AbortStreamsPipe (cInterface->interface, pipeRef, itransfer->stream_id);
   else
 #endif
-    (*(cInterface->interface))->AbortPipe (cInterface->interface, pipeRef);
+    kresult = (*(cInterface->interface))->AbortPipe (cInterface->interface, pipeRef);
 
-  usbi_dbg (ctx, "calling clear pipe stall to clear the data toggle bit");
-
-  /* newer versions of darwin support clearing additional bits on the device's endpoint */
+#if InterfaceVersion <= 245
+  /* with older releases of IOUSBFamily the OS always clears the host side data toggle. for
+     consistency also clear the data toggle on the device. */
+  usbi_dbg (ctx, "calling ClearPipeStallBothEnds to clear the data toggle bit");
   kresult = (*(cInterface->interface))->ClearPipeStallBothEnds(cInterface->interface, pipeRef);
+#endif
 
   return darwin_to_libusb (kresult);
 }


### PR DESCRIPTION
Historically Mac OS X always cleared the data toggle on the host side. For
consistency, libusb has been calling ClearPipeStallBothEnds to also clear the
device side toggle. Newer versions of the IOUSBLib do not clear the host side
toggle so there is no need to make this call. Additionally, some buggy devices
may fail to correctly implement clearing the data toggle.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>