### PR TITLE
Fix enumeration of complex composite devices on Windows

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -29,7 +29,6 @@
 #include <setupapi.h>
 #include <ctype.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "libusbi.h"
 #include "windows_winusb.h"

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1381,6 +1381,7 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	int interface_number;
 	const char *mi_str;
 	int iadi, iadintfi;
+	char* endptr;
 	struct libusb_interface_association_descriptor_array *iad_array;
 	const struct libusb_interface_association_descriptor *iad;
 
@@ -1388,14 +1389,15 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	// devices will have only MI_00 & MI_03 for instance), we retrieve the actual
 	// interface number from the path's MI value
 	mi_str = strstr(device_id, "MI_");
-        // Initialize to default
-        interface_number = 0;
-		errno = 0;
-		char* endptr = NULL;
+
+	endptr = NULL;
+	interface_number = 0;
+	
 	if (mi_str != NULL) {
 		interface_number = strtoul(&mi_str[3], &endptr, 16);
 	}
-    if (mi_str == NULL || errno != 0 || endptr - &mi_str[3] != 2) {
+
+	if (mi_str == NULL || endptr - &mi_str[3] != 2) {
 		usbi_warn(ctx, "failure to read interface number for %s, using default value", device_id);
 		interface_number = 0;
 	}

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1390,7 +1390,8 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	mi_str = strstr(device_id, "MI_");
 
 	endptr = NULL;
-	interface_number = 0;
+	// This initialization, while redundant, is needed to make MSVC happy
+	interface_number = -1;
 	
 	if (mi_str != NULL) {
 		interface_number = strtoul(&mi_str[3], &endptr, 16);

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1390,11 +1390,14 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	mi_str = strstr(device_id, "MI_");
         // Initialize to default
         interface_number = 0;
+		errno = 0;
+		char* endptr = NULL;
 	if (mi_str != NULL) {
-		interface_number = strtoul(&mi_str[3], NULL, 16);
+		interface_number = strtoul(&mi_str[3], &endptr, 16);
 	}
-        if (mi_str == NULL || errno != 0) {
+    if (mi_str == NULL || errno != 0 || endptr - &mi_str[3] != 2) {
 		usbi_warn(ctx, "failure to read interface number for %s, using default value", device_id);
+		interface_number = 0;
 	}
 
 	if (interface_number >= USB_MAXINTERFACES) {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -29,6 +29,7 @@
 #include <setupapi.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <errno.h>
 
 #include "libusbi.h"
 #include "windows_winusb.h"
@@ -1387,11 +1388,13 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	// devices will have only MI_00 & MI_03 for instance), we retrieve the actual
 	// interface number from the path's MI value
 	mi_str = strstr(device_id, "MI_");
-	if ((mi_str != NULL) && isdigit((unsigned char)mi_str[3]) && isdigit((unsigned char)mi_str[4])) {
-		interface_number = ((mi_str[3] - '0') * 10) + (mi_str[4] - '0');
-	} else {
+        // Initialize to default
+        interface_number = 0;
+	if (mi_str != NULL) {
+		interface_number = strtoul(&mi_str[3], NULL, 16);
+	}
+        if (mi_str == NULL || errno != 0) {
 		usbi_warn(ctx, "failure to read interface number for %s, using default value", device_id);
-		interface_number = 0;
 	}
 
 	if (interface_number >= USB_MAXINTERFACES) {


### PR DESCRIPTION
On Windows when a composite device has multiple interfaces, they are addressed as VID_XXXX&PID_YYYY&MI_WZ. Windows support layer in libusb currently uses naive conversion (W - '0') * 10 + (Z-'0'). However the WZ is actually hex-encoded. This results in a failure enumerating interfaces above 9 (e.g. MI_0A).

This patch addresses the above inconsistency using strtoul to convert the index. It fixes [this issue](https://github.com/libusb/libusb/issues/1280) 