### PR TITLE
Second attempt to fix #1263 by acquiring the waiters during transfer callback and reordering sync_transfer_cb.

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1719,8 +1719,11 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 	transfer->actual_length = itransfer->transferred;
 	usbi_dbg(ctx, "transfer %p has callback %p",
 		 (void *) transfer, transfer->callback);
-	if (transfer->callback)
+	if (transfer->callback) {
+		libusb_lock_event_waiters (ctx);
 		transfer->callback(transfer);
+		libusb_unlock_event_waiters(ctx);
+	}
 	/* transfer might have been freed by the above call, do not use from
 	 * this point. */
 	if (flags & LIBUSB_TRANSFER_FREE_TRANSFER)

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -34,10 +34,15 @@
 
 static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 {
+	usbi_dbg(TRANSFER_CTX(transfer), "actual_length=%d", transfer->actual_length);
+
 	int *completed = transfer->user_data;
 	*completed = 1;
-	usbi_dbg(TRANSFER_CTX(transfer), "actual_length=%d", transfer->actual_length);
-	/* caller interprets result and frees transfer */
+	/*
+	 * Right after setting 'completed', another thread might free the transfer, so don't
+	 * access it beyond this point. The instantiating thread (not necessarily the
+	 * current one) interprets the result and frees the transfer.
+	 */
 }
 
 static void sync_transfer_wait_for_completion(struct libusb_transfer *transfer)


### PR DESCRIPTION
As discussed [here](https://github.com/libusb/libusb/issues/1263#issuecomment-1494386070), this PR replaces #1264 to fix #1263 and should properly fix the race condition by using a synchronization primitive (mutex) instead of solely relying on the order of operations on memory within `sync_transfer_cb`, which is not guaranteed by the language.