### PR TITLE
Find interface descriptor by bInterfaceNumber

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1379,13 +1379,14 @@ static IOReturn darwin_get_interface (usb_device_t **darwin_device, uint8_t ifc,
 static const struct libusb_interface_descriptor *get_interface_descriptor_by_number(struct libusb_device_handle *dev_handle, struct libusb_config_descriptor *conf_desc, int iface, uint8_t altsetting)
 {
   int i;
+
   for (i = 0; i < conf_desc->bNumInterfaces; i++) {
     if (altsetting < conf_desc->interface[i].num_altsetting && conf_desc->interface[i].altsetting[altsetting].bInterfaceNumber == iface) {
       return &conf_desc->interface[i].altsetting[altsetting];
     }
   }
 
-  usbi_err(HANDLE_CTX(dev_handle), "interface %d not found for device", iface);
+  usbi_err(HANDLE_CTX(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
   return NULL;
 }
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1376,6 +1376,19 @@ static IOReturn darwin_get_interface (usb_device_t **darwin_device, uint8_t ifc,
   return kIOReturnSuccess;
 }
 
+static const struct libusb_interface_descriptor *get_interface_descriptor_by_number(struct libusb_device_handle *dev_handle, struct libusb_config_descriptor *conf_desc, int iface, uint8_t altsetting)
+{
+  int i;
+  for (i = 0; i < conf_desc->bNumInterfaces; i++) {
+    if (altsetting < conf_desc->interface[i].num_altsetting && conf_desc->interface[i].altsetting[altsetting].bInterfaceNumber == iface) {
+      return &conf_desc->interface[i].altsetting[altsetting];
+    }
+  }
+
+  usbi_err(HANDLE_CTX(dev_handle), "interface %d not found for device", iface);
+  return NULL;
+}
+
 static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface) {
   struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
 
@@ -1417,6 +1430,7 @@ static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle,
     if (kresult != kIOReturnSuccess) {
       /* probably a buggy device. try to get the endpoint address from the descriptors */
       struct libusb_config_descriptor *config;
+      const struct libusb_interface_descriptor *if_desc;
       const struct libusb_endpoint_descriptor *endpoint_desc;
       UInt8 alt_setting;
 
@@ -1431,13 +1445,13 @@ static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle,
         return rc;
       }
 
-      if (iface >= config->bNumInterfaces) {
-        usbi_err (HANDLE_CTX (dev_handle), "interface %d out of range for device", iface);
+      if_desc = get_interface_descriptor_by_number (dev_handle, config, iface, alt_setting);
+      if (if_desc == NULL) {
         libusb_free_config_descriptor (config);
         return LIBUSB_ERROR_NOT_FOUND;
       }
 
-      endpoint_desc = config->interface[iface].altsetting[alt_setting].endpoint + i - 1;
+      endpoint_desc = if_desc->endpoint + i - 1;
 
       cInterface->endpoint_addrs[i - 1] = endpoint_desc->bEndpointAddress;
       libusb_free_config_descriptor (config);

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -485,6 +485,19 @@ static int get_interface_by_endpoint(struct libusb_config_descriptor *conf_desc,
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
+static const struct libusb_interface_descriptor *get_interface_descriptor_by_number(struct libusb_device_handle *dev_handle, struct libusb_config_descriptor *conf_desc, int iface, uint8_t altsetting)
+{
+	int i;
+	for (i = 0; i < conf_desc->bNumInterfaces; i++) {
+		if (altsetting < conf_desc->interface[i].num_altsetting && conf_desc->interface[i].altsetting[altsetting].bInterfaceNumber == iface) {
+			return &conf_desc->interface[i].altsetting[altsetting];
+		}
+	}
+
+	usbi_err(HANDLE_CTX(dev_handle), "interface %d not found for device", iface);
+	return NULL;
+}
+
 /*
  * Open a device and associate the HANDLE with the context's I/O completion port
  */
@@ -523,12 +536,12 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 		return r;
 	}
 
-	if (iface >= conf_desc->bNumInterfaces) {
-		usbi_err(HANDLE_CTX(dev_handle), "interface %d out of range for device", iface);
+	if_desc = get_interface_descriptor_by_number(dev_handle, conf_desc, iface, altsetting);
+	if (if_desc == NULL) {
 		r = LIBUSB_ERROR_NOT_FOUND;
 		goto end;
 	}
-	if_desc = &conf_desc->interface[iface].altsetting[altsetting];
+
 	safe_free(priv->usb_interface[iface].endpoint);
 
 	if (if_desc->bNumEndpoints == 0) {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -488,13 +488,14 @@ static int get_interface_by_endpoint(struct libusb_config_descriptor *conf_desc,
 static const struct libusb_interface_descriptor *get_interface_descriptor_by_number(struct libusb_device_handle *dev_handle, struct libusb_config_descriptor *conf_desc, int iface, uint8_t altsetting)
 {
 	int i;
+
 	for (i = 0; i < conf_desc->bNumInterfaces; i++) {
 		if (altsetting < conf_desc->interface[i].num_altsetting && conf_desc->interface[i].altsetting[altsetting].bInterfaceNumber == iface) {
 			return &conf_desc->interface[i].altsetting[altsetting];
 		}
 	}
 
-	usbi_err(HANDLE_CTX(dev_handle), "interface %d not found for device", iface);
+	usbi_err(HANDLE_CTX(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
 	return NULL;
 }
 


### PR DESCRIPTION
In some cases, the interface number doesn't match its index in the list of interfaces in configuration descriptor;
that is the case for some (non USB-compliant) devices, e.g.:
    - when the device (descriptor) is explicitly non USB-compliant, and its interface numbers simply doesn't match its indexes (e.g. if[3]{0, 3, 4} or if[4]{0,3,1,2});
    - other cases when the decice descriptor is broken;

In such cases need to find the descriptor by iteration over all of them, to find the matching `bInterfaceNumber`.
Otherwise we might try to access data outside of the interfaces array, or access incorrect interfaces descriptor which `bInterfaceNumber` doesn't match the required one.

Related: #1093