### PR TITLE
config: allow configure to continue without pkg-config installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,12 +181,14 @@ linux)
 		AC_CHECK_LIB([udev], [udev_new], [], [AC_MSG_ERROR([udev support requested but libudev not installed])])
 
 		# We can build umockdev tests (if available)
-		PKG_PROG_PKG_CONFIG
-		PKG_CHECK_MODULES(UMOCKDEV, umockdev-1.0 >= 0.16.0, ac_have_umockdev=yes, ac_have_umockdev=no)
-		PKG_CHECK_MODULES(UMOCKDEV_HOTPLUG, umockdev-1.0 >= 0.17.7, ac_umockdev_hotplug=yes, ac_umockdev_hotplug=no)
-		if test "x$ac_umockdev_hotplug" = xyes; then
-			AC_DEFINE([UMOCKDEV_HOTPLUG], [1], [UMockdev hotplug code is not racy])
-		fi
+		m4_ifdef([PKG_PROG_PKG_CONFIG],[
+			PKG_PROG_PKG_CONFIG
+		   	PKG_CHECK_MODULES([UMOCKDEV], [umockdev-1.0 >= 0.16.0], [ac_have_umockdev=yes], [ac_have_umockdev=no])
+		   	PKG_CHECK_MODULES([UMOCKDEV_HOTPLUG], [umockdev-1.0 >= 0.17.7], [ac_umockdev_hotplug=yes], [ac_umockdev_hotplug=no])
+			if test $ac_umockdev_hotplug = yes; then
+			   AC_DEFINE([UMOCKDEV_HOTPLUG], [1], [UMockdev hotplug code is not racy])
+			fi
+		], [])
 	else
 		AC_CHECK_HEADERS([asm/types.h])
 		AC_CHECK_HEADER([linux/netlink.h], [], [AC_MSG_ERROR([Linux netlink header not found])])

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11726
+#define LIBUSB_NANO 11727


### PR DESCRIPTION
libusb only uses pkg-config macros in configure to check for umockdev. Since
this is only required for testing it makes sense to protect the usage of these
macros to only be used when pkg-config is installed. This will be the case for
maintainers and testers.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>