### PR TITLE
windows: Fix off-by-one error in HID backend for interrupt and bulk transfers without reportId.

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -4228,12 +4228,15 @@ static enum libusb_transfer_status hid_copy_transfer_data(int sub_api, struct us
 				}
 
 				if (transfer_priv->hid_buffer[0] == 0) {
+					length--;
 					memcpy(transfer_priv->hid_dest, transfer_priv->hid_buffer + 1, length);
 				} else {
 					memcpy(transfer_priv->hid_dest, transfer_priv->hid_buffer, length);
 				}
 			}
 			transfer_priv->hid_dest = NULL;
+		} else if ((length > 0) && (transfer_priv->hid_buffer[0] == 0)) {
+			length--;
 		}
 		// For write, we just need to free the hid buffer
 		safe_free(transfer_priv->hid_buffer);


### PR DESCRIPTION
When the windows hid backend is used for interrupt or bulk transfers on USB-HID compliant devices which don't support HID reportId's, the current code properly adds a zero prefix byte for reportId 0x00 before an OUT transfer, and properly strips the leading zero prefix byte from buffers received by IN transfers. Length of transmitted data is increased by +1 accordingly to account for the extra prefix byte.

However, on transfer completion the length of sent or received data is not adjusted back again by one. This leads to misreporting of effective transfer length for both OUT and IN transfers, reporting one byte too much. It also causes a memcpy for IN transfers which copies one byte of data too much into the client provided target buffer transfer_priv->hid_dest, appending an extra zero byte at the end and thereby writing one byte past the size of the client target buffer. This could lead to memory corruption or a access violation if the client application is unlucky.

This commit fixes the problem by detecting this type of HID transfers and adjusting the effective length of the transfer down one byte.

Fix successfully tested with a Griffin PowerMate USB-HID device that doesn't support reportId's, performing interrupt transfers from/to the device.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>