### PR TITLE
darwin: fix potential crash at darwin_exit

### DIFF
--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11793
+#define LIBUSB_NANO 11794


### PR DESCRIPTION
If initialization fails before hotplug can be set up then libusb_init will crash when it calls libusb_exit to clean up. This commit fixes the issue by only tearing down hotplug if it has been initialized.