### PR TITLE
core: Add new function libusb_get_session_data

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -406,6 +406,7 @@ if (cfg != desired)
   * - libusb_free_usb_2_0_extension_descriptor()
   * - libusb_get_active_config_descriptor()
   * - libusb_get_bos_descriptor()
+  * - libusb_get_session_data()
   * - libusb_get_bus_number()
   * - libusb_get_config_descriptor()
   * - libusb_get_config_descriptor_by_value()
@@ -916,6 +917,26 @@ void API_EXPORTED libusb_free_device_list(libusb_device **list,
 			libusb_unref_device(dev);
 	}
 	free(list);
+}
+
+/** \ingroup libusb_dev
+ * Returns the backend-specific identifier of the underlying system device tree
+ * node. Can be used to find the corresponding system device and directly query
+ * it (or access it otherwise) when and if necessary.
+ *
+ * Relevant backends:
+ * - Darwin: IOKit `sessionID`
+ * - Windows WinUSB: `DEVINST`
+ * - Linux, BSD: `busnum << 8 | devnum`
+ *
+ * Since version 1.0.30, \ref LIBUSB_API_VERSION >= 0x0100010C
+ *
+ * \param dev a device (must not be null)
+ * \returns the backend-specific device identifier
+ */
+unsigned long API_EXPORTED libusb_get_session_data(libusb_device *dev)
+{
+    return dev->session_data;
 }
 
 /** \ingroup libusb_dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -66,6 +66,8 @@ EXPORTS
   libusb_get_active_interface_association_descriptors@8 = libusb_get_active_interface_association_descriptors
   libusb_get_bos_descriptor
   libusb_get_bos_descriptor@8 = libusb_get_bos_descriptor
+  libusb_get_session_data
+  libusb_get_session_data@4 = libusb_get_session_data
   libusb_get_bus_number
   libusb_get_bus_number@4 = libusb_get_bus_number
   libusb_get_config_descriptor

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1768,6 +1768,7 @@ int LIBUSB_CALL libusb_get_platform_descriptor(libusb_context *ctx,
 	struct libusb_platform_descriptor **platform_descriptor);
 void LIBUSB_CALL libusb_free_platform_descriptor(
 	struct libusb_platform_descriptor *platform_descriptor);
+unsigned long LIBUSB_CALL libusb_get_session_data(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_bus_number(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_port_number(libusb_device *dev);
 int LIBUSB_CALL libusb_get_port_numbers(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len);


### PR DESCRIPTION
This trivial getter returns the backend-specific handle (libusb_device::session_data)

Allows finding the original node for a particular libusb_device in the system device tree (DEVINST in SetupAPI/CfgMgr32 on Windows; sessionID in IOKit on macOS) and accessing it if necessary.