### PR TITLE
core: Add libusb_get_max_iso_packet_size_for_alt_setting

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1113,7 +1113,7 @@ static int get_endpoint_max_packet_size(libusb_device *dev,
 	struct libusb_ss_endpoint_companion_descriptor *ss_ep_cmp;
 	enum libusb_endpoint_transfer_type ep_type;
 	uint16_t val;
-	int r;
+	int r = 0;
 	int speed;
 
 	speed = libusb_get_device_speed(dev);

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1079,6 +1079,33 @@ out:
 	return r;
 }
 
+static const struct libusb_endpoint_descriptor *find_alt_endpoint(
+	struct libusb_config_descriptor *config,
+	int iface_idx, int altsetting_idx, unsigned char endpoint)
+{
+	if (iface_idx >= config->bNumInterfaces) {
+		return NULL;
+	}
+
+	const struct libusb_interface *iface = &config->interface[iface_idx];
+
+	if (altsetting_idx >= iface->num_altsetting) {
+		return NULL;
+	}
+
+	const struct libusb_interface_descriptor *altsetting
+		= &iface->altsetting[altsetting_idx];
+	int ep_idx;
+
+	for (ep_idx = 0; ep_idx < altsetting->bNumEndpoints; ep_idx++) {
+		const struct libusb_endpoint_descriptor *ep =
+			&altsetting->endpoint[ep_idx];
+		if (ep->bEndpointAddress == endpoint)
+			return ep;
+	}
+	return NULL;
+}
+
 static int get_endpoint_max_iso_packet_size(libusb_device *dev,
 	const struct libusb_endpoint_descriptor *ep)
 {

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -414,6 +414,7 @@ if (cfg != desired)
   * - libusb_get_iso_packet_buffer()
   * - libusb_get_iso_packet_buffer_simple()
   * - libusb_get_max_iso_packet_size()
+  * - libusb_get_max_iso_packet_size_for_alt_setting()
   * - libusb_get_max_packet_size()
   * - libusb_get_next_timeout()
   * - libusb_get_parent()
@@ -1158,6 +1159,11 @@ static int get_endpoint_max_iso_packet_size(libusb_device *dev,
  * libusb_set_iso_packet_lengths() in order to set the length field of every
  * isochronous packet in a transfer.
  *
+ * This function only considers the first alternate setting of the interface.
+ * If the endpoint has different maximum packet sizes for different alternate
+ * settings, you probably want libusb_get_max_iso_packet_size_for_alt_setting()
+ * instead.
+ *
  * Since v1.0.3.
  *
  * \param dev a device
@@ -1165,6 +1171,7 @@ static int get_endpoint_max_iso_packet_size(libusb_device *dev,
  * \returns the maximum packet size which can be sent/received on this endpoint
  * \returns \ref LIBUSB_ERROR_NOT_FOUND if the endpoint does not exist
  * \returns \ref LIBUSB_ERROR_OTHER on other failure
+ * \see libusb_get_max_iso_packet_size_for_alt_setting
  */
 int API_EXPORTED libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint)
@@ -1181,6 +1188,67 @@ int API_EXPORTED libusb_get_max_iso_packet_size(libusb_device *dev,
 	}
 
 	ep = find_endpoint(config, endpoint);
+	if (!ep) {
+		r = LIBUSB_ERROR_NOT_FOUND;
+		goto out;
+	}
+
+	r = get_endpoint_max_iso_packet_size(dev, ep);
+
+out:
+	libusb_free_config_descriptor(config);
+	return r;
+}
+
+/** \ingroup libusb_dev
+ * Calculate the maximum packet size which a specific endpoint is capable of
+ * sending or receiving in the duration of 1 microframe
+ *
+ * Only the active configuration is examined. The calculation is based on the
+ * wMaxPacketSize field in the endpoint descriptor as described in section
+ * 9.6.6 in the USB 2.0 specifications.
+ *
+ * If acting on an isochronous or interrupt endpoint, this function will
+ * multiply the value found in bits 0:10 by the number of transactions per
+ * microframe (determined by bits 11:12). Otherwise, this function just
+ * returns the numeric value found in bits 0:10. For USB 3.0 device, it
+ * will attempts to retrieve the Endpoint Companion Descriptor to return
+ * wBytesPerInterval.
+ *
+ * This function is useful for setting up isochronous transfers, for example
+ * you might pass the return value from this function to
+ * libusb_set_iso_packet_lengths() in order to set the length field of every
+ * isochronous packet in a transfer.
+ *
+ * Since v1.0.27.
+ *
+ * \param dev a device
+ * \param interface_number the <tt>bInterfaceNumber</tt> of the interface
+ * the endpoint belongs to
+ * \param alternate_setting the <tt>bAlternateSetting</tt> of the interface
+ * \param endpoint address of the endpoint in question
+ * \returns the maximum packet size which can be sent/received on this endpoint
+ * \returns \ref LIBUSB_ERROR_NOT_FOUND if the endpoint does not exist
+ * \returns \ref LIBUSB_ERROR_OTHER on other failure
+ * \see libusb_get_max_iso_packet_size
+ */
+int API_EXPORTED libusb_get_max_iso_packet_size_for_alt_setting(
+	libusb_device *dev,	int interface_number,
+	int alternate_setting, unsigned char endpoint)
+{
+	struct libusb_config_descriptor *config;
+	const struct libusb_endpoint_descriptor *ep;
+	int r;
+
+	r = libusb_get_active_config_descriptor(dev, &config);
+	if (r < 0) {
+		usbi_err(DEVICE_CTX(dev),
+			"could not retrieve active config descriptor");
+		return LIBUSB_ERROR_OTHER;
+	}
+
+	ep = find_alt_endpoint(config, interface_number,
+		alternate_setting, endpoint);
 	if (!ep) {
 		r = LIBUSB_ERROR_NOT_FOUND;
 		goto out;

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1107,7 +1107,7 @@ static const struct libusb_endpoint_descriptor *find_alt_endpoint(
 	return NULL;
 }
 
-static int get_endpoint_max_iso_packet_size(libusb_device *dev,
+static int get_endpoint_max_packet_size(libusb_device *dev,
 	const struct libusb_endpoint_descriptor *ep)
 {
 	struct libusb_ss_endpoint_companion_descriptor *ss_ep_cmp;
@@ -1192,7 +1192,7 @@ int API_EXPORTED libusb_get_max_iso_packet_size(libusb_device *dev,
 		goto out;
 	}
 
-	r = get_endpoint_max_iso_packet_size(dev, ep);
+	r = get_endpoint_max_packet_size(dev, ep);
 
 out:
 	libusb_free_config_descriptor(config);
@@ -1252,7 +1252,7 @@ int API_EXPORTED libusb_get_max_alt_packet_size(libusb_device *dev,
 		goto out;
 	}
 
-	r = get_endpoint_max_iso_packet_size(dev, ep);
+	r = get_endpoint_max_packet_size(dev, ep);
 
 out:
 	libusb_free_config_descriptor(config);

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -414,7 +414,7 @@ if (cfg != desired)
   * - libusb_get_iso_packet_buffer()
   * - libusb_get_iso_packet_buffer_simple()
   * - libusb_get_max_iso_packet_size()
-  * - libusb_get_max_iso_packet_size_for_alt_setting()
+  * - libusb_get_max_alt_packet_size()
   * - libusb_get_max_packet_size()
   * - libusb_get_next_timeout()
   * - libusb_get_parent()
@@ -1161,8 +1161,7 @@ static int get_endpoint_max_iso_packet_size(libusb_device *dev,
  *
  * This function only considers the first alternate setting of the interface.
  * If the endpoint has different maximum packet sizes for different alternate
- * settings, you probably want libusb_get_max_iso_packet_size_for_alt_setting()
- * instead.
+ * settings, you probably want libusb_get_max_alt_packet_size() instead.
  *
  * Since v1.0.3.
  *
@@ -1171,7 +1170,7 @@ static int get_endpoint_max_iso_packet_size(libusb_device *dev,
  * \returns the maximum packet size which can be sent/received on this endpoint
  * \returns \ref LIBUSB_ERROR_NOT_FOUND if the endpoint does not exist
  * \returns \ref LIBUSB_ERROR_OTHER on other failure
- * \see libusb_get_max_iso_packet_size_for_alt_setting
+ * \see libusb_get_max_alt_packet_size
  */
 int API_EXPORTED libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint)
@@ -1232,9 +1231,8 @@ out:
  * \returns \ref LIBUSB_ERROR_OTHER on other failure
  * \see libusb_get_max_iso_packet_size
  */
-int API_EXPORTED libusb_get_max_iso_packet_size_for_alt_setting(
-	libusb_device *dev,	int interface_number,
-	int alternate_setting, unsigned char endpoint)
+int API_EXPORTED libusb_get_max_alt_packet_size(libusb_device *dev,
+	int interface_number, int alternate_setting, unsigned char endpoint)
 {
 	struct libusb_config_descriptor *config;
 	const struct libusb_endpoint_descriptor *ep;

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -78,8 +78,8 @@ EXPORTS
   libusb_get_device_speed@4 = libusb_get_device_speed
   libusb_get_max_iso_packet_size
   libusb_get_max_iso_packet_size@8 = libusb_get_max_iso_packet_size
-  libusb_get_max_iso_packet_size_for_alt_setting
-  libusb_get_max_iso_packet_size_for_alt_setting@16 = libusb_get_max_iso_packet_size_for_alt_setting
+  libusb_get_max_alt_packet_size
+  libusb_get_max_alt_packet_size@16 = libusb_get_max_alt_packet_size
   libusb_get_max_packet_size
   libusb_get_max_packet_size@8 = libusb_get_max_packet_size
   libusb_get_next_timeout

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -78,6 +78,8 @@ EXPORTS
   libusb_get_device_speed@4 = libusb_get_device_speed
   libusb_get_max_iso_packet_size
   libusb_get_max_iso_packet_size@8 = libusb_get_max_iso_packet_size
+  libusb_get_max_iso_packet_size_for_alt_setting
+  libusb_get_max_iso_packet_size_for_alt_setting@16 = libusb_get_max_iso_packet_size_for_alt_setting
   libusb_get_max_packet_size
   libusb_get_max_packet_size@8 = libusb_get_max_packet_size
   libusb_get_next_timeout

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1432,9 +1432,8 @@ int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint);
-int LIBUSB_CALL libusb_get_max_iso_packet_size_for_alt_setting(
-	libusb_device *dev,	int interface_number,
-	int alternate_setting, unsigned char endpoint);
+int LIBUSB_CALL libusb_get_max_alt_packet_size(libusb_device *dev,
+	int interface_number, int alternate_setting, unsigned char endpoint);
 
 int LIBUSB_CALL libusb_wrap_sys_device(libusb_context *ctx, intptr_t sys_dev, libusb_device_handle **dev_handle);
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **dev_handle);

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1432,6 +1432,9 @@ int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint);
+int LIBUSB_CALL libusb_get_max_iso_packet_size_for_alt_setting(
+	libusb_device *dev,	int interface_number,
+	int alternate_setting, unsigned char endpoint);
 
 int LIBUSB_CALL libusb_wrap_sys_device(libusb_context *ctx, intptr_t sys_dev, libusb_device_handle **dev_handle);
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **dev_handle);


### PR DESCRIPTION
As discussed in #36, [old issue #77](https://sourceforge.net/p/libusb/mailman/libusb-devel/thread/056.8f7cf80ce90539817d58effd879129d7@libusb.org/) and [the mailing list](https://sourceforge.net/p/libusb/mailman/libusb-devel/thread/4D52A463.5080108@redhat.com/).

(I don't have much more to add, but I don't want to sound like a bot, so please feel free to review and thank you!)