### PR TITLE
Replace option-based RAW_IO support with new API functions.

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2351,7 +2351,6 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 			/* Handle all backend-specific options here */
 		case LIBUSB_OPTION_USE_USBDK:
 		case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
-		case LIBUSB_OPTION_WINUSB_RAW_IO:
 			if (usbi_backend.set_option) {
 				r = usbi_backend.set_option(ctx, option, ap);
 				break;

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1501,39 +1501,6 @@ enum libusb_option {
 
 #define LIBUSB_OPTION_WEAK_AUTHORITY LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 
-	/** Enable or disable WinUSB RAW_IO mode on an endpoint
-	 *
-	 * Requires four additional arguments of:
-	 *
-	 *   libusb_device_handle *dev_handle
-	 *   unsigned int endpoint_address
-	 *   unsigned int enable
-	 *   unsigned int *max_transfer_size_ptr
-	 *
-	 * The dev_handle and endpoint_address parameters must identify a valid
-	 * IN endpoint on an open device. If enable is nonzero, RAW_IO is
-	 * enabled, otherwise it is disabled. Unless max_transfer_size_ptr is
-	 * NULL, then on a successful call to enable RAW_IO, it will be written
-	 * with the MAXIMUM_TRANSFER_SIZE value for the endpoint.
-	 *
-	 * Whilst RAW_IO is enabled for an endpoint, all transfers on that endpoint
-	 * must meet the following two requirements:
-	 *
-	 * * The buffer length must be a multiple of the maximum endpoint packet size.
-	 *
-	 * * The length must be less than or equal to the MAXIMUM_TRANSFER_SIZE value.
-	 *
-	 * This option should not be changed when any transfer is in progress on the
-	 * specified endpoint.
-	 *
-	 * This option only affects the WinUSB backend. On other backends it is ignored
-	 * and returns LIBUSB_OPTION_NOT_SUPPORTED, without modifying the value pointed
-	 * to by max_transfer_size_ptr.
-	 *
-	 *  Since version 1.0.27, \ref LIBUSB_API_VERSION >= 0x0100010A
-	 */
-	LIBUSB_OPTION_WINUSB_RAW_IO = 3,
-
 	/** Set the context log callback functon.
 	 *
 	 * Set the log callback function either on a context or globally. This
@@ -1543,9 +1510,9 @@ enum libusb_option {
 	 * equivalent to calling libusb_set_log_cb with mode
 	 * LIBUSB_LOG_CB_CONTEXT.
 	 */
-	LIBUSB_OPTION_LOG_CB = 4,
+	LIBUSB_OPTION_LOG_CB = 3,
 
-	LIBUSB_OPTION_MAX = 5
+	LIBUSB_OPTION_MAX = 4
 };
 
 /** \ingroup libusb_lib

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1667,6 +1667,13 @@ int LIBUSB_CALL libusb_attach_kernel_driver(libusb_device_handle *dev_handle,
 int LIBUSB_CALL libusb_set_auto_detach_kernel_driver(
 	libusb_device_handle *dev_handle, int enable);
 
+int LIBUSB_CALL libusb_backend_supports_raw_io(void);
+int LIBUSB_CALL libusb_get_max_raw_io_transfer_size(
+	libusb_device_handle *dev_handle,
+	unsigned int endpoint_address);
+int LIBUSB_CALL libusb_set_raw_io(libusb_device_handle *dev_handle,
+	unsigned int endpoint_address, int enable);
+
 /* async I/O */
 
 /** \ingroup libusb_asyncio

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1323,6 +1323,27 @@ struct usbi_os_backend {
 	int (*attach_kernel_driver)(struct libusb_device_handle *dev_handle,
 		uint8_t interface_number);
 
+	/* Retrieve the maximum transfer size supported for raw I/O for an
+	 * inbound bulk or interrupt endpoint on an open device. Optional.
+	 *
+	 * Return:
+	 * - a positive maximum transfer size on success.
+	 * - a LIBUSB_ERROR code on failure
+	 */
+	int (*get_max_raw_io_transfer_size)(
+		struct libusb_device_handle *dev_handle,
+		unsigned int endpoint);
+
+	/* Enable or disable raw I/O for an inbound bulk or interrupt endpoint
+	 * on an open device. Optional.
+	 *
+	 * Return:
+	 * - 0 on success
+	 * - a LIBUSB_ERROR code on failure
+	 */
+	int (*set_raw_io)(struct libusb_device_handle *dev_handle,
+		unsigned int endpoint, int enable);
+
 	/* Destroy a device. Optional.
 	 *
 	 * This function is called when the last reference to a device is

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -716,6 +716,24 @@ static void windows_destroy_device(struct libusb_device *dev)
 	priv->backend->destroy_device(dev);
 }
 
+static int windows_get_max_raw_io_transfer_size(struct libusb_device_handle *dev_handle,
+	unsigned int endpoint)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	if (priv->backend->get_max_raw_io_transfer_size)
+		return priv->backend->get_max_raw_io_transfer_size(dev_handle, endpoint);
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+static int windows_set_raw_io(struct libusb_device_handle *dev_handle,
+	unsigned int endpoint, int enable)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	if (priv->backend->set_raw_io)
+		return priv->backend->set_raw_io(dev_handle, endpoint, enable);
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int windows_submit_transfer(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
@@ -908,6 +926,8 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* kernel_driver_active */
 	NULL,	/* detach_kernel_driver */
 	NULL,	/* attach_kernel_driver */
+	windows_get_max_raw_io_transfer_size,
+	windows_set_raw_io,
 	windows_destroy_device,
 	windows_submit_transfer,
 	windows_cancel_transfer,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -608,6 +608,8 @@ static int windows_set_option(struct libusb_context *ctx, enum libusb_option opt
 {
 	struct windows_context_priv *priv = usbi_get_context_priv(ctx);
 
+	UNUSED(ap);
+
 	if (option == LIBUSB_OPTION_USE_USBDK) {
 		if (!usbdk_available) {
 			usbi_err(ctx, "UsbDk backend not available");
@@ -616,10 +618,6 @@ static int windows_set_option(struct libusb_context *ctx, enum libusb_option opt
 		usbi_dbg(ctx, "switching context %p to use UsbDk backend", ctx);
 		priv->backend = &usbdk_backend;
 		return LIBUSB_SUCCESS;
-	}
-
-	if (priv->backend->set_option) {
-		return priv->backend->set_option(ctx, option, ap);
 	}
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -342,7 +342,6 @@ struct windows_backend {
 	int (*cancel_transfer)(struct usbi_transfer *itransfer);
 	void (*clear_transfer_priv)(struct usbi_transfer *itransfer);
 	enum libusb_transfer_status (*copy_transfer_data)(struct usbi_transfer *itransfer, DWORD length);
-	int (*set_option)(struct libusb_context *ctx, enum libusb_option option, va_list args);
 };
 
 struct windows_context_priv {

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -342,6 +342,11 @@ struct windows_backend {
 	int (*cancel_transfer)(struct usbi_transfer *itransfer);
 	void (*clear_transfer_priv)(struct usbi_transfer *itransfer);
 	enum libusb_transfer_status (*copy_transfer_data)(struct usbi_transfer *itransfer, DWORD length);
+	int (*get_max_raw_io_transfer_size)(
+                struct libusb_device_handle *dev_handle,
+                unsigned int endpoint);
+	int (*set_raw_io)(struct libusb_device_handle *dev_handle,
+                unsigned int endpoint, int enable);
 };
 
 struct windows_context_priv {

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -721,5 +721,4 @@ const struct windows_backend usbdk_backend = {
 	NULL,	/* cancel_transfer */
 	usbdk_clear_transfer_priv,
 	usbdk_copy_transfer_data,
-	NULL /* usbdk_set_option */,
 };

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -721,4 +721,6 @@ const struct windows_backend usbdk_backend = {
 	NULL,	/* cancel_transfer */
 	usbdk_clear_transfer_priv,
 	usbdk_copy_transfer_data,
+	NULL,	/* get_max_raw_io_transfer_size */
+	NULL,	/* set_raw_io */
 };

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -42,8 +42,6 @@
 		continue;			\
 	}
 
-static int interface_by_endpoint(struct winusb_device_priv *priv,
-	struct winusb_device_handle_priv *handle_priv, uint8_t endpoint_address);
 // WinUSB-like API prototypes
 static bool winusbx_init(struct libusb_context *ctx);
 static void winusbx_exit(void);
@@ -2177,111 +2175,6 @@ static enum libusb_transfer_status winusb_copy_transfer_data(struct usbi_transfe
 	return priv->apib->copy_transfer_data(SUB_API_NOTSET, itransfer, length);
 }
 
-static int winusb_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
-{
-	struct libusb_device_handle *dev_handle;
-	unsigned int endpoint;
-	unsigned int enable;
-	unsigned int *max_transfer_size_ptr;
-	struct winusb_device_handle_priv *handle_priv;
-	struct winusb_device_priv *priv;
-	UCHAR policy;
-	int current_interface;
-	HANDLE winusb_handle;
-	int sub_api = SUB_API_NOTSET;
-	ULONG max_transfer_size = 0;
-
-	switch (option) {
-	case LIBUSB_OPTION_WINUSB_RAW_IO:
-		dev_handle = va_arg(ap, struct libusb_device_handle *);
-		endpoint = va_arg(ap, unsigned int);
-		enable = va_arg(ap, unsigned int);
-		max_transfer_size_ptr = va_arg(ap, unsigned int *);
-
-		policy = enable != 0;
-
-		if (dev_handle == NULL) {
-			usbi_err(ctx, "device handle passed for RAW_IO was NULL");
-			return LIBUSB_ERROR_INVALID_PARAM;
-		}
-
-		if (HANDLE_CTX(dev_handle) != ctx) {
-			usbi_err(ctx, "device handle passed for RAW_IO has wrong context");
-			return LIBUSB_ERROR_INVALID_PARAM;
-		}
-
-		if (endpoint & ~(LIBUSB_ENDPOINT_DIR_MASK | LIBUSB_ENDPOINT_ADDRESS_MASK)) {
-			usbi_err(ctx, "invalid endpoint %X passed for RAW_IO", endpoint);
-			return LIBUSB_ERROR_INVALID_PARAM;
-		}
-
-		if (!(endpoint & LIBUSB_ENDPOINT_DIR_MASK)) {
-			usbi_err(ctx, "endpoint %02X passed for RAW_IO is OUT, not IN", endpoint);
-			return LIBUSB_ERROR_INVALID_PARAM;
-		}
-
-		handle_priv = get_winusb_device_handle_priv(dev_handle);
-		priv = usbi_get_device_priv(dev_handle->dev);
-		current_interface = interface_by_endpoint(priv, handle_priv, (uint8_t) endpoint);
-
-		if (current_interface < 0) {
-			usbi_err(ctx, "unable to match endpoint to an open interface for RAW_IO");
-			return LIBUSB_ERROR_NOT_FOUND;
-		}
-
-		if (priv->usb_interface[current_interface].apib->id != USB_API_WINUSBX) {
-			usbi_err(ctx, "interface is not winusb when setting RAW_IO");
-			return LIBUSB_ERROR_NOT_SUPPORTED;
-		}
-
-		winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
-
-		if (!HANDLE_VALID(winusb_handle)) {
-			usbi_err(HANDLE_CTX(dev_handle), "WinUSB handle not valid when setting RAW_IO");
-			return LIBUSB_ERROR_NOT_FOUND;
-		}
-
-		CHECK_WINUSBX_AVAILABLE(sub_api);
-
-		if (enable && max_transfer_size_ptr != NULL) {
-			ULONG size = sizeof(ULONG);
-			if (!WinUSBX[sub_api].GetPipePolicy(winusb_handle, (UCHAR) endpoint,
-				MAXIMUM_TRANSFER_SIZE, &size, &max_transfer_size)) {
-				usbi_err(ctx, "failed to get MAXIMUM_TRANSFER_SIZE for endpoint %02X", endpoint);
-				switch (GetLastError()) {
-				case ERROR_INVALID_HANDLE:
-					return LIBUSB_ERROR_INVALID_PARAM;
-				default:
-					return LIBUSB_ERROR_OTHER;
-				}
-			}
-		}
-
-		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, (UCHAR) endpoint,
-			RAW_IO, sizeof(UCHAR), &policy)) {
-			usbi_err(ctx, "failed to change RAW_IO for endpoint %02X", endpoint);
-			switch (GetLastError()) {
-			case ERROR_INVALID_HANDLE:
-			case ERROR_INVALID_PARAMETER:
-				return LIBUSB_ERROR_INVALID_PARAM;
-			case ERROR_NOT_ENOUGH_MEMORY:
-				return LIBUSB_ERROR_NO_MEM;
-			default:
-				return LIBUSB_ERROR_OTHER;
-			}
-		}
-
-		usbi_dbg(ctx, "%s RAW_IO for endpoint %02X", enable ? "enabled" : "disabled", endpoint);
-
-		if (enable && max_transfer_size_ptr != NULL)
-			*max_transfer_size_ptr = max_transfer_size;
-
-		return LIBUSB_SUCCESS;
-	default:
-		return LIBUSB_ERROR_NOT_SUPPORTED;
-	}
-}
-
 // NB: MSVC6 does not support named initializers.
 const struct windows_backend winusb_backend = {
 	winusb_init,
@@ -2304,7 +2197,6 @@ const struct windows_backend winusb_backend = {
 	winusb_cancel_transfer,
 	winusb_clear_transfer_priv,
 	winusb_copy_transfer_data,
-	winusb_set_option,
 };
 
 /*

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11807
+#define LIBUSB_NANO 11808

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11808
+#define LIBUSB_NANO 11809


### PR DESCRIPTION
This PR implements an improved API for controlling the WinUSB `RAW_IO` feature.

The `LIBUSB_OPTION_WINUSB_RAW_IO` option is removed. This is not an API break, as this option was not yet included in a release. The aim is to replace this API before the release of 1.0.27.

The option-based approach worked, but the requirement to attach several variadic arguments made it ugly and error-prone. It also had the undesirable effect of coupling two operations: fetching the maximum supported transfer size, and enabling or disabling raw I/O.

Instead of the option-based mechanism, three new functions are added to the API as follows:

```c
/* Check whether the backend in use supports raw I/O. Returns 1 if so, otherwise 0.
 *
 * When raw I/O is available, an application must take some extra steps if it needs to
 * achieve the highest possible inbound throughput on bulk and interrupt endpoints.
 * See libusb_set_raw_io.
 */
int libusb_backend_supports_raw_io(void);

/* Retrieve the maximum transfer size supported for raw I/O for an inbound bulk or
*  interrupt endpoint on an open device.
 *
 * Returns a maximum transfer size, or a negative error code.
 * If the backend does not support raw I/O, returns LIBUSB_ERROR_NOT_SUPPORTED.
 */
int libusb_get_max_raw_io_transfer_size(libusb_device_handle *dev_handle, unsigned int endpoint_address);

/* Enable or disable raw I/O for an inbound bulk or interrupt endpoint on an open device.
 *
 * When raw I/O is in use on an endpoint, all transfers on the endpoint must have a size that is
 * a multiple of the maximum packet size returned by `libusb_get_max_packet_size`, and less
 * than or equal to the maximum transfer size returned by `libusb_get_max_raw_io_transfer_size`.
 *
 * Returns LIBUSB_SUCCESS or a negative error code.
 * If the backend does not support raw I/O, returns LIBUSB_ERROR_NOT_SUPPORTED.
 */
int libusb_set_raw_io(libusb_device_handle *dev_handle, unsigned int endpoint_address, int enable);
```

For further background, see https://github.com/libusb/libusb/pull/1208#issuecomment-1554929606 and the discussion preceding it.