### PR TITLE
Fix config.h to define __FUNCTION__ for vs2015

### DIFF
--- a/msvc/config.h
+++ b/msvc/config.h
@@ -10,8 +10,8 @@
 #error "Visual Studio 2013 or later is required."
 #endif
 
-/* Visual Studio 2013 does not support __func__ */
-#if (_MSC_VER < 1900)
+/* Visual Studio 2013 and 2015 do not support __func__ */
+#if (_MSC_VER <= 1900)
 #define __func__ __FUNCTION__
 #endif
 


### PR DESCRIPTION
I wasn't able to build libusb using vs2015 until making this fix. All other versions worked fine. 
![image](https://user-images.githubusercontent.com/19939445/183471455-e3991ad3-ec02-4729-9548-27692348c182.png)

What ended up fixing this was changing config.h to also define \_\_func__ as \_\_FUNCTION__ for vs2015 (currently only done on vs2013).

This seems like a weird fix, since \_\_func__ should be supported on vs2015 since it supports the C++11 standard. Thoughts?