### PR TITLE
core: Add new function libusb_get_session_data

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -401,6 +401,7 @@ if (cfg != desired)
   * - libusb_free_usb_2_0_extension_descriptor()
   * - libusb_get_active_config_descriptor()
   * - libusb_get_bos_descriptor()
+  * - libusb_get_session_data()
   * - libusb_get_bus_number()
   * - libusb_get_config_descriptor()
   * - libusb_get_config_descriptor_by_value()
@@ -900,6 +901,17 @@ void API_EXPORTED libusb_free_device_list(libusb_device **list,
 			libusb_unref_device(dev);
 	}
 	free(list);
+}
+
+/** \ingroup libusb_dev
+ * Get the backend-specific handle (session data in terms of libusb) of a device.
+ * Can be used for direct low-level access to the backend when necessary.
+ * \param dev a device
+ * \returns the backend-specific handle (session data)
+ */
+unsigned long API_EXPORTED libusb_get_session_data(libusb_device *dev)
+{
+    return dev->session_data;
 }
 
 /** \ingroup libusb_dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -62,6 +62,8 @@ EXPORTS
   libusb_get_active_interface_association_descriptors@8 = libusb_get_active_interface_association_descriptors
   libusb_get_bos_descriptor
   libusb_get_bos_descriptor@8 = libusb_get_bos_descriptor
+  libusb_get_session_data
+  libusb_get_session_data@4 = libusb_get_session_data
   libusb_get_bus_number
   libusb_get_bus_number@4 = libusb_get_bus_number
   libusb_get_config_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -151,6 +151,11 @@ typedef SSIZE_T ssize_t;
 /* The following is kept for compatibility, but will be deprecated in the future */
 #define LIBUSBX_API_VERSION LIBUSB_API_VERSION
 
+/** \ingroup libusb_dev
+ * Can be used to determine the presence of libusb_get_session_data for
+ * conditional compilation */
+#define LIBUSB_HAS_GET_SESSION_DATA 1
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -1638,6 +1643,7 @@ int LIBUSB_CALL libusb_get_platform_descriptor(libusb_context *ctx,
 	struct libusb_platform_descriptor **platform_descriptor);
 void LIBUSB_CALL libusb_free_platform_descriptor(
 	struct libusb_platform_descriptor *platform_descriptor);
+unsigned long LIBUSB_CALL libusb_get_session_data(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_bus_number(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_port_number(libusb_device *dev);
 int LIBUSB_CALL libusb_get_port_numbers(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len);


### PR DESCRIPTION
This trivial getter returns the platform-specific libusb_device::session_data to allow finding the original node for a particular libusb_device in the system device tree (DEVINST in SetupAPI/CfgMgr32 on Windows; sessionID in IOKit on macOS)