### PR TITLE
linux_usbfs: Enable libusb hotplug events for Android native services

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/xvrfam94jii4a6lw?svg=true)](https://ci.appveyor.com/project/LudovicRousseau/libusb)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/2180/badge.svg)](https://scan.coverity.com/projects/libusb-libusb)
 
+#
 libusb is a library for USB device access from Linux, macOS,
 Windows, OpenBSD/NetBSD, Haiku, Solaris userspace, and WebAssembly
 via WebUSB.

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -174,10 +174,8 @@ static inline int linux_start_event_monitor(void)
 {
 #if defined(HAVE_LIBUDEV)
 	return linux_udev_start_event_monitor();
-#elif !defined(__ANDROID__)
-	return linux_netlink_start_event_monitor();
 #else
-	return LIBUSB_SUCCESS;
+	return linux_netlink_start_event_monitor();
 #endif
 }
 
@@ -185,7 +183,7 @@ static inline void linux_stop_event_monitor(void)
 {
 #if defined(HAVE_LIBUDEV)
 	linux_udev_stop_event_monitor();
-#elif !defined(__ANDROID__)
+#else
 	linux_netlink_stop_event_monitor();
 #endif
 }
@@ -194,7 +192,7 @@ static inline void linux_hotplug_poll(void)
 {
 #if defined(HAVE_LIBUDEV)
 	linux_udev_hotplug_poll();
-#elif !defined(__ANDROID__)
+#else
 	linux_netlink_hotplug_poll();
 #endif
 }


### PR DESCRIPTION
Android native services with proper permission still need an support for hotplug events from libusb instead of android platform API. 

Reference:
https://github.com/libusb/libusb/issues/1154
