### PR TITLE
JNI Android Support on Unrooted devices

### DIFF
--- a/android/config.h
+++ b/android/config.h
@@ -16,8 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-
-/* Define to the attribute for default visibility. */
+ /* Define to the attribute for default visibility. */
 #define DEFAULT_VISIBILITY __attribute__ ((visibility ("default")))
 
 /* Define to 1 to start with debug message logging enabled. */
@@ -32,14 +31,35 @@
 /* Define to 1 if you have the `clock_gettime' function. */
 #define HAVE_CLOCK_GETTIME 1
 
+/* Define to 1 if the system has eventfd functionality. */
+#define HAVE_EVENTFD 1
+
+/* Define to 1 if you have the `udev' library (-ludev). */
+/* #undef #define HAVE_LIBUDEV */
+
 /* Define to 1 if the system has the type `nfds_t'. */
 #define HAVE_NFDS_T 1
 
 /* Define to 1 if you have the `pipe2' function. */
 #define HAVE_PIPE2 1
 
+/* Define to 1 if you have the `pthread_condattr_setclock' function. */
+#define HAVE_PTHREAD_CONDATTR_SETCLOCK 1
+
+/* Define to 1 if you have the `pthread_setname_np' function. */
+#define HAVE_PTHREAD_SETNAME_NP 1
+
+/* Define to 1 if you have the `pthread_threadid_np' function. */
+#define HAVE_PTHREAD_THREADID_NP 1
+
+/* Define to 1 if you have the `syslog' function. */
+/* #undef HAVE_SYSLOG */
+
 /* Define to 1 if you have the <sys/time.h> header file. */
 #define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if the system has timerfd functionality. */
+#define HAVE_TIMERFD 1
 
 /* Define to 1 if compiling for a POSIX platform. */
 #define PLATFORM_POSIX 1

--- a/android/jni/libusb.mk
+++ b/android/jni/libusb.mk
@@ -34,7 +34,8 @@ LOCAL_SRC_FILES := \
   $(LIBUSB_ROOT_REL)/libusb/os/linux_usbfs.c \
   $(LIBUSB_ROOT_REL)/libusb/os/events_posix.c \
   $(LIBUSB_ROOT_REL)/libusb/os/threads_posix.c \
-  $(LIBUSB_ROOT_REL)/libusb/os/linux_netlink.c
+  $(LIBUSB_ROOT_REL)/libusb/os/linux_netlink.c \
+  $(LIBUSB_ROOT_REL)/libusb/os/linux_android_jni.c
 
 LOCAL_C_INCLUDES += \
   $(LOCAL_PATH)/.. \

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2233,11 +2233,13 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 		/* Handle all backend-specific options here */
 	case LIBUSB_OPTION_USE_USBDK:
 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+	case LIBUSB_OPTION_ANDROID_JNIENV:
+	case LIBUSB_OPTION_ANDROID_JAVAVM:
+		usbi_mutex_static_lock(&default_context_lock);
 		if (usbi_backend.set_option)
 			return usbi_backend.set_option(ctx, option, ap);
 
-		return LIBUSB_ERROR_NOT_SUPPORTED;
-		break;
+		return r;
 
 	default:
 		return LIBUSB_ERROR_INVALID_PARAM;

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -44,7 +44,7 @@ struct libusb_context *usbi_default_context;
 struct libusb_context *usbi_fallback_context;
 static int default_context_refcnt;
 static usbi_mutex_static_t default_context_lock = USBI_MUTEX_INITIALIZER;
-static struct usbi_option default_context_options[LIBUSB_OPTION_MAX];
+struct usbi_option default_context_options[LIBUSB_OPTION_MAX];
 
 
 usbi_mutex_static_t active_contexts_lock = USBI_MUTEX_INITIALIZER;

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2235,11 +2235,10 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
 	case LIBUSB_OPTION_ANDROID_JNIENV:
 	case LIBUSB_OPTION_ANDROID_JAVAVM:
-		usbi_mutex_static_lock(&default_context_lock);
 		if (usbi_backend.set_option)
 			return usbi_backend.set_option(ctx, option, ap);
 
-		return r;
+		return LIBUSB_ERROR_NOT_SUPPORTED;
 
 	default:
 		return LIBUSB_ERROR_INVALID_PARAM;

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -2131,7 +2131,52 @@ enum libusb_option {
 
 #define LIBUSB_OPTION_WEAK_AUTHORITY LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 
-	LIBUSB_OPTION_MAX = 3
+	/** Provide a JNIEnv* pointer for libusb to use on Android.  If this
+	 * pointer is nonzero, the Android SDK will be used for backend
+	 * functions that would otherwise require additional Java code to
+	 * ask for permission.  The pointer must be correct for the current
+	 * thread and process.
+	 *
+	 * This option should be set _before_ calling libusb_init(), and
+	 * specifies the java virtual machine only for new calls to
+	 * libusb_init() after the option is set.  The context pointer is
+	 * unused.
+	 *
+	 * When this option is set, the provided pointer is used for device
+	 * enumeration and connection for the entire lifetime of the libusb
+	 * context.  After connection, the normal linux backend is used via
+	 * the opened file descriptor.
+	 *
+	 * If a device does not have permission to connect, an Android Intent
+	 * is broadcast via UsbManager.requestPermission with action string
+	 * "libusb.android.USB_PERMISSION".  As documented in the Android
+	 * SDK, this Intent will have two "extras" indicating details of the
+	 * USB device in question, and whether or not the user granted
+	 * permission. The call to open the device returns LIBUSB_ERROR_ACCESS.
+	 *
+	 * Before a connection is made and the user provides permission for a
+	 * device, libusb generates fake descriptors for it from Android's API.
+	 * If these descriptors are used before connection, the correct ones
+	 * must be rerequested with an appropriate libusb API function, after
+	 * connection.
+	 *
+	 * A crash may happen if fork() is performed in a way Android doesn't
+	 * track, because the Application Context will no longer be valid.
+	 *
+	 * Only valid on Android.
+	 */
+	LIBUSB_OPTION_ANDROID_JNIENV = 3,
+
+	/** Like LIBUSB_OPTION_ANDROID_JNIENV, except a thread-agnostic JavaVM*
+	 * pointer is passed instead of a thread-specific JNIEnv* pointer.  If
+	 * you can pass a JavaVM* instead of a JNIEnv* pointer, the it does not
+	 * matter what thread it is passed from.
+	 *
+	 * Setting either option is equivalent.
+	 */
+	LIBUSB_OPTION_ANDROID_JAVAVM = 4,
+
+	LIBUSB_OPTION_MAX = 5
 };
 
 int LIBUSB_CALLV libusb_set_option(libusb_context *ctx, enum libusb_option option, ...);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -676,6 +676,15 @@ struct usbi_interface_descriptor {
 	uint8_t  iInterface;
 } LIBUSB_PACKED;
 
+struct usbi_endpoint_descriptor {
+	uint8_t  bLength;
+	uint8_t  bDescriptorType;
+	uint8_t  bEndpointAddress;
+	uint8_t  bmAttributes;
+	uint16_t wMaxPacketSize;
+	uint8_t  bInterval;
+} LIBUSB_PACKED;
+
 struct usbi_string_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;

