### PR TITLE
libusb-1.0.def: remove LIBRARY

### DIFF
--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -1,4 +1,3 @@
-LIBRARY "libusb-1.0.dll"
 EXPORTS
   libusb_alloc_streams
   libusb_alloc_streams@16 = libusb_alloc_streams


### PR DESCRIPTION
Under MSYS2 and WrapDB, LIBRARY must be removed as otherwise proper linking
cannot take place.