### PR TITLE
fix memory leak - configuration descriptor wan't released

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1433,11 +1433,14 @@ static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle,
 
       if (iface >= config->bNumInterfaces) {
         usbi_err (HANDLE_CTX (dev_handle), "interface %d out of range for device", iface);
+        libusb_free_config_descriptor (config);
         return LIBUSB_ERROR_NOT_FOUND;
       }
+
       endpoint_desc = config->interface[iface].altsetting[alt_setting].endpoint + i - 1;
 
       cInterface->endpoint_addrs[i - 1] = endpoint_desc->bEndpointAddress;
+      libusb_free_config_descriptor (config);
     } else {
       cInterface->endpoint_addrs[i - 1] = (UInt8)(((kUSBIn == direction) << kUSBRqDirnShift) | (number & LIBUSB_ENDPOINT_ADDRESS_MASK));
     }

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -525,7 +525,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 
 	if (iface >= conf_desc->bNumInterfaces) {
 		usbi_err(HANDLE_CTX(dev_handle), "interface %d out of range for device", iface);
-		r = LIBUSB_ERROR_NO_MEM;
+		r = LIBUSB_ERROR_NOT_FOUND;
 		goto end;
 	}
 	if_desc = &conf_desc->interface[iface].altsetting[altsetting];


### PR DESCRIPTION
- Darwin: config descriptor never released in case if GetPipePropertiesV3 fails;
- Windows: config descriptor not released for some broken config descriptors;