### PR TITLE
Adjust IOUSBLib interface versions used based on the running macOS (or Mac OS X) version

### DIFF
--- a/libusb/Makefile.am
+++ b/libusb/Makefile.am
@@ -34,8 +34,10 @@ if OS_DARWIN
 OS_SRC = $(OS_DARWIN_SRC)
 endif
 
+noinst_LTLIBRARIES =
+
 if OS_HAIKU
-noinst_LTLIBRARIES = libusb_haiku.la
+noinst_LTLIBRARIES += libusb_haiku.la
 libusb_haiku_la_SOURCES = $(OS_HAIKU_SRC)
 libusb_1_0_la_LIBADD = libusb_haiku.la
 endif
@@ -50,7 +52,7 @@ endif
 endif
 
 if OS_EMSCRIPTEN
-noinst_LTLIBRARIES = libusb_emscripten.la
+noinst_LTLIBRARIES += libusb_emscripten.la
 libusb_emscripten_la_SOURCES = $(OS_EMSCRIPTEN_SRC)
 libusb_1_0_la_LIBADD = libusb_emscripten.la
 endif

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -160,15 +160,13 @@
 #define IO_OBJECT_NULL ((io_object_t) 0)
 #endif
 
-/* Testing availability */
-#ifndef __has_builtin
-  #define __has_builtin(x) 0  // Compatibility with non-clang compilers.
-#endif
-#if __has_builtin(__builtin_available)
-  #define HAS_CAPTURE_DEVICE() __builtin_available(macOS 10.10, *)
-#else
-  #define HAS_CAPTURE_DEVICE() 0
-#endif
+/* returns the current macOS version in a format similar to the
+ * MAC_OS_X_VERSION_MIN_REQUIRED macro.
+ * Examples:
+ *   10.1.5 -> 100105
+ *   13.3.0 -> 130300
+ */
+uint32_t get_running_version(void);
 
 typedef IOCFPlugInInterface *io_cf_plugin_ref_t;
 typedef IONotificationPortRef io_notification_port_t;

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -1,7 +1,7 @@
 /*
  * darwin backend for libusb 1.0
- * Copyright © 2008-2019 Nathan Hjelm <hjelmn@users.sourceforge.net>
- * Copyright © 2019      Google LLC. All rights reserved.
+ * Copyright © 2008-2023 Nathan Hjelm <hjelmn@users.sourceforge.net>
+ * Copyright © 2019-2023 Google LLC. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,67 +36,26 @@
 
 /* IOUSBInterfaceInferface */
 
-/* New in OS 10.12.0. */
-#if defined (kIOUSBInterfaceInterfaceID800)
-
-#define usb_interface_t IOUSBInterfaceInterface800
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID800
-#define InterfaceVersion 800
-
-/* New in OS 10.10.0. */
-#elif defined (kIOUSBInterfaceInterfaceID700)
-
-#define usb_interface_t IOUSBInterfaceInterface700
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID700
-#define InterfaceVersion 700
-
-/* New in OS 10.9.0. */
-#elif defined (kIOUSBInterfaceInterfaceID650)
-
-#define usb_interface_t IOUSBInterfaceInterface650
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID650
-#define InterfaceVersion 650
-
-/* New in OS 10.8.2 but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBInterfaceInterfaceID550)
-
-#define usb_interface_t IOUSBInterfaceInterface550
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID550
-#define InterfaceVersion 550
-
-/* New in OS 10.7.3 but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBInterfaceInterfaceID500)
-
-#define usb_interface_t IOUSBInterfaceInterface500
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID500
-#define InterfaceVersion 500
-
-/* New in OS 10.5.0. */
-#elif defined (kIOUSBInterfaceInterfaceID300)
-
-#define usb_interface_t IOUSBInterfaceInterface300
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID300
-#define InterfaceVersion 300
-
-/* New in OS 10.4.5 (or 10.4.6?) but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBInterfaceInterfaceID245)
-
-#define usb_interface_t IOUSBInterfaceInterface245
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID245
-#define InterfaceVersion 245
-
-/* New in OS 10.4.0. */
-#elif defined (kIOUSBInterfaceInterfaceID220)
-
-#define usb_interface_t IOUSBInterfaceInterface220
-#define InterfaceInterfaceID kIOUSBInterfaceInterfaceID220
-#define InterfaceVersion 220
-
+#if defined(kIOUSBInterfaceInterfaceID800)
+#define MAX_INTERFACE_VERSION 800
+#elif defined(kIOUSBInterfaceInterfaceID700)
+#define	MAX_INTERFACE_VERSION 700
+#elif defined(kIOUSBInterfaceInterfaceID650)
+#define MAX_INTERFACE_VERSION 650
+#elif defined(kIOUSBInterfaceInterfaceID550)
+#define MAX_INTERFACE_VERSION 550
+#elif defined(kIOUSBInterfaceInterfaceID245)
+#define MAX_INTERFACE_VERSION 245
 #else
