### PR TITLE
Fix infinite loop in descriptor read

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1220,6 +1220,11 @@ static int parse_iad_array(struct libusb_context *ctx,
 	iad_array->length = 0;
 	while (consumed < size) {
 		parse_descriptor(buf, "bb", &header);
+		if (header.bLength < 2) {
+			usbi_err(ctx, "short descriptor read %d/%d",
+					 size, LIBUSB_DT_CONFIG_SIZE);
+			return LIBUSB_ERROR_IO;
+		}
 		if (header.bDescriptorType == LIBUSB_DT_INTERFACE_ASSOCIATION)
 			iad_array->length++;
 		buf += header.bLength;

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -652,13 +652,18 @@ static int seek_to_next_config(struct libusb_context *ctx,
 
 	while (len > 0) {
 		if (len < 2) {
-			usbi_err(ctx, "short descriptor read %zu/2", len);
+			usbi_err(ctx, "remaining descriptors len too small %zu/2", len);
 			return LIBUSB_ERROR_IO;
 		}
 
 		header = (struct usbi_descriptor_header *)buffer;
 		if (header->bDescriptorType == LIBUSB_DT_CONFIG)
 			return offset;
+
+		if (header->bLength < 2) {
+			usbi_err(ctx, "short descriptor read %hhu/2", header->bLength);
+			return LIBUSB_ERROR_IO;
+		}
 
 		if (len < header->bLength) {
 			usbi_err(ctx, "bLength overflow by %zu bytes",


### PR DESCRIPTION
This fixes an unlikely-in-practice bug which caused an infinite loop during some local testing. Namely, if the length specified by the descriptor header is 0, then the loop in `seek_to_next_config` will spin as the loop cannot exit without len increasing.