### PR TITLE
Continuation of "add support for querying serial manufacturer product without opening device"

### DIFF
--- a/examples/listdevs.c
+++ b/examples/listdevs.c
@@ -45,6 +45,13 @@ static void print_devs(libusb_device **devs)
 			for (j = 1; j < r; j++)
 				printf(".%d", path[j]);
 		}
+
+		unsigned char buf[255];
+		r = libusb_get_serial_string_descriptor_ascii(dev, buf, sizeof(buf));
+		if (r > 0) {
+			printf(" serial: \"%s\"", buf);
+		}
+
 		printf("\n");
 	}
 }

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -539,6 +539,49 @@ int API_EXPORTED libusb_get_device_descriptor(libusb_device *dev,
 }
 
 /** \ingroup libusb_desc
+ * Get the USB device serial for a given device. The string returned is Unicode,
+ * as detailed in the USB specifications.
+ *
+ * \param dev the device
+ * \param data output buffer for descriptor
+ * \param length size of data buffer
+ * \returns number of bytes returned in data, or LIBUSB_ERROR code on failure
+ * \see libusb_get_serial_string_descriptor_ascii()
+ */
+int API_EXPORTED libusb_get_serial_string_descriptor(libusb_device *dev,
+	unsigned char *data, int length)
+{
+	if (usbi_backend.get_serial_string_descriptor) {
+		return usbi_backend.get_serial_string_descriptor(dev, data, length);
+	}
+
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+/** \ingroup libusb_desc
+ * Get the USB device serial for a given device in C style ASCII.
+ *
+ * Wrapper around libusb_get_serial_string_descriptor().
+ *
+ * \param dev the device
+ * \param data output buffer for ASCII string descriptor
+ * \param length size of data buffer
+ * \returns number of bytes returned in data, or LIBUSB_ERROR code on failure
+ */
+int API_EXPORTED libusb_get_serial_string_descriptor_ascii(libusb_device *dev,
+	unsigned char *data, int length)
+{
+	union usbi_string_desc_buf str;
+	int r;
+
+	r = libusb_get_serial_string_descriptor(dev, str.buf, sizeof(str.buf));
+	if (r < 0)
+		return r;
+
+	return usbi_string_descriptor_to_ascii(&str, data, length);
+}
+
+/** \ingroup libusb_desc
  * Get the USB configuration descriptor for the currently active configuration.
  * This is a non-blocking function which does not involve any requests being
  * sent to the device.

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -104,6 +104,10 @@ EXPORTS
   libusb_get_port_numbers@12 = libusb_get_port_numbers
   libusb_get_port_path
   libusb_get_port_path@16 = libusb_get_port_path
+  libusb_get_serial_string_descriptor
+  libusb_get_serial_string_descriptor@12 = libusb_get_serial_string_descriptor
+  libusb_get_serial_string_descriptor_ascii
+  libusb_get_serial_string_descriptor_ascii@12 = libusb_get_serial_string_descriptor_ascii
   libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_endpoint_companion_descriptor@12 = libusb_get_ss_endpoint_companion_descriptor
   libusb_get_ss_usb_device_capability_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1588,6 +1588,10 @@ int LIBUSB_CALL libusb_get_configuration(libusb_device_handle *dev,
 	int *config);
 int LIBUSB_CALL libusb_get_device_descriptor(libusb_device *dev,
 	struct libusb_device_descriptor *desc);
+int LIBUSB_CALL libusb_get_serial_string_descriptor(libusb_device *dev,
+	unsigned char *data, int length);
+int LIBUSB_CALL libusb_get_serial_string_descriptor_ascii(libusb_device *dev,
+	unsigned char *data, int length);
 int LIBUSB_CALL libusb_get_active_config_descriptor(libusb_device *dev,
 	struct libusb_config_descriptor **config);
 int LIBUSB_CALL libusb_get_config_descriptor(libusb_device *dev,

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -824,6 +824,9 @@ void usbi_destroy_event(usbi_event_t *event);
 void usbi_signal_event(usbi_event_t *event);
 void usbi_clear_event(usbi_event_t *event);
 
+int usbi_string_descriptor_to_ascii(union usbi_string_desc_buf* str,
+	unsigned char *data, int length);
+
 #ifdef HAVE_OS_TIMER
 int usbi_create_timer(usbi_timer_t *timer);
 void usbi_destroy_timer(usbi_timer_t *timer);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1079,6 +1079,20 @@ struct usbi_os_backend {
 	 */
 	void (*close)(struct libusb_device_handle *dev_handle);
 
+	/* Retrieve the device serial number string from a device.
+	 *
+	 * The descriptor should be retrieved from memory, NOT via bus I/O to the
+	 * device. This means that you may have to cache it in a private structure
+	 * during get_device_list enumeration. Alternatively, you may be able
+	 * to retrieve it from a kernel interface still without generating bus I/O.
+	 *
+	 * This function is expected to write length bytes into data or fewer.
+	 *
+	 * Return size of written data on success or a LIBUSB_ERROR code on failure.
+	 */
+	int (*get_serial_string_descriptor)(struct libusb_device *dev,
+		unsigned char *data, int length);
+
 	/* Get the ACTIVE configuration descriptor for a device.
 	 *
 	 * The descriptor should be retrieved from memory, NOT via bus I/O to the

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -191,6 +191,7 @@ const struct usbi_os_backend usbi_backend = {
 	/*.open =*/ haiku_open,
 	/*.close =*/ haiku_close,
 
+	/*.get_serial_string_descriptor =*/ NULL,
 	/*.get_active_config_descriptor =*/ haiku_get_active_config_descriptor,
 	/*.get_config_descriptor =*/ haiku_get_config_descriptor,
 	/*.get_config_descriptor_by_value =*/ NULL,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -892,6 +892,7 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* wrap_sys_device */
 	windows_open,
 	windows_close,
+	NULL,	/* get_serial_string_descriptor */
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,
 	windows_get_config_descriptor_by_value,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -645,6 +645,13 @@ static void windows_close(struct libusb_device_handle *dev_handle)
 	priv->backend->close(dev_handle);
 }
 
