### PR TITLE
xusb: Fix MAX LUN retrieval handling, kernel attached and claim error messages

### DIFF
--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -474,8 +474,8 @@ static int test_mass_storage(libusb_device_handle *handle, uint8_t endpoint_in, 
 		lun = 0;
 		printf("   Stalled, setting Max LUN to 0\n");
 	} else if (r < 0) {
-		perr("   Failed: (error %d) %s\n", r, libusb_strerror((enum libusb_error)r));
-		return -1;
+		perr("   Failed.\n");
+		return r;
 	} else {
 		printf("   Max LUN = %d\n", lun);
 	}

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -470,12 +470,15 @@ static int test_mass_storage(libusb_device_handle *handle, uint8_t endpoint_in, 
 		BOMS_GET_MAX_LUN, 0, 0, &lun, 1, 1000);
 	// Some devices send a STALL instead of the actual value.
 	// In such cases we should set lun to 0.
-	if (r == 0) {
+	if (r == LIBUSB_ERROR_PIPE) {
 		lun = 0;
+		printf("   Stalled, setting Max LUN to 0\n");
 	} else if (r < 0) {
-		perr("   Failed: %s", libusb_strerror((enum libusb_error)r));
+		perr("   Failed: (error %d) %s\n", r, libusb_strerror((enum libusb_error)r));
+		return -1;
+	} else {
+		printf("   Max LUN = %d\n", lun);
 	}
-	printf("   Max LUN = %d\n", lun);
 
 	// Send Inquiry
 	printf("\nSending Inquiry:\n");

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -930,12 +930,25 @@ static int test_device(uint16_t vid, uint16_t pid)
 	libusb_set_auto_detach_kernel_driver(handle, 1);
 	for (iface = 0; iface < nb_ifaces; iface++)
 	{
-		int ret = libusb_kernel_driver_active(handle, iface);
-		printf("\nKernel driver attached for interface %d: %d\n", iface, ret);
+		int ret;
+
+		printf("\nKernel driver attached for interface %d: ", iface);
+		ret = libusb_kernel_driver_active(handle, iface);
+		if (ret == 0)
+			printf("none\n");
+		else if (ret == 1)
+			printf("yes\n");
+		else if (ret == LIBUSB_ERROR_NOT_SUPPORTED)
+			printf("(not supported)\n");
+		else
+			perr("\n   Failed (error %d) %s\n", ret,
+			     libusb_strerror((enum libusb_error) ret));
+
 		printf("\nClaiming interface %d...\n", iface);
 		r = libusb_claim_interface(handle, iface);
 		if (r != LIBUSB_SUCCESS) {
-			perr("   Failed.\n");
+			perr("   Failed (error %d) %s\n", ret,
+			     libusb_strerror((enum libusb_error) ret));
 		}
 	}
 


### PR DESCRIPTION
Great if this can be tested for the various cases.