### PR TITLE
Build stress_mt on Windows with pthreads

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,15 @@ if test "x$platform" = xposix; then
 	fi
 elif test "x$platform" = xwindows; then
 	AC_DEFINE([PLATFORM_WINDOWS], [1], [Define to 1 if compiling for a Windows platform.])
+	dnl windows platforms may have pthread support, use for portable tests only
+	saved_LIBS="${LIBS}"
+	AC_SEARCH_LIBS([pthread_create], [pthread],
+		[win_has_pthread=yes], [], [])
+	WIN_PTHREAD_LIBS="${LIBS}"
+	LIBS="${saved_LIBS}"
+	if test "x$win_has_pthread" = xyes; then
+		AC_DEFINE([HAVE_WIN_PTHREAD], [1], [Windows platform has pthread support])
+	fi
 else
 	AC_MSG_ERROR([Unknown platform])
 fi
@@ -238,6 +247,9 @@ esac
 
 dnl headers not available on all platforms but required on others
 AC_CHECK_HEADERS([sys/time.h])
+
+dnl for detecting general pthread support (non-Windows) in tests
+AC_CHECK_FUNCS([pthread_create])
 
 dnl check availability of clock_gettime(), except don't bother on Darwin, because the result is not used.
 if test "x$platform" = xposix && test "x$backend" != xdarwin; then
@@ -390,6 +402,7 @@ AM_CONDITIONAL([OS_EMSCRIPTEN], [test "x$backend" = xemscripten])
 AM_CONDITIONAL([PLATFORM_POSIX], [test "x$platform" = xposix])
 AM_CONDITIONAL([PLATFORM_WINDOWS], [test "x$platform" = xwindows])
 AM_CONDITIONAL([USE_UDEV], [test "x$use_udev" = xyes])
+AM_CONDITIONAL([WIN_HAS_PTHREAD], [test "x$win_has_pthread" = xyes])
 
 dnl The -Wcast-function-type warning causes a flurry of warnings when compiling
 dnl Windows with GCC 8 or later because of dynamically loaded functions
@@ -429,6 +442,8 @@ AC_SUBST(LT_LDFLAGS)
 AC_SUBST(AM_LDFLAGS)
 
 AC_SUBST([EXTRA_LDFLAGS])
+
+AC_SUBST([WIN_PTHREAD_LIBS])
 
 dnl set name of html output directory for doxygen
 AC_SUBST(DOXYGEN_HTMLDIR, [api-1.0])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,15 +2,13 @@ AM_CPPFLAGS = -I$(top_srcdir)/libusb
 LDADD = ../libusb/libusb-1.0.la
 LIBS =
 
+if WIN_HAS_PTHREAD
+stress_mt_LDFLAGS = ${WIN_PTHREAD_LIBS}
+endif
 stress_SOURCES = stress.c libusb_testlib.h testlib.c
-
-noinst_PROGRAMS = stress
-
-if PLATFORM_POSIX
 stress_mt_SOURCES = stress_mt.c
 
-noinst_PROGRAMS += stress_mt
-endif
+noinst_PROGRAMS = stress stress_mt
 
 if BUILD_UMOCKDEV_TEST
 # NOTE: We add libumockdev-preload.so so that we can run tests in-process

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -1,5 +1,9 @@
+#include "config.h"
+
 #include <libusb.h>
 #include <stdio.h>
+
+#if defined (HAVE_PTHREAD_CREATE) || defined(HAVE_WIN_PTHREAD)
 #include <pthread.h>
 
 /* Test that creates and destroys contexts repeatedly */
@@ -43,3 +47,13 @@ int main(void)
 
 	return 0;
 }
+
+#else
+int main(int argc, char **argv)
+{
+	(void) argc;
+	printf("%s: This test requires Posix threads\n", argv[0]);
+	/* return success to not upset CI test runs */
+	return 0;
+}
+#endif /* HAVE_PTHREAD_CREATE */

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -9,7 +9,7 @@
 
 static void *test_init_and_exit(void * arg)
 {
-	long int threadno = (long int) arg;
+	long int threadno = (long int)(intptr_t) arg;
 
 	printf("Thread %ld started\n", threadno);
 	for (int i = 0; i < ITERS; ++i) {
@@ -34,7 +34,7 @@ int main(void)
 
 	printf("Starting multithreaded init and exit test...\n");
 	for(t = 0; t < NTHREADS; t++)
-		pthread_create(&threadId[t], NULL, &test_init_and_exit, (void *) t);
+		pthread_create(&threadId[t], NULL, &test_init_and_exit, (void *)(intptr_t) t);
 
 	for(t = 0; t < NTHREADS; t++)
 		pthread_join(threadId[t], NULL);


### PR DESCRIPTION
There is a bit of autoconf crafting to make sure we only add pthreads for stress_mt, and not for library building. Would be good if some autoconf aficinados can review this.

Maybe it would have been easier to add native Windows thread support to stress_mt :-/