### PR TITLE
Fix advertisement of detach kernel driver capability in sunos backend

### DIFF
--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -1584,7 +1584,7 @@ sunos_usb_get_status(struct libusb_context *ctx, int fd)
 
 const struct usbi_os_backend usbi_backend = {
         .name = "Solaris",
-        .caps = 0,
+        .caps = USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER,
         .get_device_list = sunos_get_device_list,
         .get_active_config_descriptor = sunos_get_active_config_descriptor,
         .get_config_descriptor = sunos_get_config_descriptor,


### PR DESCRIPTION
The code in the backend already supports this feature but fails to disclose it properly so application code may not be aware this is even available at times. This adds the corresponding capability flag so detach kernel driver support is properly advertised.