+static int windows_get_serial_string_descriptor(struct libusb_device *dev,
+	unsigned char *data, int length)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(DEVICE_CTX(dev));
+	return priv->backend->get_serial_string_descriptor(dev, data, length);
+}
+
 static int windows_get_active_config_descriptor(struct libusb_device *dev,
 	void *buffer, size_t len)
 {
@@ -892,7 +899,7 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* wrap_sys_device */
 	windows_open,
 	windows_close,
-	NULL,	/* get_serial_string_descriptor */
+	windows_get_serial_string_descriptor,
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,
 	windows_get_config_descriptor_by_value,

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -189,6 +189,12 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
 	UCHAR  MaxPower;
 } USB_CONFIGURATION_DESCRIPTOR, *PUSB_CONFIGURATION_DESCRIPTOR;
 
+typedef struct USB_STRING_DESCRIPTOR {
+	UCHAR bLength;
+	UCHAR bDescriptorType;
+	WCHAR bString[1];
+} USB_STRING_DESCRIPTOR, *PUSB_STRING_DESCRIPTOR;
+
 #include <poppack.h>
 
 #define MAX_DEVICE_ID_LEN	200
@@ -267,6 +273,7 @@ struct winusb_device_priv {
 	} usb_interface[USB_MAXINTERFACES];
 	struct hid_device_priv *hid;
 	PUSB_CONFIGURATION_DESCRIPTOR *config_descriptor; // list of pointers to the cached config descriptors
+	PUSB_STRING_DESCRIPTOR serial_string_descriptor;
 	GUID class_guid; // checked for change during re-enumeration
 };
 
@@ -321,6 +328,8 @@ struct windows_backend {
 		struct discovered_devs **discdevs);
 	int (*open)(struct libusb_device_handle *dev_handle);
 	void (*close)(struct libusb_device_handle *dev_handle);
+	int (*get_serial_string_descriptor)(struct libusb_device *device,
+		unsigned char *data, int length);
 	int (*get_active_config_descriptor)(struct libusb_device *device,
 		void *buffer, size_t len);
 	int (*get_config_descriptor)(struct libusb_device *device,

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -359,6 +359,16 @@ func_exit:
 	return r;
 }
 
+static int usbdk_get_serial_string_descriptor(struct libusb_device *device,
+	unsigned char *data, int length)
+{
+	UNREFERENCED_PARAMETER(device);
+	UNREFERENCED_PARAMETER(data);
+	UNREFERENCED_PARAMETER(length);
+
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int usbdk_get_config_descriptor(struct libusb_device *dev, uint8_t config_index, void *buffer, size_t len)
 {
 	struct usbdk_device_priv *priv = usbi_get_device_priv(dev);
@@ -706,6 +716,7 @@ const struct windows_backend usbdk_backend = {
 	usbdk_get_device_list,
 	usbdk_open,
 	usbdk_close,
+	usbdk_get_serial_string_descriptor,
 	usbdk_get_active_config_descriptor,
 	usbdk_get_config_descriptor,
 	usbdk_get_config_descriptor_by_value,

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -201,6 +201,7 @@ static inline void winusb_device_priv_release(struct libusb_device *dev)
 		}
 	}
 	free(priv->config_descriptor);
+	free(priv->serial_string_descriptor);
 	free(priv->hid);
 	for (i = 0; i < USB_MAXINTERFACES; i++) {
 		free(priv->usb_interface[i].path);
@@ -348,6 +349,11 @@ typedef struct _USB_CONFIGURATION_DESCRIPTOR_SHORT {
 	USB_DESCRIPTOR_REQUEST req;
 	USB_CONFIGURATION_DESCRIPTOR desc;
 } USB_CONFIGURATION_DESCRIPTOR_SHORT;
+
+typedef struct _USB_STRING_DESCRIPTOR_SHORT {
+	USB_DESCRIPTOR_REQUEST req;
+	USB_STRING_DESCRIPTOR desc;
+} USB_STRING_DESCRIPTOR_SHORT;
 
 typedef struct USB_INTERFACE_DESCRIPTOR {
 	UCHAR bLength;


### PR DESCRIPTION
This is a continuation / replacement for https://github.com/libusb/libusb/pull/875, starting where @hjmallon left it, i.e. at the commit referenced here: https://github.com/libusb/libusb/pull/875#issuecomment-779791692 : _"I have a windows patch which I was using on 1.0.22 branch here https://github.com/hjmallon/libusb/commit/d0f9fd4852dfceaa4f8f55700ed9b74c4e5406dd but too much stuff has changed in that area in between and it doesn't build"_

This commit branch is rebased on current master and corrected for issues under Windows, therefore this PR is 99.9% @hjmallon code.

As described here https://github.com/libusb/libusb/pull/875#issuecomment-1457854746 the idea is to get some first validation on the principle of these changes, before investing time for adding support for manufacturer and product strings in the same way as done for serial number.

Thanks in advance for your review.