### PR TITLE
Adjust NetBSD's udi_bus/udi_addr to libusb's 1-based notion

### DIFF
--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -146,8 +146,8 @@ netbsd_get_device_list(struct libusb_context * ctx,
 			if (dev == NULL)
 				return (LIBUSB_ERROR_NO_MEM);
 
-			dev->bus_number = di.udi_bus;
-			dev->device_address = di.udi_addr;
+			dev->bus_number = 1 + di.udi_bus;
+			dev->device_address = 1 + di.udi_addr;
 			dev->speed = di.udi_speed; /* NetBSD #define's happen to match libusb enum */
 
 			dpriv = usbi_get_device_priv(dev);


### PR DESCRIPTION
NetBSD's `udi_bus`/`udi_addr` values in `struct usb_device_info` start from 0. OTOH, libusb's `bus_number`/`device_address` in `struct libusb_device` use 0 to represent a missing value. Adjust between the two worlds by adding an offset of 1.

While there, add a comment that, because NetBSD's `#define`s for USB speeds happen to match the corresponding libusb `enum` values, it's OK to assign `struct usb_device_info`'s `udi_speed` field to a `struct libusb_devices`'s `speed` field.