-
-#error "IOUSBFamily is too old. Please upgrade your SDK and/or deployment target"
-
+#define	MAX_INTERFACE_VERSION 220
 #endif
+
+/* set to the minimum version and casted up as needed. */
+typedef IOUSBInterfaceInterface220 **usb_interface_t;
+
+#define IOINTERFACE0(darwin_interface, version) ((IOUSBInterfaceInterface ## version **) (darwin_interface)->interface)
+#define IOINTERFACE_V(darwin_interface, version) IOINTERFACE0(darwin_interface, version)
+#define IOINTERFACE(darwin_interface) ((darwin_interface)->interface)
 
 /* IOUSBDeviceInterface */
 
@@ -199,7 +158,7 @@ struct darwin_device_handle_priv {
   CFRunLoopSourceRef   cfSource;
 
   struct darwin_interface {
-    usb_interface_t    **interface;
+    usb_interface_t      interface;
     uint8_t              num_endpoints;
     CFRunLoopSourceRef   cfSource;
     uint64_t             frames[256];

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -59,53 +59,25 @@ typedef IOUSBInterfaceInterface220 **usb_interface_t;
 
 /* IOUSBDeviceInterface */
 
-/* New in OS 10.9.0. */
-#if defined (kIOUSBDeviceInterfaceID650)
-
-#define usb_device_t    IOUSBDeviceInterface650
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID650
-#define DeviceVersion 650
-
-/* New in OS 10.7.3 but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBDeviceInterfaceID500)
-
-#define usb_device_t    IOUSBDeviceInterface500
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID500
-#define DeviceVersion 500
-
-/* New in OS 10.5.4 but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBDeviceInterfaceID320)
-
-#define usb_device_t    IOUSBDeviceInterface320
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID320
-#define DeviceVersion 320
-
-/* New in OS 10.5.0. */
-#elif defined (kIOUSBDeviceInterfaceID300)
-
-#define usb_device_t    IOUSBDeviceInterface300
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID300
-#define DeviceVersion 300
-
-/* New in OS 10.4.5 (or 10.4.6?) but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBDeviceInterfaceID245)
-
-#define usb_device_t    IOUSBDeviceInterface245
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID245
-#define DeviceVersion 245
-
-/* New in OS 10.2.3 but can't test deployment target to that granularity, so round up. */
-#elif defined (kIOUSBDeviceInterfaceID197)
-
-#define usb_device_t    IOUSBDeviceInterface197
-#define DeviceInterfaceID kIOUSBDeviceInterfaceID197
-#define DeviceVersion 197
-
+#if defined(kIOUSBDeviceInterfaceID650)
+#define MAX_DEVICE_VERSION 650
+#elif defined(kIOUSBDeviceInterfaceID500)
+#define	MAX_DEVICE_VERSION 500
+#elif defined(kIOUSBDeviceInterfaceID320)
+#define MAX_DEVICE_VERSION 320
+#elif defined(kIOUSBDeviceInterfaceID300)
+#define MAX_DEVICE_VERSION 300
+#elif defined(kIOUSBDeviceInterfaceID245)
+#define MAX_DEVICE_VERSION 245
 #else
-
-#error "IOUSBFamily is too old. Please upgrade your SDK and/or deployment target"
-
+#define	MAX_DEVICE_VERSION 197
 #endif
+
+/* set to the minimum version and casted up as needed */
+typedef IOUSBDeviceInterface197 **usb_device_t;
+
+#define IODEVICE0(darwin_device, version) ((IOUSBDeviceInterface ## version **)(darwin_device))
+#define IODEVICE_V(darwin_device, version) IODEVICE0(darwin_device, version)
 
 #if !defined(kIOUSBHostInterfaceClassName)
 #define kIOUSBHostInterfaceClassName "IOUSBHostInterface"
@@ -139,7 +111,7 @@ struct darwin_cached_device {
   UInt64                session;
   USBDeviceAddress      address;
   char                  sys_path[21];
-  usb_device_t        **device;
+  usb_device_t          device;
   io_service_t          service;
   int                   open_count;
   UInt8                 first_config, active_config, port;

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11838
+#define LIBUSB_NANO 11839

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11839
+#define LIBUSB_NANO 11840

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11840
+#define LIBUSB_NANO 11841

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11841
+#define LIBUSB_NANO 11842

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,11 +1,12 @@
 AM_CPPFLAGS = -I$(top_srcdir)/libusb
 LDADD = ../libusb/libusb-1.0.la
-LIBS =
+LDFLAGS = -static
 
 stress_SOURCES = stress.c testlib.c
 stress_mt_SOURCES = stress_mt.c
 set_option_SOURCES = set_option.c testlib.c
 init_context_SOURCES = init_context.c testlib.c
+macos_SOURCES = macos.c testlib.c
 
 stress_mt_CFLAGS = $(AM_CFLAGS) $(THREAD_CFLAGS)
 stress_mt_LDADD = $(LDADD) $(THREAD_LIBS)
@@ -20,6 +21,9 @@ endif
 
 noinst_HEADERS = libusb_testlib.h
 noinst_PROGRAMS = stress stress_mt set_option init_context
+if OS_DARWIN
+noinst_PROGRAMS += macos
+endif
 
 if BUILD_UMOCKDEV_TEST
 # NOTE: We add libumockdev-preload.so so that we can run tests in-process

--- a/tests/macos.c
+++ b/tests/macos.c
@@ -1,0 +1,130 @@
+/* -*- Mode: C; indent-tabs-mode:nil -*- */
+/*
+ * Unit tests for libusb_set_option
+ * Copyright © 2023 Nathan Hjelm <hjelmn@cs.unm.edu>
+ * Copyright © 2023 Google, LLC. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include "libusbi.h"
+#include "libusb_testlib.h"
+
+#define LIBUSB_TEST_CLEAN_EXIT(code) \
+  do {                               \
+    if (test_ctx != NULL) {          \
+      libusb_exit(test_ctx);         \
+    }                                \
+    unsetenv("LIBUSB_DEBUG");        \
+    return (code);                   \
+  } while (0)
+
+/**
+ * Fail the test if the expression does not evaluate to LIBUSB_SUCCESS.
+ */
+#define LIBUSB_TEST_RETURN_ON_ERROR(expr)                       \
+  do {                                                          \
+    int _result = (expr);                                       \
+    if (LIBUSB_SUCCESS != _result) {                            \
+      libusb_testlib_logf("Not success (%s) at %s:%d", #expr,   \
+                          __FILE__, __LINE__);                  \
+      LIBUSB_TEST_CLEAN_EXIT(TEST_STATUS_FAILURE);              \
+    }                                                           \
+  } while (0)
+
+/**
+ * Use relational operatator to compare two values and fail the test if the
+ * comparison is false. Intended to compare integer or pointer types.
+ *
+ * Example: LIBUSB_EXPECT(==, 0, 1) -> fail, LIBUSB_EXPECT(==, 0, 0) -> ok.
+ */
+#define LIBUSB_EXPECT(operator, lhs, rhs)                               \
+  do {                                                                  \
+    int64_t _lhs = (lhs), _rhs = (rhs);                                 \
+    if (!(_lhs operator _rhs)) {                                        \
+      libusb_testlib_logf("Expected %s (%" PRId64 ") " #operator        \
+                          " %s (%" PRId64 ") at %s:%d", #lhs,           \
+                          (int64_t)(intptr_t)_lhs, #rhs,                \
+                          (int64_t)(intptr_t)_rhs, __FILE__,            \
+                          __LINE__);                                    \
+      LIBUSB_TEST_CLEAN_EXIT(TEST_STATUS_FAILURE);                      \
+    }                                                                   \
+  } while (0)
+
+
+extern uint32_t libusb_testonly_fake_running_version;
+extern int libusb_testonly_using_running_interface_version;
+extern int libusb_testonly_using_running_device_version;
+extern bool libusb_testonly_clear_running_version_cache;
+
+static libusb_testlib_result test_macos_version_fallback(void) {
+  libusb_context *test_ctx = NULL;
+  libusb_testonly_fake_running_version = 100001;
+  libusb_testonly_clear_running_version_cache = true;
+
+  LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,
+                                                  /*num_options=*/0));
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_interface_version, 220);
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_device_version, 197);
+
+  libusb_exit(test_ctx);
+  test_ctx = NULL;
+
+  libusb_testonly_fake_running_version = 100900;
+
+  LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,
+                                                  /*num_options=*/0));
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_interface_version, 650);
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_device_version, 650);
+
+  libusb_exit(test_ctx);
+  test_ctx = NULL;
+
+  libusb_testonly_fake_running_version = 101200;
+
+  LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,
+                                                  /*num_options=*/0));
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_interface_version, 800);
+  LIBUSB_EXPECT(==, libusb_testonly_using_running_device_version, 650);
+
+  libusb_exit(test_ctx);
+  test_ctx = NULL;
+
+  // Test a version smaller than 10.0. Initialization should fail.
+  libusb_testonly_fake_running_version = 99999;
+
+  int error = libusb_init_context(&test_ctx, /*options=*/NULL,
+                                  /*num_options=*/0);
+  LIBUSB_EXPECT(!=, error, LIBUSB_SUCCESS);
+
+
+  LIBUSB_TEST_CLEAN_EXIT(TEST_STATUS_SUCCESS);
+}
+
+static const libusb_testlib_test tests[] = {
+  { "test_macos_version_fallback", &test_macos_version_fallback },
+  LIBUSB_NULL_TEST
+};
+
+int main(int argc, char *argv[])
+{
+  return libusb_testlib_run_tests(argc, argv, tests);
+}


### PR DESCRIPTION
This is an RFC (needs some cleanup) on a potential way to handle using newer IOUSBLib interfaces even if the minimum macOS version of the binary is older. This is done by dynamically choosing the appropriate interface based on the environment at compile time and run time.