### PR TITLE
windows: Recognize Samsung composite device driver

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2311,7 +2311,10 @@ const struct windows_backend winusb_backend = {
  * USB API backends
  */
 
-static const char * const composite_driver_names[] = {"USBCCGP"};
+static const char * const composite_driver_names[] = {
+  "USBCCGP", // (Windows built-in) USB Composite Device
+  "dg_ssudbus" // SAMSUNG Mobile USB Composite Device
+};
 static const char * const winusbx_driver_names[] = {"libusbK", "libusb0", "WinUSB"};
 static const char * const hid_driver_names[] = {"HIDUSB", "MOUHID", "KBDHID"};
 const struct windows_usb_api_backend usb_api_backend[USB_API_MAX] = {


### PR DESCRIPTION
Relates to #1001 and https://github.com/Genymobile/scrcpy/issues/3654

This is a simple fix that treats SAMSUNG Mobile USB Composite Device driver (download: https://developer.samsung.com/android-usb-driver) as a composite device driver. This allows Samsung Android devices to be enumrated and opened by libusb.

I had previously filed a bug for Chrome's WebUSB implementation at https://crbug.com/1127206 and this PR is derived from their fix at https://chromium-review.googlesource.com/c/chromium/src/+/2436786.

Besides the name, Samsung's custom driver doesn't seem to behave differently from the Windows built-in driver (`usbccgp`). I have verified that Scrcpy OTG mode works on Samsung devices with their custom driver after this fix.