### PR TITLE
def: remove __stdcall libusb_set_option

### DIFF
--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -155,7 +155,6 @@ EXPORTS
   libusb_set_log_cb
   libusb_set_log_cb@12 = libusb_set_log_cb
   libusb_set_option
-  libusb_set_option@8 = libusb_set_option
   libusb_set_pollfd_notifiers
   libusb_set_pollfd_notifiers@16 = libusb_set_pollfd_notifiers
   libusb_setlocale


### PR DESCRIPTION
libusb_set_option uses variable arguments and therefore cannot use __stdcall. In practice, this does not get exported. Verified under MinGW's objdump tool with 32 and 64-bit combinations.

Signed-off-by: Rosen Penev <rosenp@gmail.com>