### PR TITLE
mark libusb_set_option as WINAPIV

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2183,7 +2183,7 @@ void API_EXPORTED libusb_set_log_cb(libusb_context *ctx, libusb_log_cb cb,
  * on this platform
  * \returns \ref LIBUSB_ERROR_NOT_FOUND if LIBUSB_OPTION_USE_USBDK is valid on this platform but UsbDk is not available
  */
-int API_EXPORTED libusb_set_option(libusb_context *ctx,
+int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 	enum libusb_option option, ...)
 {
 	int arg = 0, r = LIBUSB_SUCCESS;

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -120,8 +120,10 @@ typedef SSIZE_T ssize_t;
  */
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define LIBUSB_CALL WINAPI
+#define LIBUSB_CALLV WINAPIV
 #else
 #define LIBUSB_CALL
+#define LIBUSB_CALLV
 #endif /* _WIN32 || __CYGWIN__ */
 
 /** \def LIBUSB_API_VERSION
@@ -2132,7 +2134,7 @@ enum libusb_option {
 	LIBUSB_OPTION_MAX = 3
 };
 
-int LIBUSB_CALL libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);
+int LIBUSB_CALLV libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -128,6 +128,7 @@ typedef atomic_long usbi_atomic_t;
  *   return_type LIBUSB_CALL function_name(params);
  */
 #define API_EXPORTED LIBUSB_CALL DEFAULT_VISIBILITY
+#define API_EXPORTEDV LIBUSB_CALLV DEFAULT_VISIBILITY
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
WINAPI evaluates to __stdcall, which does not work with variadic
functions. MSVC and MinGW implicitly demote this to __cdecl. Instead of
having this implicit, make it explicit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>