--- a/libusb/os/linux_android_jni.c
+++ b/libusb/os/linux_android_jni.c
@@ -1,0 +1,998 @@
+/* -*- Mode: C; c-basic-offset:8 ; indent-tabs-mode:t -*- */
+/*
+ * Android jni interface for libusb
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "linux_android_jni.h"
+#include "libusb.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <jni.h>
+
+static int android_jni_env(struct android_jni_context *jni, JNIEnv **jni_env);
+static int android_jni_fill_ctx_ids(struct android_jni_context *jni,
+                                    JNIEnv *jni_env);
+static int android_jni_gen_epoint(struct android_jni_context *jni,
+                                  JNIEnv *jni_env, jobject endpoint,
+                                  uint8_t **descriptors, size_t *descriptors_len);
+static int android_jni_gen_iface(struct android_jni_context *jni, JNIEnv *jni_env,
+                                 jobject interface, uint8_t *num_ifaces,
+                                 uint8_t **descriptors, size_t *descriptors_len);
+static int android_jni_gen_config(struct android_jni_context *jni,
+                                  JNIEnv *jni_env, jobject config,
+                                  uint8_t **descriptors, size_t *descriptors_len);
+
+struct android_jni_context
+{
+	JavaVM *javavm;
+	pthread_key_t detach_pthread_key;
+
+	/* jobjects need global references */
+	jclass Intent, PendingIntent;
+
+	jobject PackageManager__FEATURE_USB_HOST;
+
+	jobject application_context;
+	jobject package_manager;
+	jobject usb_manager;
+
+	jstring permission_action;
+
+	/* ids do not need global references */
+	jmethodID Collection_iterator;
+	jmethodID HashMap_values;
+	jmethodID Iterator_hasNext, Iterator_next;
+
+	int Build__VERSION__SDK_INT;
+	int Build__VERSION_CODES__P;
+	jmethodID Intent_init;
+	jmethodID PackageManager_hasSystemFeature;
+	jmethodID PendingIntent__getBroadcast;
+	jmethodID UsbConfiguration_getInterfaceCount, UsbConfiguration_getId,
+	          UsbConfiguration_getName, UsbConfiguration_isSelfPowered,
+	          UsbConfiguration_isRemoteWakeup, UsbConfiguration_getMaxPower,
+	          UsbConfiguration_getInterface;
+	jmethodID UsbDevice_getDeviceId, UsbDevice_getConfigurationCount,
+	          UsbDevice_getVersion, UsbDevice_getDeviceClass,
+	          UsbDevice_getDeviceSubclass, UsbDevice_getDeviceProtocol,
+	          UsbDevice_getVendorId, UsbDevice_getProductId,
+	          UsbDevice_getManufacturerName, UsbDevice_getProductName,
+	          UsbDevice_getSerialNumber, UsbDevice_getConfiguration;
+	jmethodID UsbDeviceConnection_close, UsbDeviceConnection_getFileDescriptor,
+	          UsbDeviceConnection_getRawDescriptors;
+	jmethodID UsbEndpoint_getAddress, UsbEndpoint_getAttributes,
+	          UsbEndpoint_getMaxPacketSize, UsbEndpoint_getInterval;
+	jmethodID UsbInterface_getEndpointCount, UsbInterface_getId,
+	          UsbInterface_getAlternateSetting, UsbInterface_getInterfaceClass,
+	          UsbInterface_getInterfaceSubclass, UsbInterface_getInterfaceProtocol,
+	          UsbInterface_getName, UsbInterface_getEndpoint;
+	jmethodID UsbManager_getDeviceList, UsbManager_hasPermission,
+	          UsbManager_openDevice, UsbManager_requestPermission;
+};
+
+int android_jnienv_javavm(JNIEnv *jni_env, JavaVM **javavm)
+{
+	if (jni_env == NULL) {
+		*javavm = NULL;
+		return LIBUSB_SUCCESS;
+	}
+	return (*jni_env)->GetJavaVM(jni_env, javavm) == JNI_OK ?
+		LIBUSB_SUCCESS : LIBUSB_ERROR_OTHER;
+}
+
+int android_jni(JavaVM *javavm, struct android_jni_context **jni)
+{
+	int r;
+	JNIEnv *jni_env;
+
+	jclass ActivityThread, Context;
+	jmethodID ActivityThread__currentActivityThread, ActivityThread_getApplication;
+	jmethodID Context_getPackageManager, Context_getSystemService;
+	jobject activity_thread, Context__USB_SERVICE;
+	jobject local_context, local_pkg_mgr, local_usb_mgr;
+	jstring local_perm_act;
+
+	*jni = malloc(sizeof(struct android_jni_context));
+	if (*jni == NULL)
+		return LIBUSB_ERROR_NO_MEM;
+
+	(*jni)->javavm = javavm;
+
+	r = pthread_key_create(
+		&(*jni)->detach_pthread_key,
+		(void(*)(void*))(*javavm)->DetachCurrentThread);
+	if (r != 0) {
+		free(*jni);
+		return r == ENOMEM ? LIBUSB_ERROR_NO_MEM : LIBUSB_ERROR_OTHER;
+	}
+
+	r = android_jni_env(*jni, &jni_env);
+	if (r != LIBUSB_SUCCESS) {
+		free(*jni);
+		return r;
+	}
+
+	r = android_jni_fill_ctx_ids(*jni, jni_env);
+	if (r != LIBUSB_SUCCESS) {
+		free(*jni);
+		return r;
+	}
+
+	/* ActivityThread activity_thread = ActivityThread.currentActivityThread(); */
+	ActivityThread = (*jni_env)->FindClass(jni_env, "android/app/ActivityThread");
+	ActivityThread__currentActivityThread =
+		(*jni_env)->GetStaticMethodID(jni_env,
+			ActivityThread, "currentActivityThread",
+			"()Landroid/app/ActivityThread;");
+	ActivityThread_getApplication =
+		(*jni_env)->GetMethodID(jni_env,
+			ActivityThread, "getApplication", "()Landroid/app/Application;");
+	activity_thread =
+		(*jni_env)->CallStaticObjectMethod(jni_env,
+			ActivityThread, ActivityThread__currentActivityThread);
+
+	/* Context local_context = activity_thread.getApplication(); */
+	local_context =
+		(*jni_env)->CallObjectMethod(jni_env,
+			activity_thread, ActivityThread_getApplication);
+
+	(*jni)->application_context = (*jni_env)->NewGlobalRef(jni_env, local_context);
+
+
+	Context = (*jni_env)->FindClass(jni_env, "android/content/Context");
+	Context__USB_SERVICE =
+		(*jni_env)->GetStaticObjectField(jni_env,
+			Context,
+			(*jni_env)->GetStaticFieldID(jni_env,
+				Context, "USB_SERVICE", "Ljava/lang/String;"));
+	Context_getPackageManager =
+		(*jni_env)->GetMethodID(jni_env,
+			Context, "getPackageManager",
+			"()Landroid/content/pm/PackageManager;");
+	Context_getSystemService =
+		(*jni_env)->GetMethodID(jni_env,
+			Context, "getSystemService",
+			"(Ljava/lang/String;)Ljava/lang/Object;");
+
+	/* PackageManager local_pkg_mgr = application_context.getPackageManager(); */
+	local_pkg_mgr =
+		(*jni_env)->CallObjectMethod(jni_env,
+			(*jni)->application_context, Context_getPackageManager);
+
+	(*jni)->package_manager = (*jni_env)->NewGlobalRef(jni_env, local_pkg_mgr);
+
+	/* UsbManager local_usb_mgr =
+		application_context.getSystemService(Context.USB_SERVICE); */
+	local_usb_mgr =
+		(*jni_env)->CallObjectMethod(jni_env,
+			(*jni)->application_context, Context_getSystemService,
+			Context__USB_SERVICE);
+
+	(*jni)->usb_manager = (*jni_env)->NewGlobalRef(jni_env, local_usb_mgr);
+
+	/* String local_perm_act = "libusb.android.USB_PERMISSION"; */
+	local_perm_act = (*jni_env)->NewStringUTF(jni_env,
+		"libusb.android.USB_PERMISSION");
+
+	(*jni)->permission_action = (*jni_env)->NewGlobalRef(jni_env, local_perm_act);
+
+	(*jni_env)->DeleteLocalRef(jni_env, local_perm_act);
+	(*jni_env)->DeleteLocalRef(jni_env, local_usb_mgr);
+	(*jni_env)->DeleteLocalRef(jni_env, local_pkg_mgr);
+	(*jni_env)->DeleteLocalRef(jni_env, local_context);
+
+	(*jni_env)->DeleteLocalRef(jni_env, Context);
+	(*jni_env)->DeleteLocalRef(jni_env, Context__USB_SERVICE);
+	(*jni_env)->DeleteLocalRef(jni_env, ActivityThread);
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_free(struct android_jni_context *jni)
+{
+	int r;
+	JNIEnv *jni_env;
+	JavaVM *javavm = jni->javavm;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS) {
+		goto out;
+	}
+
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->Intent);
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->PendingIntent);
+
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->PackageManager__FEATURE_USB_HOST);
+
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->application_context);
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->package_manager);
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->usb_manager);
+
+	(*jni_env)->DeleteGlobalRef(jni_env, jni->permission_action);
+
+out:
+	if (pthread_getspecific(jni->detach_pthread_key) == javavm) {
+		(*javavm)->DetachCurrentThread(javavm);
+	}
+	pthread_key_delete(jni->detach_pthread_key);
+
+	free(jni);
+	return r;
+}
+
+int android_jni_detect_usbhost(struct android_jni_context *jni, int *has_usbhost)
+{
+	int r;
+	JNIEnv *jni_env;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* has_usbhost =
+		package_manager.hasSystemFeature(PackageManager.FEATURE_USB_HOST); */
+	*has_usbhost =
+		(*jni_env)->CallBooleanMethod(jni_env,
+			jni->package_manager, jni->PackageManager_hasSystemFeature,
+			jni->PackageManager__FEATURE_USB_HOST);
+
+	return LIBUSB_SUCCESS;
+}
+
+struct android_jni_devices
+{
+	struct android_jni_context *jni;
+	jobject iterator;
+};
+
+int android_jni_devices_alloc(struct android_jni_context *jni,
+	struct android_jni_devices **devices)
+{
+	int r;
+	JNIEnv *jni_env;
+	jobject deviceMap, deviceCollection, deviceIterator;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* HashMap<String, UsbDevice> deviceMap = usb_manager.getDeviceList(); */
+	deviceMap = (*jni_env)->CallObjectMethod(jni_env,
+		jni->usb_manager, jni->UsbManager_getDeviceList);
+
+	/* Collection<UsbDevice> deviceCollection = deviceMap.values(); */
+	deviceCollection = (*jni_env)->CallObjectMethod(jni_env,
+		deviceMap, jni->HashMap_values);
+
+	(*jni_env)->DeleteLocalRef(jni_env, deviceMap);
+
+	/* Iterator<UsbDevice> deviceIterator = deviceCollection.iterator(); */
+	deviceIterator = (*jni_env)->CallObjectMethod(jni_env,
+		deviceCollection, jni->Collection_iterator);
+
+	(*jni_env)->DeleteLocalRef(jni_env, deviceCollection);
+
+	*devices = malloc(sizeof(struct android_jni_devices));
+	if (*devices == NULL)
+		return LIBUSB_ERROR_NO_MEM;
+	(*devices)->jni = jni;
+	(*devices)->iterator = (*jni_env)->NewGlobalRef(jni_env, deviceIterator);
+
+	(*jni_env)->DeleteLocalRef(jni_env, deviceIterator);
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_devices_next(struct android_jni_devices *devices,
+	jobject *device, uint8_t *busnum, uint8_t *devaddr)
+{
+	struct android_jni_context *jni = devices->jni;
+	JNIEnv *jni_env;
+	jobject deviceIterator = devices->iterator;
+	jobject local_device;
+	uint16_t deviceid;
+	int r;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* if (!deviceIterator.hasNext()) */
+	if (!(*jni_env)->CallBooleanMethod(jni_env,
+			deviceIterator, jni->Iterator_hasNext))
+
+		return LIBUSB_ERROR_NOT_FOUND;
+
+	/* UsbDevice local_device = deviceIterator.next(); */
+	local_device =
+		(*jni_env)->CallObjectMethod(jni_env,
+			deviceIterator, jni->Iterator_next);
+
+	/* int deviceid = device.getDeviceId(); */
+	deviceid =
+		(*jni_env)->CallIntMethod(jni_env,
+			local_device, jni->UsbDevice_getDeviceId);
+
+	*device = (*jni_env)->NewGlobalRef(jni_env, local_device);
+	(*jni_env)->DeleteLocalRef(jni_env, local_device);
+
+	/* https://android.googlesource.com/platform/system/core/+/master/libusbhost/usbhost.c */
+	*busnum = deviceid / 1000;
+	*devaddr = deviceid % 1000;
+
+	return LIBUSB_SUCCESS;
+}
+
+void android_jni_devices_free(struct android_jni_devices *devices)
+{
+	struct android_jni_context *jni = devices->jni;
+	int r;
+	JNIEnv *jni_env;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r == LIBUSB_SUCCESS)
+		(*jni_env)->DeleteGlobalRef(jni_env, devices->iterator);
+
+	free(devices);
+}
+
+int android_jni_gen_descriptors(struct android_jni_context *jni, jobject device,
+	uint8_t **descriptors, size_t *descriptors_len)
+{
+	int r, num_configs, idx, version, tens, ones, tenths, hundredths;
+	JNIEnv *jni_env;
+	jobject config;
+	jstring jversion;
+	const char *sversion;
+	struct usbi_device_descriptor desc;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* int num_configs = device.getConfigurationCount(); */
+	num_configs =
+		(*jni_env)->CallIntMethod(jni_env,
+			device, jni->UsbDevice_getConfigurationCount);
+
+	*descriptors_len = LIBUSB_DT_DEVICE_SIZE;
+	*descriptors = malloc(*descriptors_len);
+	if (!*descriptors)
+		return LIBUSB_ERROR_NO_MEM;
+
+	/* parse binary coded decimal version */
+	/* String jversion = device.getVersion(); */
+	jversion =
+		(*jni_env)->CallObjectMethod(jni_env,
+			device, jni->UsbDevice_getVersion);
+
+	sversion = (*jni_env)->GetStringUTFChars(jni_env, jversion, NULL);
+	sscanf(sversion, "%d.%d", &ones, &hundredths);
+	(*jni_env)->ReleaseStringUTFChars(jni_env, jversion, sversion);
+
+	/* Android usb version bug was fixed in commit 608ec66d62647f60c3988922fead33fd7e07755e in Pie */
+	if (jni->Build__VERSION__SDK_INT < jni->Build__VERSION_CODES__P) {
+		/* undo pre-pie bug */
+		tenths = hundredths / 16;
+		hundredths = hundredths % 16;
+	} else {
+		/* bug has been fixed */
+		tenths = hundredths / 10;
+		hundredths = hundredths % 10;
+	}
+	tens = ones / 10;
+	ones = ones % 10;
+
+	version = hundredths | (tenths << 4) | (ones << 8) | (tens << 12);
+
+	desc = (struct usbi_device_descriptor){
+		.bLength = LIBUSB_DT_DEVICE_SIZE,
+		.bDescriptorType = LIBUSB_DT_DEVICE,
+		.bcdUSB = libusb_cpu_to_le16(version),
+		.bDeviceClass =
+			 (*jni_env)->CallIntMethod(jni_env,
+				device, jni->UsbDevice_getDeviceClass),
+		.bDeviceSubClass =
+			(*jni_env)->CallIntMethod(jni_env,
+				device, jni->UsbDevice_getDeviceSubclass),
+		.bDeviceProtocol =
+			(*jni_env)->CallIntMethod(jni_env,
+				device, jni->UsbDevice_getDeviceProtocol),
+		.bMaxPacketSize0 = 8,
+		.idVendor = libusb_cpu_to_le16(
+			(*jni_env)->CallIntMethod(jni_env,
+				device, jni->UsbDevice_getVendorId)),
+		.idProduct = libusb_cpu_to_le16(
+			(*jni_env)->CallIntMethod(jni_env,
+				device, jni->UsbDevice_getProductId)),
+		.bcdDevice = 0xFFFF,
+		.iManufacturer = 0,
+		.iProduct = 0,
+		.iSerialNumber = 0,
+		.bNumConfigurations = num_configs,
+	};
+	*(struct usbi_device_descriptor *)*descriptors = desc;
+
+	for (idx = 0; idx < num_configs; idx ++) {
+		/* UsbConfiguration config = device.getConfiguration(i); */
+		config =
+			(*jni_env)->CallObjectMethod(jni_env,
+				device, jni->UsbDevice_getConfiguration, idx);
+
+		r =
+			android_jni_gen_config(jni, jni_env, config,
+				descriptors, descriptors_len);
+
+		(*jni_env)->DeleteLocalRef(jni_env, config);
+
+		if (r != LIBUSB_SUCCESS)
+			return r;
+	}
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_detect_permission(struct android_jni_context *jni, jobject device,
+	int *has_permission)
+{
+	int r;
+	JNIEnv *jni_env;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* boolean has_permission = usb_manager.hasPermission(device); */
+	*has_permission =
+		(*jni_env)->CallBooleanMethod(jni_env,
+			jni->usb_manager, jni->UsbManager_hasPermission, device);
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_request_permission(struct android_jni_context *jni,
+	jobject device)
+{
+	int r;
+	JNIEnv *jni_env;
+	jobject intent, permission_intent;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* Intent intent = new Intent(permission_action); */
+	intent =
+		(*jni_env)->NewObject(jni_env,
+			jni->Intent, jni->Intent_init,
+			jni->permission_action);
+
+	/* PendingIntent permission_intent =
+		PendingIntent.getBroadcast(application_context, 0, intent, 0); */
+	permission_intent =
+		(*jni_env)->CallStaticObjectMethod(jni_env,
+			jni->PendingIntent, jni->PendingIntent__getBroadcast,
+			jni->application_context, 0, intent, 0);
+
+	(*jni_env)->DeleteLocalRef(jni_env, intent);
+
+	/* usb_manager.requestPermission(device, permission_intent); */
+	(*jni_env)->CallVoidMethod(jni_env,
+		jni->usb_manager, jni->UsbManager_requestPermission,
+		device, permission_intent);
+
+	(*jni_env)->DeleteLocalRef(jni_env, permission_intent);
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_connect(struct android_jni_context *jni,
+	jobject device, jobject *connection,
+	int *fd, uint8_t **descriptors, size_t *descriptors_len)
+{
+	int has_permission, r;
+	JNIEnv *jni_env;
+	jobject local_connection;
+	jbyteArray local_descriptors;
+	jbyte * local_descriptors_ptr;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	r = android_jni_detect_permission(jni, device, &has_permission);
+
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	if (!has_permission)
+		return LIBUSB_ERROR_ACCESS;
+
+	/* UsbDeviceConnection local_connection = usb_manager.openDevice(device); */
+	local_connection =
+		(*jni_env)->CallObjectMethod(jni_env,
+			jni->usb_manager, jni->UsbManager_openDevice, device);
+
+	/* fd output */
+	/* fd = local_connection.getFileDescriptor(); */
+	*fd =
+		(*jni_env)->CallIntMethod(jni_env,
+			local_connection, jni->UsbDeviceConnection_getFileDescriptor);
+
+	if (*fd == -1) {
+		(*jni_env)->DeleteLocalRef(jni_env, local_connection);
+		return LIBUSB_ERROR_IO;
+	}
+
+	/* byte[] local_descriptors = local_connection.getRawDescriptors(); */
+	local_descriptors =
+		(*jni_env)->CallObjectMethod(jni_env,
+			local_connection, jni->UsbDeviceConnection_getRawDescriptors);
+
+	/* descriptors buffer output */
+	*descriptors_len = (*jni_env)->GetArrayLength(jni_env, local_descriptors);
+	*descriptors = malloc(*descriptors_len);
+	if (!*descriptors) {
+		(*jni_env)->DeleteLocalRef(jni_env, local_descriptors);
+		(*jni_env)->DeleteLocalRef(jni_env, local_connection);
+		return LIBUSB_ERROR_NO_MEM;
+	}
+
+	/* jni buffer copy */
+	local_descriptors_ptr =
+		(*jni_env)->GetPrimitiveArrayCritical(jni_env, local_descriptors, NULL);
+	memcpy(*descriptors, local_descriptors_ptr, *descriptors_len);
+	(*jni_env)->ReleasePrimitiveArrayCritical(jni_env,
+		local_descriptors, local_descriptors_ptr, JNI_ABORT);
+
+	/* connection jobject output */
+	*connection = (*jni_env)->NewGlobalRef(jni_env, local_connection);
+
+	(*jni_env)->DeleteLocalRef(jni_env, local_descriptors);
+	(*jni_env)->DeleteLocalRef(jni_env, local_connection);
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_disconnect(struct android_jni_context *jni, jobject connection)
+{
+	int r;
+	JNIEnv *jni_env;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	/* connection.close(); */
+	(*jni_env)->CallVoidMethod(jni_env,
+		connection, jni->UsbDeviceConnection_close);
+
+	(*jni_env)->DeleteGlobalRef(jni_env, connection);
+	return LIBUSB_SUCCESS;
+}
+
+void android_jni_globalunref(struct android_jni_context *jni, jobject object)
+{
+	int r;
+	JNIEnv *jni_env;
+
+	r = android_jni_env(jni, &jni_env);
+	if (r != LIBUSB_SUCCESS)
+		return;
+
+	(*jni_env)->DeleteGlobalRef(jni_env, object);
+}
+
+static int android_jni_gen_config(struct android_jni_context *jni,
+	JNIEnv *jni_env, jobject config,
+	uint8_t **descriptors, size_t *descriptors_len)
+{
+	int r;
+	size_t num_ifaces, offset, idx;
+	struct usbi_configuration_descriptor desc;
+
+	/* int num_ifaces = config.getInterfaceCount(); */
+	num_ifaces =
+		(*jni_env)->CallIntMethod(jni_env,
+			config, jni->UsbConfiguration_getInterfaceCount);
+
+	offset = *descriptors_len;
+	*descriptors_len = offset + LIBUSB_DT_CONFIG_SIZE;
+	*descriptors = usbi_reallocf(*descriptors, *descriptors_len);
+	if (!*descriptors)
+		return LIBUSB_ERROR_NO_MEM;
+
+	desc = (struct usbi_configuration_descriptor){
+		.bLength = LIBUSB_DT_CONFIG_SIZE,
+		.bDescriptorType = LIBUSB_DT_CONFIG,
+		.wTotalLength = 0, /* assigned below */
+		.bNumInterfaces = 0, /* assigned within interfaces */
+		.bConfigurationValue =
+			(*jni_env)->CallIntMethod(jni_env,
+				config, jni->UsbConfiguration_getId),
+		.iConfiguration = 0,
+		.bmAttributes = 0x80 |
+			((*jni_env)->CallBooleanMethod(jni_env,
+				config, jni->UsbConfiguration_isSelfPowered)
+			 ? 0x40 : 0) |
+			((*jni_env)->CallBooleanMethod(jni_env,
+				config, jni->UsbConfiguration_isRemoteWakeup)
+			 ? 0x20 : 0),
+		.bMaxPower =
+			(*jni_env)->CallIntMethod(jni_env,
+				config, jni->UsbConfiguration_getMaxPower) / 2
+	};
+	if (desc.iConfiguration < 0)
+		return desc.iConfiguration;
+
+	for (idx = 0; idx < num_ifaces; ++ idx) {
+		/* UsbInterface interface = config.getInterface(idx); */
+		jobject interface = (*jni_env)->CallObjectMethod(jni_env,
+			config, jni->UsbConfiguration_getInterface, idx);
+
+		r = android_jni_gen_iface(jni,
+			jni_env, interface, &desc.bNumInterfaces,
+			descriptors, descriptors_len);
+
+		(*jni_env)->DeleteLocalRef(jni_env, interface);
+
+		if (r != LIBUSB_SUCCESS)
+			return r;
+	}
+
+	desc.wTotalLength = libusb_cpu_to_le16(*descriptors_len - offset);
+	*(struct usbi_configuration_descriptor *)(*descriptors + offset) = desc;
+
+	return LIBUSB_SUCCESS;
+}
+
+int android_jni_gen_iface(struct android_jni_context *jni,
+	JNIEnv *jni_env, jobject interface, uint8_t *num_ifaces,
+	uint8_t **descriptors, size_t *descriptors_len)
+{
+	int r;
+	size_t num_epoints, offset, idx;
+	struct usbi_interface_descriptor desc;
+
+	/* int num_epoints = interface.getEndpointCount(); */
+	num_epoints =
+		(*jni_env)->CallIntMethod(jni_env,
+			interface, jni->UsbInterface_getEndpointCount);
+
+	offset = *descriptors_len;
+	*descriptors_len = offset + LIBUSB_DT_INTERFACE_SIZE;
+	*descriptors = usbi_reallocf(*descriptors, *descriptors_len);
+	if (!*descriptors)
+		return LIBUSB_ERROR_NO_MEM;
+
+	desc = (struct usbi_interface_descriptor){
+		.bLength = LIBUSB_DT_INTERFACE_SIZE,
+		.bDescriptorType = LIBUSB_DT_INTERFACE,
+		.bInterfaceNumber =
+			(*jni_env)->CallIntMethod(jni_env,
+				interface, jni->UsbInterface_getId),
+		.bAlternateSetting =
+			(*jni_env)->CallIntMethod(jni_env,
+				interface, jni->UsbInterface_getAlternateSetting),
+		.bNumEndpoints = num_epoints,
+		.bInterfaceClass =
+			(*jni_env)->CallIntMethod(jni_env,
+				interface, jni->UsbInterface_getInterfaceClass),
+		.bInterfaceSubClass =
+			(*jni_env)->CallIntMethod(jni_env,
+				interface, jni->UsbInterface_getInterfaceSubclass),
+		.bInterfaceProtocol =
+			(*jni_env)->CallIntMethod(jni_env,
+				interface, jni->UsbInterface_getInterfaceProtocol),
+		.iInterface = 0
+	};
+	*(struct usbi_interface_descriptor *)(*descriptors + offset) = desc;
+
+	if (desc.bInterfaceNumber >= *num_ifaces)
+		*num_ifaces = desc.bInterfaceNumber + 1;
+
+	for (idx = 0; idx < num_epoints; idx ++) {
+		/* UsbEndpoint endpoint = interface.getEndpoint(idx); */
+		jobject endpoint =
+			(*jni_env)->CallObjectMethod(jni_env,
+				interface, jni->UsbInterface_getEndpoint, idx);
+
+		r =
+			android_jni_gen_epoint(jni,
+				jni_env, endpoint,
+				descriptors, descriptors_len);
+
+		(*jni_env)->DeleteLocalRef(jni_env, endpoint);
+
+		if (r != LIBUSB_SUCCESS)
+			return r;
+	}
+	return LIBUSB_SUCCESS;
+}
+
+static int android_jni_gen_epoint(struct android_jni_context *jni,
+	JNIEnv *jni_env, jobject endpoint,
+	uint8_t **descriptors, size_t *descriptors_len)
+{
+	size_t offset;
+	struct usbi_endpoint_descriptor desc;
+
+	offset = *descriptors_len;
+	*descriptors_len = offset + LIBUSB_DT_ENDPOINT_SIZE;
+	*descriptors = usbi_reallocf(*descriptors, *descriptors_len);
+	if (!*descriptors)
+		return LIBUSB_ERROR_NO_MEM;
+
+	desc = (struct usbi_endpoint_descriptor){
+		.bLength = LIBUSB_DT_ENDPOINT_SIZE,
+		.bDescriptorType = LIBUSB_DT_ENDPOINT,
+		.bEndpointAddress =
+			(*jni_env)->CallIntMethod(jni_env,
+				endpoint, jni->UsbEndpoint_getAddress),
+		.bmAttributes =
+			(*jni_env)->CallIntMethod(jni_env,
+				endpoint, jni->UsbEndpoint_getAttributes),
+		.wMaxPacketSize = libusb_cpu_to_le16(
+			(*jni_env)->CallIntMethod(jni_env,
+				endpoint, jni->UsbEndpoint_getMaxPacketSize)),
+		.bInterval =
+			(*jni_env)->CallIntMethod(jni_env,
+				endpoint, jni->UsbEndpoint_getInterval)
+	};
+	*(struct usbi_endpoint_descriptor *)(*descriptors + offset) = desc;
+
+	return LIBUSB_SUCCESS;
+}
+
+static int android_jni_fill_ctx_ids(struct android_jni_context *jni,
+	JNIEnv *jni_env)
+{
+	jclass Collection, HashMap, Iterator;
+	jclass Build__VERSION, Intent, PackageManager, PendingIntent,
+		UsbConfiguration, UsbDevice, UsbDeviceConnection, UsbEndpoint,
+		UsbInterface, UsbManager;
+
+	jobject PackageManager__FEATURE_USB_HOST;
+
+	Collection = (*jni_env)->FindClass(jni_env, "java/util/Collection");
+	jni->Collection_iterator =
+		(*jni_env)->GetMethodID(jni_env,
+			Collection, "iterator", "()Ljava/util/Iterator;");
+
+	HashMap = (*jni_env)->FindClass(jni_env, "java/util/HashMap");
+	jni->HashMap_values =
+		(*jni_env)->GetMethodID(jni_env,
+			HashMap, "values", "()Ljava/util/Collection;");
+
+	Iterator = (*jni_env)->FindClass(jni_env, "java/util/Iterator");
+	jni->Iterator_hasNext =
+		(*jni_env)->GetMethodID(jni_env, Iterator, "hasNext", "()Z");
+	jni->Iterator_next =
+		(*jni_env)->GetMethodID(jni_env,
+			Iterator, "next", "()Ljava/lang/Object;");
+
+	Build__VERSION = (*jni_env)->FindClass(jni_env, "android/os/Build$VERSION");
+	jni->Build__VERSION__SDK_INT =
+		(*jni_env)->GetStaticIntField(jni_env,
+			Build__VERSION,
+			(*jni_env)->GetStaticFieldID(jni_env,
+				Build__VERSION, "SDK_INT", "I"));
+	jni->Build__VERSION_CODES__P = 28;
+
+	Intent = (*jni_env)->FindClass(jni_env, "android/content/Intent");
+	jni->Intent = (*jni_env)->NewGlobalRef(jni_env, Intent);
+	jni->Intent_init =
+		(*jni_env)->GetMethodID(jni_env,
+			jni->Intent, "<init>", "(Ljava/lang/String;)V");
+
+	PackageManager =
+		(*jni_env)->FindClass(jni_env, "android/content/pm/PackageManager");
+	PackageManager__FEATURE_USB_HOST =
+		(*jni_env)->GetStaticObjectField(jni_env,
+			PackageManager,
+			(*jni_env)->GetStaticFieldID(jni_env,
+				PackageManager, "FEATURE_USB_HOST", "Ljava/lang/String;"));
+	jni->PackageManager__FEATURE_USB_HOST =
+		(*jni_env)->NewGlobalRef(jni_env, PackageManager__FEATURE_USB_HOST);
+	jni->PackageManager_hasSystemFeature =
+		(*jni_env)->GetMethodID(jni_env,
+			PackageManager, "hasSystemFeature", "(Ljava/lang/String;)Z");
+
+	PendingIntent =
+		(*jni_env)->FindClass(jni_env, "android/app/PendingIntent");
+	jni->PendingIntent = (*jni_env)->NewGlobalRef(jni_env, PendingIntent);
+	jni->PendingIntent__getBroadcast =
+		(*jni_env)->GetStaticMethodID(jni_env,
+			jni->PendingIntent, "getBroadcast",
+			"(Landroid/content/Context;ILandroid/content/Intent;I)" /**/
+			"Landroid/app/PendingIntent;");
+
+	UsbConfiguration =
+		(*jni_env)->FindClass(jni_env, "android/hardware/usb/UsbConfiguration");
+	jni->UsbConfiguration_getInterfaceCount =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "getInterfaceCount", "()I");
+	jni->UsbConfiguration_getId =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "getId", "()I");
+	jni->UsbConfiguration_getName =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "getName", "()Ljava/lang/String;");
+	jni->UsbConfiguration_isSelfPowered =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "isSelfPowered", "()Z");
+	jni->UsbConfiguration_isRemoteWakeup =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "isRemoteWakeup", "()Z");
+	jni->UsbConfiguration_getMaxPower =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "getMaxPower", "()I");
+	jni->UsbConfiguration_getInterface =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbConfiguration, "getInterface",
+			"(I)Landroid/hardware/usb/UsbInterface;");
+
+	UsbDevice =
+		(*jni_env)->FindClass(jni_env, "android/hardware/usb/UsbDevice");
+	jni->UsbDevice_getDeviceId =
+		(*jni_env)->GetMethodID(jni_env, UsbDevice, "getDeviceId", "()I");
+	jni->UsbDevice_getConfigurationCount =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getConfigurationCount", "()I");
+	jni->UsbDevice_getVersion =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getVersion", "()Ljava/lang/String;");
+	jni->UsbDevice_getDeviceClass =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getDeviceClass", "()I");
+	jni->UsbDevice_getDeviceSubclass =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getDeviceSubclass", "()I");
+	jni->UsbDevice_getDeviceProtocol =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getDeviceProtocol", "()I");
+	jni->UsbDevice_getVendorId =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getVendorId", "()I");
+	jni->UsbDevice_getProductId =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getProductId", "()I");
+	jni->UsbDevice_getManufacturerName =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getManufacturerName", "()Ljava/lang/String;");
+	jni->UsbDevice_getProductName =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getProductName", "()Ljava/lang/String;");
+	jni->UsbDevice_getSerialNumber =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getSerialNumber", "()Ljava/lang/String;");
+	jni->UsbDevice_getConfiguration =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDevice, "getConfiguration",
+			"(I)Landroid/hardware/usb/UsbConfiguration;");
+
+	UsbDeviceConnection =
+		(*jni_env)->FindClass(jni_env,
+			"android/hardware/usb/UsbDeviceConnection");
+	jni->UsbDeviceConnection_close =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDeviceConnection, "close", "()V");
+	jni->UsbDeviceConnection_getFileDescriptor =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDeviceConnection, "getFileDescriptor", "()I");
+	jni->UsbDeviceConnection_getRawDescriptors =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbDeviceConnection, "getRawDescriptors", "()[B");
+
+	UsbEndpoint =
+		(*jni_env)->FindClass(jni_env, "android/hardware/usb/UsbEndpoint");
+	jni->UsbEndpoint_getAddress =
+		(*jni_env)->GetMethodID(jni_env, UsbEndpoint, "getAddress", "()I");
+	jni->UsbEndpoint_getAttributes =
+		(*jni_env)->GetMethodID(jni_env, UsbEndpoint, "getAttributes", "()I");
+	jni->UsbEndpoint_getMaxPacketSize =
+		(*jni_env)->GetMethodID(jni_env, UsbEndpoint, "getMaxPacketSize", "()I");
+	jni->UsbEndpoint_getInterval =
+		(*jni_env)->GetMethodID(jni_env, UsbEndpoint, "getInterval", "()I");
+
+	UsbInterface =
+		(*jni_env)->FindClass(jni_env, "android/hardware/usb/UsbInterface");
+	jni->UsbInterface_getEndpointCount =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getEndpointCount", "()I");
+	jni->UsbInterface_getId =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getId", "()I");
+	jni->UsbInterface_getAlternateSetting =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getAlternateSetting", "()I");
+	jni->UsbInterface_getInterfaceClass =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getInterfaceClass", "()I");
+	jni->UsbInterface_getInterfaceSubclass =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getInterfaceSubclass", "()I");
+	jni->UsbInterface_getInterfaceProtocol =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getInterfaceProtocol", "()I");
+	jni->UsbInterface_getName =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getName", "()Ljava/lang/String;");
+	jni->UsbInterface_getEndpoint =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbInterface, "getEndpoint",
+			"(I)Landroid/hardware/usb/UsbEndpoint;");
+
+	UsbManager =
+		(*jni_env)->FindClass(jni_env, "android/hardware/usb/UsbManager");
+	jni->UsbManager_getDeviceList =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbManager, "getDeviceList", "()Ljava/util/HashMap;");
+	jni->UsbManager_hasPermission =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbManager, "hasPermission", "(Landroid/hardware/usb/UsbDevice;)Z");
+	jni->UsbManager_openDevice =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbManager, "openDevice",
+			"(Landroid/hardware/usb/UsbDevice;)" /**/
+			"Landroid/hardware/usb/UsbDeviceConnection;");
+	jni->UsbManager_requestPermission =
+		(*jni_env)->GetMethodID(jni_env,
+			UsbManager, "requestPermission",
+			"(Landroid/hardware/usb/UsbDevice;Landroid/app/PendingIntent;)V");
+
+	(*jni_env)->DeleteLocalRef(jni_env, UsbManager);
+	(*jni_env)->DeleteLocalRef(jni_env, UsbInterface);
+	(*jni_env)->DeleteLocalRef(jni_env, UsbEndpoint);
+	(*jni_env)->DeleteLocalRef(jni_env, UsbDeviceConnection);
+	(*jni_env)->DeleteLocalRef(jni_env, UsbDevice);
+	(*jni_env)->DeleteLocalRef(jni_env, UsbConfiguration);
+	(*jni_env)->DeleteLocalRef(jni_env, PendingIntent);
+	(*jni_env)->DeleteLocalRef(jni_env, PackageManager__FEATURE_USB_HOST);
+	(*jni_env)->DeleteLocalRef(jni_env, PackageManager);
+	(*jni_env)->DeleteLocalRef(jni_env, Intent);
+	(*jni_env)->DeleteLocalRef(jni_env, Build__VERSION);
+
+	(*jni_env)->DeleteLocalRef(jni_env, Iterator);
+	(*jni_env)->DeleteLocalRef(jni_env, HashMap);
+	(*jni_env)->DeleteLocalRef(jni_env, Collection);
+	return LIBUSB_SUCCESS;
+}
+
+static int android_jni_env(struct android_jni_context *jni, JNIEnv **jni_env)
+{
+	JavaVM *javavm = jni->javavm;
+	int status = (*javavm)->GetEnv(javavm, (void**)jni_env, JNI_VERSION_1_1);
+	if (status == JNI_EDETACHED) {
+		JavaVMAttachArgs thr_args = {
+			.version = JNI_VERSION_1_6,
+			.name = NULL,
+			.group = NULL
+		};
+		status = (*javavm)->AttachCurrentThread(javavm, jni_env, &thr_args);
+		if (status == JNI_OK) {
+			status = pthread_setspecific(jni->detach_pthread_key, javavm);
+			if (status == ENOMEM)
+				return LIBUSB_ERROR_NO_MEM;
+		}
+	}
+	return status == 0 ? LIBUSB_SUCCESS : LIBUSB_ERROR_OTHER;
+}

