### PR TITLE
Fix setting log level before libusb_init()

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2307,7 +2307,7 @@ int API_EXPORTED libusb_init(libusb_context **ctx)
 	}
 
 #if defined(ENABLE_LOGGING) && !defined(ENABLE_DEBUG_LOGGING)
-	if (NULL == ctx && default_context_options[LIBUSB_OPTION_LOG_LEVEL].is_set) {
+	if (default_context_options[LIBUSB_OPTION_LOG_LEVEL].is_set) {
 		_ctx->debug = default_context_options[LIBUSB_OPTION_LOG_LEVEL].arg.ival;
 	} else {
 		_ctx->debug = get_env_debug_level();


### PR DESCRIPTION
The header docs state its possible to set a default log level before calling libusb_init(), and that this log level will be used for all contexts created after (to quote):

    "Note that libusb_set_option(NULL, ...) is special, and adds
     an option to a list of default options for new contexts."

This updates the logic inside libusb_init() to ensure this behaviour is followed.