### PR TITLE
Add 20Gbps speed support for Linux and macOS backend.

### DIFF
--- a/android/examples/unrooted_android.c
+++ b/android/examples/unrooted_android.c
@@ -205,12 +205,13 @@ static void print_device(libusb_device *dev, libusb_device_handle *handle)
     uint8_t i;
 
     switch (libusb_get_device_speed(dev)) {
-        case LIBUSB_SPEED_LOW:		speed = "1.5M"; break;
-        case LIBUSB_SPEED_FULL:		speed = "12M"; break;
-        case LIBUSB_SPEED_HIGH:		speed = "480M"; break;
-        case LIBUSB_SPEED_SUPER:	speed = "5G"; break;
-        case LIBUSB_SPEED_SUPER_PLUS:	speed = "10G"; break;
-        default:			speed = "Unknown";
+        case LIBUSB_SPEED_LOW:			speed = "1.5M"; break;
+        case LIBUSB_SPEED_FULL:			speed = "12M"; break;
+        case LIBUSB_SPEED_HIGH:			speed = "480M"; break;
+        case LIBUSB_SPEED_SUPER:		speed = "5G"; break;
+        case LIBUSB_SPEED_SUPER_PLUS:		speed = "10G"; break;
+        case LIBUSB_SPEED_SUPER_PLUS_BY2:	speed = "20G"; break;
+        default:				speed = "Unknown";
     }
 
     ret = libusb_get_device_descriptor(dev, &desc);

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -169,12 +169,13 @@ static void print_device(libusb_device *dev, libusb_device_handle *handle)
 	uint8_t i;
 
 	switch (libusb_get_device_speed(dev)) {
-	case LIBUSB_SPEED_LOW:		speed = "1.5M"; break;
-	case LIBUSB_SPEED_FULL:		speed = "12M"; break;
-	case LIBUSB_SPEED_HIGH:		speed = "480M"; break;
-	case LIBUSB_SPEED_SUPER:	speed = "5G"; break;
-	case LIBUSB_SPEED_SUPER_PLUS:	speed = "10G"; break;
-	default:			speed = "Unknown";
+	case LIBUSB_SPEED_LOW:			speed = "1.5M"; break;
+	case LIBUSB_SPEED_FULL:			speed = "12M"; break;
+	case LIBUSB_SPEED_HIGH:			speed = "480M"; break;
+	case LIBUSB_SPEED_SUPER:		speed = "5G"; break;
+	case LIBUSB_SPEED_SUPER_PLUS:		speed = "10G"; break;
+	case LIBUSB_SPEED_SUPER_PLUS_BY2:	speed = "20G"; break;
+	default:				speed = "Unknown";
 	}
 
 	ret = libusb_get_device_descriptor(dev, &desc);

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -850,7 +850,7 @@ static int test_device(uint16_t vid, uint16_t pid)
 			printf(" (from root hub)\n");
 		}
 		r = libusb_get_device_speed(dev);
-		if ((r<0) || (r>5)) r=0;
+		if ((r<0) || (r>6)) r=0;
 		printf("             speed: %s\n", speed_name[r]);
 	}
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1140,7 +1140,10 @@ enum libusb_speed {
 	LIBUSB_SPEED_SUPER = 4,
 
 	/** The device is operating at super speed plus (10000MBit/s). */
-	LIBUSB_SPEED_SUPER_PLUS = 5
+	LIBUSB_SPEED_SUPER_PLUS = 5,
+
+	/** The device is operating at super speed plus (20000MBit/s). */
+	LIBUSB_SPEED_SUPER_PLUS_BY2 = 6
 };
 
 /** \ingroup libusb_misc

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1160,6 +1160,9 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
     case kUSBDeviceSpeedSuperPlus: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
 #endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+    case kUSBDeviceSpeedSuperPlusBy2: dev->speed = LIBUSB_SPEED_SUPER_PLUS_BY2; break;
+#endif
     default:
       usbi_warn (ctx, "Got unknown device speed %d", devSpeed);
     }

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -928,6 +928,7 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 			case   480: dev->speed = LIBUSB_SPEED_HIGH; break;
 			case  5000: dev->speed = LIBUSB_SPEED_SUPER; break;
 			case 10000: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
+			case 20000: dev->speed = LIBUSB_SPEED_SUPER_PLUS_BY2; break;
 			default:
 				usbi_warn(ctx, "unknown device speed: %d Mbps", speed);
 			}


### PR DESCRIPTION
As USB 3.2 devices come into market, a new speed needs to be supported.
There are three commits here in order to do the minimal things in each one.
One adds a new speed called LIBUSB_SPEED_SUPER_PLUS_BY2.
One adds support for macOS backend and the third one adds support for Linux backend.