### PR TITLE
libusbi.h: get rid of UNREFERENCED_PARAMETER

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -73,11 +73,7 @@
 #endif
 
 /* The following is used to silence warnings for unused variables */
-#if defined(UNREFERENCED_PARAMETER)
-#define UNUSED(var)	UNREFERENCED_PARAMETER(var)
-#else
 #define UNUSED(var)	do { (void)(var); } while(0)
-#endif
 
 /* Macro to align a value up to the next multiple of the size of a pointer */
 #define PTR_ALIGN(v) \


### PR DESCRIPTION
The way it's used in the code is incorrect. UNREFERENCED_PARAMETER evaluates to {(P) = (P);} and error with:
`error: lvalue required as left operand of assignment.`
because P is NULL _if logging is disabled_.
Just use standard C.