### PR TITLE
Match any device in hotplugtest by default

### DIFF
--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -60,10 +60,18 @@ static int LIBUSB_CALL hotplug_callback(libusb_context *ctx, libusb_device *dev,
 
 static int LIBUSB_CALL hotplug_callback_detach(libusb_context *ctx, libusb_device *dev, libusb_hotplug_event event, void *user_data)
 {
+	struct libusb_device_descriptor desc;
+	int rc;
+
 	(void)ctx;
 	(void)dev;
 	(void)event;
 	(void)user_data;
+
+	rc = libusb_get_device_descriptor(dev, &desc);
+	if (LIBUSB_SUCCESS != rc) {
+		fprintf (stderr, "Error getting device descriptor\n");
+	}
 
 	printf ("Device detached: %04x:%04x\n", desc.idVendor, desc.idProduct);
 

--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -65,7 +65,7 @@ static int LIBUSB_CALL hotplug_callback_detach(libusb_context *ctx, libusb_devic
 	(void)event;
 	(void)user_data;
 
-	printf ("Device detached\n");
+	printf ("Device detached: %04x:%04x\n", desc.idVendor, desc.idProduct);
 
 	if (handle) {
 		libusb_close (handle);
@@ -83,8 +83,8 @@ int main(int argc, char *argv[])
 	int product_id, vendor_id, class_id;
 	int rc;
 
-	vendor_id  = (argc > 1) ? (int)strtol (argv[1], NULL, 0) : 0x045a;
-	product_id = (argc > 2) ? (int)strtol (argv[2], NULL, 0) : 0x5005;
+	vendor_id  = (argc > 1) ? (int)strtol (argv[1], NULL, 0) : LIBUSB_HOTPLUG_MATCH_ANY;
+	product_id = (argc > 2) ? (int)strtol (argv[2], NULL, 0) : LIBUSB_HOTPLUG_MATCH_ANY;
 	class_id   = (argc > 3) ? (int)strtol (argv[3], NULL, 0) : LIBUSB_HOTPLUG_MATCH_ANY;
 
 	rc = libusb_init_context(/*ctx=*/NULL, /*options=*/NULL, /*num_options=*/0);


### PR DESCRIPTION
I spent some time trying to figure out why, when I run this example, it's not showing any events, until I looked into the code and saw it has some hardcoded vid:pid.

Most people probably don't have the specific device hardcoded here, and it seems better to default to showing events for any device unless overridden.

While at it, also updated device detached message to match the attached one to show vid:pid.