--- a/libusb/os/linux_android_jni.h
+++ b/libusb/os/linux_android_jni.h
@@ -1,0 +1,113 @@
+/*
+ * android_jni interface
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef LIBUSB_ANDROID_JNI_H
+#define LIBUSB_ANDROID_JNI_H
+
+#include "libusbi.h"
+
+struct android_jni_context;
+struct android_jni_devices;
+
+/* from jni.h */
+typedef const struct JNINativeInterface *JNIEnv;
+typedef const struct JNIInvokeInterface *JavaVM;
+typedef void *jobject;
+
+/* All the functions in this file return a libusb error code. */
+
+/* Converts a jni_env pointer to a javavm pointer, for utility. */
+int android_jnienv_javavm(JNIEnv *jni_env, JavaVM **javavm);
+
+/* Prepares to use android jni calls.
+ *
+ * The jni structure should be freed with android_jni_free().
+ *
+ * It's possible to automatically find a running java vm without the user
+ * providing one, but it appears unreasonably difficult to do this until an ndk
+ * issue is resolved: https://github.com/android/ndk/issues/1320
+ */
+int android_jni(JavaVM *javavm, struct android_jni_context **jni);
+
+/* Frees this android jni structure. */
+int android_jni_free(struct android_jni_context *jni);
+
+/* Detects whether or not the platform supports usb host mode. */
+int android_jni_detect_usbhost(struct android_jni_context *jni,
+                               int *has_usbhost);
+
+/* Prepares to iterate all connected devices. */
+int android_jni_devices_alloc(struct android_jni_context *jni,
+                              struct android_jni_devices **devices);
+
+/* Iterates through connected devices.
+ *
+ * The device jobject should be freed with android_jni_globalunref().
+ *
+ * Returns LIBUSB_ERROR_NOT_FOUND when all devices have been enumerated.
+ */
+int android_jni_devices_next(struct android_jni_devices *devices,
+                             jobject *device, uint8_t *busnum, uint8_t *devaddr);
+
+/* Frees a device iteration structure. */
+void android_jni_devices_free(struct android_jni_devices *devices);
+
+/* Generates descriptors for a device witout connecting to it.  The descriptors
+ * are generated from the information available in the android api, which
+ * itself is generated from the real descriptors but does not quite include
+ * everything.
+ *
+ * The descriptors buffers should be freed with free().
+ */
+int android_jni_gen_descriptors(struct android_jni_context *jni, jobject device,
+                                uint8_t **descriptors, size_t *descriptors_len);
+
+/* Detects whether or not the application has permission to connect to a device. */
+int android_jni_detect_permission(struct android_jni_context *jni, jobject device,
+                                  int *has_permission);
+
+/* Requests permission from the user to connect to a device.
+ *
+ * This calls UsbManager.requestPermission, which pauses the running activity
+ * and pops up a system dialogue asking for permission, then resumes the
+ * activity and broadcasts an intent with the device and the user's response.
+ * The intent will have action "libusb.android.USB_PERMISSION".
+ *
+ * For further information on this intent, see:
+ * https://developer.android.com/guide/topics/connectivity/usb/host#permission-d
+ */
+int android_jni_request_permission(struct android_jni_context *jni, jobject device);
+
+/* Connects to a device.
+ *
+ * The connection jobject should be freed with android_jni_disconnect().
+ *
+ * The descriptors buffer should be freed with free().
+ *
+ * If permission is needed, LIBUSB_ERROR_ACCESS is returned.
+ */
+int android_jni_connect(struct android_jni_context *jni, jobject device, jobject *connection,
+                        int *fd, uint8_t **descriptors, size_t *descriptors_len);
+
+/* Disconnects from a device and frees connection object. */
+int android_jni_disconnect(struct android_jni_context *jni, jobject connection);
+
+/* Frees a global reference to an object. */
+void android_jni_globalunref(struct android_jni_context *jni, jobject object);
+
+#endif

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -437,6 +437,7 @@ static void op_exit(struct libusb_context *ctx)
 static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
 {
 	UNUSED(ctx);
+	UNUSED(option);
 	UNUSED(ap);
 
 	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY) {

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -482,7 +482,8 @@ static void op_exit(struct libusb_context *ctx)
 
 static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
 {
-	if (NULL != ctx) {
+	/* ensure ctx is not active yet */
+	if (ctx->list.next != NULL) {
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -38,6 +38,10 @@
 #include <sys/vfs.h>
 #include <unistd.h>
 
+#ifdef __ANDROID__
+#include "linux_android_jni.h"
+#endif
+
 /* sysfs vs usbfs:
  * opening a usbfs node causes the device to be resumed, so we attempt to
  * avoid this during enumeration.
@@ -95,6 +99,12 @@ static int sysfs_available = -1;
 /* how many times have we initted (and not exited) ? */
 static int init_count = 0;
 
+#ifdef __ANDROID__
+static int android_jni_scan_devices(struct libusb_context *ctx);
+
+JavaVM* javaVm = NULL;
+#endif
+
 /* have no authority to operate usb device directly */
 static int no_enumeration = 0;
 
@@ -103,6 +113,7 @@ usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
 
 static int linux_scan_devices(struct libusb_context *ctx);
 static int detach_kernel_driver_and_claim(struct libusb_device_handle *, uint8_t);
+static int parse_config_descriptors(struct libusb_device *dev);
 
 #if !defined(HAVE_LIBUDEV)
 static int linux_default_scan_devices(struct libusb_context *ctx);
@@ -122,6 +133,10 @@ struct config_descriptor {
 struct linux_context_priv {
 	/* have no authority to operate usb device directly */
 	int no_device_discovery;
+#ifdef __ANDROID__
+	/* android java context */
+	struct android_jni_context *android_jni;
+#endif
 };
 
 struct linux_device_priv {
@@ -130,6 +145,9 @@ struct linux_device_priv {
 	size_t descriptors_len;
 	struct config_descriptor *config_descriptors;
 	int active_config; /* cache val for !sysfs_available  */
+#ifdef __ANDROID__
+	jobject android_jni_device;
+#endif
 };
 
 struct linux_device_handle_priv {
@@ -137,6 +155,9 @@ struct linux_device_handle_priv {
 	int fd_removed;
 	int fd_keep;
 	uint32_t caps;
+#ifdef __ANDROID__
+	jobject android_jni_connection;
+#endif
 };
 
 enum reap_action {
@@ -358,7 +379,7 @@ static int op_init(struct libusb_context *ctx)
 {
 	struct kernel_version kversion;
 	const char *usbfs_path;
-	int r;
+	int r = LIBUSB_SUCCESS;
 	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
 
 	if (get_kernel_version(ctx, &kversion) < 0)
@@ -404,9 +425,20 @@ static int op_init(struct libusb_context *ctx)
 	}
 
 	cpriv->no_device_discovery = no_enumeration;
-	if (no_enumeration) {
-		return LIBUSB_SUCCESS;
+
+#ifdef __ANDROID__
+	if (javaVm != NULL) {
+		r = android_jni(
+			(JavaVM*)javaVm,
+			&cpriv->android_jni);
+		if (r != LIBUSB_SUCCESS)
+			return r;
+		return android_jni_scan_devices(ctx);
 	}
+#endif
+
+	if (cpriv->no_device_discovery)
+		return LIBUSB_SUCCESS;
 
 	r = LIBUSB_SUCCESS;
 	if (init_count == 0) {
@@ -430,6 +462,13 @@ static void op_exit(struct libusb_context *ctx)
 {
 	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
 
+#ifdef __ANDROID__
+	if (cpriv->android_jni != NULL) {
+		android_jni_free(cpriv->android_jni);
+		return;
+	}
+#endif
+
 	if (cpriv->no_device_discovery) {
 		return;
 	}
@@ -443,9 +482,24 @@ static void op_exit(struct libusb_context *ctx)
 
 static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
 {
-	UNUSED(ctx);
-	UNUSED(option);
+	if (NULL != ctx) {
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+	}
+
+#ifdef __ANDROID__
+	if (option == LIBUSB_OPTION_ANDROID_JNIENV) {
+		JNIEnv * jni_env = va_arg(ap, JNIEnv *);
+		int r = android_jnienv_javavm(jni_env, &javaVm);
+		usbi_dbg(ctx, "set default jnienv javavm %p %p", jni_env, javaVm);
+		return r;
+	} else if (option == LIBUSB_OPTION_ANDROID_JAVAVM) {
+		javaVm = va_arg(ap, JavaVM *);
+		usbi_dbg(ctx, "set default javavm %p", javaVm);
+		return LIBUSB_SUCCESS;
+	}
+#else
 	UNUSED(ap);
+#endif
 
 	if (option == LIBUSB_OPTION_NO_DEVICE_DISCOVERY) {
 		usbi_dbg(ctx, "no enumeration will be performed");
@@ -453,8 +507,130 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 		return LIBUSB_SUCCESS;
 	}
 
-	return LIBUSB_ERROR_NOT_SUPPORTED;
+#ifdef __ANDROID__
+
+static int android_jni_scan_devices(struct libusb_context *ctx)
+{
+	/* Access and use the Android API via jni_env */
+
+	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
+	int r, has_usbhost;
+
+	struct android_jni_devices *devices;
+	jobject device;
+	uint8_t busnum, devaddr;
+
+	r = android_jni_detect_usbhost(cpriv->android_jni, &has_usbhost);
+
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	if (!has_usbhost) {
+		usbi_dbg(ctx, "This device does not have the android.hardware.usb.host feature");
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+	}
+
+	usbi_dbg(ctx, "enumerating usb devices using android api");
+
+	r = android_jni_devices_alloc(cpriv->android_jni, &devices);
+
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	while (LIBUSB_SUCCESS ==
+		android_jni_devices_next(devices, &device, &busnum, &devaddr))
+	{
+
+		if (linux_enumerate_device(ctx, busnum, devaddr, NULL) < 0)
+			usbi_dbg(ctx, "failed to enumerate android device %d/%d", busnum, devaddr);
+
+		android_jni_globalunref(cpriv->android_jni, device);
+	}
+
+	android_jni_devices_free(devices);
+
+	return LIBUSB_SUCCESS;
 }
+
+static int get_android_jni_fd(struct libusb_device_handle *handle)
+{
+	struct linux_context_priv *cpriv = usbi_get_context_priv(HANDLE_CTX(handle));
+	struct libusb_device *dev = handle->dev;
+	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+	struct linux_device_handle_priv *hpriv = usbi_get_device_handle_priv(handle);
+
+	int r, fd;
+	uint8_t *descriptors;
+	size_t descriptors_len;
+
+	r = android_jni_connect(cpriv->android_jni, priv->android_jni_device,
+		&hpriv->android_jni_connection, &fd, &descriptors, &descriptors_len);
+	if (r != LIBUSB_SUCCESS) {
+		if (r == LIBUSB_ERROR_ACCESS)
+			android_jni_request_permission(cpriv->android_jni, priv->android_jni_device);
+		return r;
+	}
+
+	free(priv->descriptors);
+	priv->descriptors = descriptors;
+	priv->descriptors_len = descriptors_len;
+
+	/* right now android_jni_device is only filled if sysfs is not being used,
+	 * so localize the device descriptor as if this were usbfs */
+	usbi_localize_device_descriptor(priv->descriptors);
+
+	memcpy(&dev->device_descriptor, priv->descriptors, LIBUSB_DT_DEVICE_SIZE);
+	parse_config_descriptors(dev);
+
+	return fd;
+}
+
+static int android_jni_initialize_device(struct libusb_device *dev, uint8_t busnum,
+	uint8_t devaddr)
+{
+	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
+	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+
+	struct android_jni_devices *devices;
+	jobject iter_device;
+	uint8_t iter_busnum, iter_devaddr;
+
+	int r = android_jni_devices_alloc(cpriv->android_jni, &devices);
+	if (r != LIBUSB_SUCCESS)
+		return r;
+
+	priv->android_jni_device = NULL;
+
+	while (LIBUSB_SUCCESS ==
+		android_jni_devices_next(devices, &iter_device,
+		                         &iter_busnum, &iter_devaddr))
+	{
+		if (iter_busnum == busnum && iter_devaddr == devaddr) {
+			priv->android_jni_device = iter_device;
+			break;
+		} else {
+			android_jni_globalunref(cpriv->android_jni, iter_device);
+		}
+	}
+
+	android_jni_devices_free(devices);
+
+	if (priv->android_jni_device == NULL)
+	{
+		return LIBUSB_ERROR_NO_DEVICE;
+	}
+
+	r = android_jni_gen_descriptors(
+		cpriv->android_jni, priv->android_jni_device,
+		(uint8_t**)&priv->descriptors, &priv->descriptors_len);
+	if (r < 0)
+		return r;
+
+	return LIBUSB_SUCCESS;
+}
+
+#endif
 
 static int linux_scan_devices(struct libusb_context *ctx)
 {
@@ -911,8 +1087,9 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 {
 	struct linux_device_priv *priv = usbi_get_device_priv(dev);
 	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
 	size_t alloc_len;
-	int fd, speed, r;
+	int fd, speed, r, skip_fd = 0;
 	ssize_t nb;
 
 	dev->bus_number = busnum;
@@ -943,51 +1120,64 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 	/* cache descriptors in memory */
 	if (sysfs_dir) {
 		fd = open_sysfs_attr(ctx, sysfs_dir, "descriptors");
-	} else if (wrapped_fd < 0) {
-		fd = get_usbfs_fd(dev, O_RDONLY, 0);
-	} else {
+	} else if (wrapped_fd >= 0) {
 		fd = wrapped_fd;
 		r = lseek(fd, 0, SEEK_SET);
 		if (r < 0) {
 			usbi_err(ctx, "lseek failed, errno=%d", errno);
 			return LIBUSB_ERROR_IO;
 		}
+#ifdef __ANDROID__
+	} else if (cpriv->android_jni != NULL) {
+		r = android_jni_initialize_device(dev, busnum, devaddr);
+		if (r < 0)
+			return r;
+		usbi_localize_device_descriptor(priv->descriptors);
+		fd = -1;
+		skip_fd = 1;
+#else
+		UNUSED(cpriv);
+#endif
+	} else {
+		fd = get_usbfs_fd(dev, O_RDONLY, 0);
 	}
-	if (fd < 0)
-		return fd;
+	if (!skip_fd) {
+		if (fd < 0)
+			return fd;
 
-	alloc_len = 0;
-	do {
-		const size_t desc_read_length = 256;
-		uint8_t *read_ptr;
+		alloc_len = 0;
+		do {
+			const size_t desc_read_length = 256;
+			uint8_t *read_ptr;
 
-		alloc_len += desc_read_length;
-		priv->descriptors = usbi_reallocf(priv->descriptors, alloc_len);
-		if (!priv->descriptors) {
-			if (fd != wrapped_fd)
-				close(fd);
-			return LIBUSB_ERROR_NO_MEM;
-		}
-		read_ptr = (uint8_t *)priv->descriptors + priv->descriptors_len;
-		/* usbfs has holes in the file */
-		if (!sysfs_dir)
-			memset(read_ptr, 0, desc_read_length);
-		nb = read(fd, read_ptr, desc_read_length);
-		if (nb < 0) {
-			usbi_err(ctx, "read descriptor failed, errno=%d", errno);
-			if (fd != wrapped_fd)
-				close(fd);
+			alloc_len += desc_read_length;
+			priv->descriptors = usbi_reallocf(priv->descriptors, alloc_len);
+			if (!priv->descriptors) {
+				if (fd != wrapped_fd)
+					close(fd);
+				return LIBUSB_ERROR_NO_MEM;
+			}
+			read_ptr = (uint8_t *)priv->descriptors + priv->descriptors_len;
+			/* usbfs has holes in the file */
+			if (!sysfs_dir)
+				memset(read_ptr, 0, desc_read_length);
+			nb = read(fd, read_ptr, desc_read_length);
+			if (nb < 0) {
+				usbi_err(ctx, "read descriptor failed, errno=%d", errno);
+				if (fd != wrapped_fd)
+					close(fd);
+				return LIBUSB_ERROR_IO;
+			}
+			priv->descriptors_len += (size_t)nb;
+		} while (priv->descriptors_len == alloc_len);
+
+		if (fd != wrapped_fd)
+			close(fd);
+
+		if (priv->descriptors_len < LIBUSB_DT_DEVICE_SIZE) {
+			usbi_err(ctx, "short descriptor read (%zu)", priv->descriptors_len);
 			return LIBUSB_ERROR_IO;
 		}
-		priv->descriptors_len += (size_t)nb;
-	} while (priv->descriptors_len == alloc_len);
-
-	if (fd != wrapped_fd)
-		close(fd);
-
-	if (priv->descriptors_len < LIBUSB_DT_DEVICE_SIZE) {
-		usbi_err(ctx, "short descriptor read (%zu)", priv->descriptors_len);
-		return LIBUSB_ERROR_IO;
 	}
 
 	r = parse_config_descriptors(dev);
@@ -1397,9 +1587,16 @@ out:
 
 static int op_open(struct libusb_device_handle *handle)
 {
-	int fd, r;
+	int fd = -1, r;
 
-	fd = get_usbfs_fd(handle->dev, O_RDWR, 0);
+#ifdef __ANDROID__
+	struct linux_device_priv *priv = usbi_get_device_priv(handle->dev);
+	if (priv->android_jni_device != NULL)
+		fd = get_android_jni_fd(handle);
+#endif
+
+	if (fd < 0)
+		fd = get_usbfs_fd(handle->dev, O_RDWR, 0);
 	if (fd < 0) {
 		if (fd == LIBUSB_ERROR_NO_DEVICE) {
 			/* device will still be marked as attached if hotplug monitor thread
@@ -1425,12 +1622,20 @@ static int op_open(struct libusb_device_handle *handle)
 static void op_close(struct libusb_device_handle *dev_handle)
 {
 	struct linux_device_handle_priv *hpriv = usbi_get_device_handle_priv(dev_handle);
+	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct linux_context_priv *cpriv = usbi_get_context_priv(ctx);
 
 	/* fd may have already been removed by POLLERR condition in op_handle_events() */
 	if (!hpriv->fd_removed)
-		usbi_remove_event_source(HANDLE_CTX(dev_handle), hpriv->fd);
+		usbi_remove_event_source(ctx, hpriv->fd);
 	if (!hpriv->fd_keep)
 		close(hpriv->fd);
+#ifdef __ANDROID__
+	if (hpriv->android_jni_connection != NULL)
+		android_jni_disconnect(cpriv->android_jni, hpriv->android_jni_connection);
+#else
+	UNUSED(cpriv);
+#endif
 }
 
 static int op_get_configuration(struct libusb_device_handle *handle,
@@ -1849,6 +2054,15 @@ static int op_release_interface(struct libusb_device_handle *handle, uint8_t int
 static void op_destroy_device(struct libusb_device *dev)
 {
 	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+	struct linux_context_priv *cpriv = usbi_get_context_priv(DEVICE_CTX(dev));
+
+#ifdef __ANDROID__
+	if (priv->android_jni_device != NULL) {
+		android_jni_globalunref(cpriv->android_jni, priv->android_jni_device);
+	}
+#else
+	UNUSED(cpriv);
+#endif
 
 	free(priv->config_descriptors);
 	free(priv->descriptors);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -102,7 +102,7 @@ static int init_count = 0;
 #ifdef __ANDROID__
 static int android_jni_scan_devices(struct libusb_context *ctx);
 
-JavaVM* javaVm = NULL;
+static JavaVM* javaVm = NULL;
 #endif
 
 /* have no authority to operate usb device directly */
@@ -433,7 +433,6 @@ static int op_init(struct libusb_context *ctx)
 			&cpriv->android_jni);
 		if (r != LIBUSB_SUCCESS)
 			return r;
-		return android_jni_scan_devices(ctx);
 	}
 #endif
 
@@ -465,7 +464,7 @@ static void op_exit(struct libusb_context *ctx)
 #ifdef __ANDROID__
 	if (cpriv->android_jni != NULL) {
 		android_jni_free(cpriv->android_jni);
-		return;
+		cpriv->android_jni = NULL;
 	}
 #endif
 
@@ -482,11 +481,6 @@ static void op_exit(struct libusb_context *ctx)
 
 static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
 {
-	/* ensure ctx is not active yet */
-	if (ctx->list.next != NULL) {
-		return LIBUSB_ERROR_NOT_SUPPORTED;
-	}
-
 #ifdef __ANDROID__
 	if (option == LIBUSB_OPTION_ANDROID_JNIENV) {
 		JNIEnv * jni_env = va_arg(ap, JNIEnv *);
@@ -511,9 +505,13 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 		return LIBUSB_SUCCESS;
 	}
 
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 #ifdef __ANDROID__
 
-static int android_jni_scan_devices(struct libusb_context *ctx)
+#define LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL 32
+int android_jni_scan_devices(struct libusb_context *ctx)
 {
 	/* Access and use the Android API via jni_env */
 
@@ -523,6 +521,10 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	struct android_jni_devices *devices;
 	jobject device;
 	uint8_t busnum, devaddr;
+
+	if(cpriv->android_jni == NULL) {
+		return 0;
+	}
 
 	r = android_jni_detect_usbhost(cpriv->android_jni, &has_usbhost);
 
@@ -541,9 +543,22 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	if (r != LIBUSB_SUCCESS)
 		return r;
 
+	// for every session id not found, disconnect
+	unsigned long session_id_avail[LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL];
+	size_t session_id_count = 0;
+
 	while (LIBUSB_SUCCESS ==
 		android_jni_devices_next(devices, &device, &busnum, &devaddr))
 	{
+		/* FIXME: session ID is not guaranteed unique as addresses can wrap and
+		* will be reused. instead we should add a simple sysfs attribute with
+		* a session ID. */
+		unsigned long session_id = busnum << 8 | devaddr;
+
+		if(session_id_count < LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL){
+			session_id_avail[session_id_count] = session_id;
+			session_id_count++;
+		}
 
 		if (linux_enumerate_device(ctx, busnum, devaddr, NULL) < 0)
 			usbi_dbg(ctx, "failed to enumerate android device %d/%d", busnum, devaddr);
@@ -552,6 +567,46 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	}
 
 	android_jni_devices_free(devices);
+
+	// for every session id not found, disconnect
+	unsigned long session_id_del[LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL];
+	size_t session_id_del_count = 0;
+
+	{
+		struct libusb_device *dev;
+		struct libusb_device *ret = NULL;
+		usbi_mutex_lock(&ctx->usb_devs_lock);
+		for_each_device(ctx, dev) {
+			uint8_t found = 0;
+			for(size_t i = 0; i < session_id_count; i++){
+				if(dev->session_data == session_id_avail[i]){
+					found = 1;
+					break;
+				}
+			}
+
+			if(!found){
+				// "disconnect"
+				if(session_id_del_count < LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL){
+					session_id_del[session_id_del_count] = dev->session_data;
+					session_id_del_count++;
+				}
+			}
+		}
+		usbi_mutex_unlock(&ctx->usb_devs_lock);
+	}
+
+	// Actually disconnect
+	for(size_t i = 0; i < session_id_del_count; i++) {
+		struct libusb_device *dev;
+		dev = usbi_get_device_by_session_id(ctx, session_id_del[i]);
+		if (dev) {
+			usbi_disconnect_device(dev);
+			libusb_unref_device(dev);
+		} else {
+			usbi_dbg(ctx, "device not found for session %lx", session_id_del[i]);
+		}
+	}
 
 	return LIBUSB_SUCCESS;
 }
@@ -634,6 +689,17 @@ static int android_jni_initialize_device(struct libusb_device *dev, uint8_t busn
 	return LIBUSB_SUCCESS;
 }
 
+void android_jni_hotplug_poll()
+{
+	struct libusb_context *ctx;
+	// Poll each context
+	usbi_mutex_static_lock(&active_contexts_lock);
+	for_each_context(ctx) {
+		linux_scan_devices(ctx);
+	}
+	usbi_mutex_static_unlock(&active_contexts_lock);
+}
+
 #endif
 
 static int linux_scan_devices(struct libusb_context *ctx)
@@ -644,6 +710,8 @@ static int linux_scan_devices(struct libusb_context *ctx)
 
 #if defined(HAVE_LIBUDEV)
 	ret = linux_udev_scan_devices(ctx);
+#elif defined(__ANDROID__)
+	ret = android_jni_scan_devices(ctx);
 #else
 	ret = linux_default_scan_devices(ctx);
 #endif
@@ -2991,6 +3059,12 @@ const struct usbi_os_backend usbi_backend = {
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER,
 	.init = op_init,
 	.exit = op_exit,
+
+// Another option, disable hotplug all together
+#if defined(__ANDROID__) && __ANDROID__
+	//.get_device_list = android_jni_get_device_list,
+#endif
+
 	.set_option = op_set_option,
 	.hotplug_poll = op_hotplug_poll,
 	.get_active_config_descriptor = op_get_active_config_descriptor,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -491,8 +491,11 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	if (option == LIBUSB_OPTION_ANDROID_JNIENV) {
 		JNIEnv * jni_env = va_arg(ap, JNIEnv *);
 		int r = android_jnienv_javavm(jni_env, &javaVm);
+		if (r != LIBUSB_SUCCESS) {
+			return r;
+		}
 		usbi_dbg(ctx, "set default jnienv javavm %p %p", jni_env, javaVm);
-		return r;
+		return LIBUSB_SUCCESS;
 	} else if (option == LIBUSB_OPTION_ANDROID_JAVAVM) {
 		javaVm = va_arg(ap, JavaVM *);
 		usbi_dbg(ctx, "set default javavm %p", javaVm);

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -164,10 +164,12 @@ int linux_udev_start_event_monitor(void);
 int linux_udev_stop_event_monitor(void);
 int linux_udev_scan_devices(struct libusb_context *ctx);
 void linux_udev_hotplug_poll(void);
-#else
+#elif !defined(__ANDROID__)
 int linux_netlink_start_event_monitor(void);
 int linux_netlink_stop_event_monitor(void);
 void linux_netlink_hotplug_poll(void);
+#elif defined(__ANDROID__)
+void android_jni_hotplug_poll();
 #endif
 
 static inline int linux_start_event_monitor(void)
@@ -196,6 +198,8 @@ static inline void linux_hotplug_poll(void)
 	linux_udev_hotplug_poll();
 #elif !defined(__ANDROID__)
 	linux_netlink_hotplug_poll();
+#elif defined(__ANDROID__)
+	android_jni_hotplug_poll();
 #endif
 }
 


### PR DESCRIPTION
Rebase of work on #874:

**This code implements connection and device listing on unrooted android devices, without requiring any user-provided java.**
This PR is usable now 🎉  

The java native interface library is used, which is always available when building on android, to do the sdk calls within libusb itself. The approach is modularised to aid expanding if new features are needed.
- Device enumeration by generating usb descriptors from the android sdk, which requires no user permission for this information.
- Detect if permission is needed when an unpermissioned device is opened, and perform the requestPermission call if necessary. This pops up a dialogue to the user asking if they will allow the connection.
   📓 Dispatching this request involves setting an action string on the intent for permission that the application can optionally subscribe to. The permission intent I dispatch has action string libusb.android.USB_PERMISSION.

The code only takes effect if the user provides their JNIEnv* or JavaVM* pointer via a new libusb option.