### PR TITLE
Run WebUSB tests via Node.js shim on CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,5 +40,14 @@ jobs:
         shell: bash
         run: .private/ci-build.sh --build-dir build-debug -- --enable-debug-log
 
+      - uses: mymindstorm/setup-emsdk@v13
+
+      - run: npm ci
+        working-directory: tests/webusb-test-shim
+
+      - name: emscripten
+        shell: bash
+        run: .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten
+
       - name: umockdev test
         run: .private/ci-container-build.sh docker.io/amd64/ubuntu:rolling

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: emscripten
         shell: bash
-        run: .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten
+        run: emconfigure .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten
 
       - name: umockdev test
         run: .private/ci-container-build.sh docker.io/amd64/ubuntu:rolling

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: netlink
         shell: bash
-        run: .private/ci-build.sh --build-dir build-netlink -- --disable-udev
+        # Disable tests for netlink as it doesn't seem to work in the CI environment.
+        run: .private/ci-build.sh --build-dir build-netlink --no-test -- --disable-udev
 
       - name: udev
         shell: bash

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -18,4 +18,5 @@ jobs:
         run: |
           echo 'Running in MSYS2!'
           ./bootstrap.sh
-          ./.private/ci-build.sh --build-dir build-msys2
+          # GCC on MSYS2 doesn't have ASAN support (but Clang does).
+          ./.private/ci-build.sh --build-dir build-msys2 --no-asan

--- a/.github/workflows/msys2_clang32.yml
+++ b/.github/workflows/msys2_clang32.yml
@@ -18,4 +18,8 @@ jobs:
         run: |
           echo 'Running in MSYS2!'
           ./bootstrap.sh
-          ./.private/ci-build.sh --build-dir build-msys2-clang32
+          # Disabling tests as there is some issue that prevents libtool from
+          # finalizing its executable wrappers.
+          # Perhaps this one https://github.com/msys2/MSYS2-packages/issues/1351
+          # but it only occurs on clang32 configuration.
+          ./.private/ci-build.sh --build-dir build-msys2-clang32 --no-test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Makefile.in
 *.lo
 *.o
 *.js
+!/tests/webusb-test-shim/*.js
 *.wasm
 *.html
 libtool

--- a/.private/appveyor_build.sh
+++ b/.private/appveyor_build.sh
@@ -19,4 +19,8 @@ echo "Bootstrapping ..."
 ./bootstrap.sh
 echo ""
 
-exec .private/ci-build.sh --build-dir "${builddir}" --install -- "--prefix=${installdir}"
+extra_args=""
+if [ "${Configuration}" == "Release" ]; then
+	extra_args="--no-asan"
+fi
+exec .private/ci-build.sh --build-dir "${builddir}" --install ${extra_args} -- "--prefix=${installdir}"

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -60,6 +60,12 @@ echo ""
 echo "Building ..."
 make -j4 -k
 
+for test in init_context set_option stress stress_mt; do
+	echo ""
+	echo "Running test '${test}' ..."
+	./tests/${test}
+done
+
 if [ "${install}" = "yes" ]; then
 	echo ""
 	echo "Installing ..."

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -72,7 +72,7 @@ fi
 
 echo ""
 echo "Configuring ..."
-CFLAGS="${cflags}" ../configure --enable-examples-build --enable-tests-build "$@"
+CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure --enable-examples-build --enable-tests-build "$@"
 
 echo ""
 echo "Building ..."

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -5,6 +5,7 @@ set -e
 builddir=
 install=no
 test=yes
+asan=yes
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -22,6 +23,10 @@ while [ $# -gt 0 ]; do
 		;;
 	--no-test)
 		test=no
+		shift
+		;;
+	--no-asan)
+		asan=no
 		shift
 		;;
 	--)
@@ -56,6 +61,11 @@ cflags+=" -Wnested-externs"
 cflags+=" -Wpointer-arith"
 cflags+=" -Wredundant-decls"
 cflags+=" -Wswitch-enum"
+
+# enable address sanitizer
+if [ "${asan}" = "yes" ]; then
+	cflags+=" -fsanitize=address"
+fi
 
 echo ""
 echo "Configuring ..."

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -62,6 +62,9 @@ cflags+=" -Wpointer-arith"
 cflags+=" -Wredundant-decls"
 cflags+=" -Wswitch-enum"
 
+# Tell tests that we don't have any devices.
+cflags+=" -DCI_WITHOUT_DEVICES"
+
 # enable address sanitizer
 if [ "${asan}" = "yes" ]; then
 	cflags+=" -fsanitize=address"

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -3,6 +3,7 @@
 set -e
 
 builddir=
+scriptdir=$(dirname $(readlink -f "$0"))
 install=no
 test=yes
 asan=yes
@@ -79,6 +80,8 @@ echo "Building ..."
 make -j4 -k
 
 if [ "${test}" = "yes" ]; then
+	# Load custom shim for WebUSB tests that simulates Web environment.
+	export NODE_OPTIONS="--require ${scriptdir}/../tests/webusb-test-shim/"
 	for test_name in init_context set_option stress stress_mt; do
 		echo ""
 		echo "Running test '${test_name}' ..."

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -4,6 +4,7 @@ set -e
 
 builddir=
 install=no
+test=yes
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -17,6 +18,10 @@ while [ $# -gt 0 ]; do
 		;;
 	--install)
 		install=yes
+		shift
+		;;
+	--no-test)
+		test=no
 		shift
 		;;
 	--)
@@ -60,11 +65,13 @@ echo ""
 echo "Building ..."
 make -j4 -k
 
-for test in init_context set_option stress stress_mt; do
-	echo ""
-	echo "Running test '${test}' ..."
-	./tests/${test}
-done
+if [ "${test}" = "yes" ]; then
+	for test_name in init_context set_option stress stress_mt; do
+		echo ""
+		echo "Running test '${test_name}' ..."
+		./tests/${test_name}
+	done
+fi
 
 if [ "${install}" = "yes" ]; then
 	echo ""

--- a/.private/ci-container-build.sh
+++ b/.private/ci-container-build.sh
@@ -50,6 +50,8 @@ CFLAGS+=" -Wredundant-decls"
 CFLAGS+=" -Wswitch-enum"
 export CFLAGS
 
+export CXXFLAGS="\${CFLAGS}"
+
 echo ""
 echo "Configuring ..."
 /source/configure --enable-examples-build --enable-tests-build

--- a/.private/ci-container-build.sh
+++ b/.private/ci-container-build.sh
@@ -61,11 +61,5 @@ make -j4 -k
 echo ""
 echo "Running umockdev tests ..."
 tests/umockdev
-
-echo "Running stress tests ..."
-tests/stress
-tests/stress_mt
 EOG
 EOF
-
-

--- a/configure.ac
+++ b/configure.ac
@@ -227,9 +227,8 @@ windows)
 	LT_LDFLAGS="${LT_LDFLAGS} -avoid-version"
 	;;
 emscripten)
-	AC_SUBST(EXEEXT, [.html])
 	# Note: LT_LDFLAGS is not enough here because we need link flags for executable.
-	AM_LDFLAGS="${AM_LDFLAGS} --bind -s ASYNCIFY -s ASSERTIONS -s ALLOW_MEMORY_GROWTH -s INVOKE_RUN=0 -s EXPORTED_RUNTIME_METHODS=['callMain']"
+	AM_LDFLAGS="${AM_LDFLAGS} --bind -s ASYNCIFY -s ASSERTIONS -s ALLOW_MEMORY_GROWTH"
 	;;
 *)
 	dnl no special handling required

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,14 @@ stress_mt_SOURCES = stress_mt.c
 set_option_SOURCES = set_option.c testlib.c
 init_context_SOURCES = init_context.c testlib.c
 
+if OS_EMSCRIPTEN
+# On the Web you can't block the main thread as this blocks the event loop itself,
+# causing deadlocks when trying to use async APIs like WebUSB.
+# We use the PROXY_TO_PTHREAD Emscripten's feature to move the main app to a separate thread
+# where it can block safely.
+stress_mt_LDFLAGS = ${AM_LDFLAGS} -s PROXY_TO_PTHREAD -s EXIT_RUNTIME
+endif
+
 noinst_HEADERS = libusb_testlib.h
 noinst_PROGRAMS = stress stress_mt set_option init_context
 

--- a/tests/init_context.c
+++ b/tests/init_context.c
@@ -110,8 +110,8 @@ static libusb_testlib_result test_init_context_log_level(void) {
   LIBUSB_TEST_CLEAN_EXIT(TEST_STATUS_SUCCESS);
 }
 
-static void test_log_cb(libusb_context *ctx, enum libusb_log_level level,
-                        const char *str) {
+static void LIBUSB_CALL test_log_cb(libusb_context *ctx, enum libusb_log_level level,
+                                    const char *str) {
   UNUSED(ctx);
   UNUSED(level);
   UNUSED(str);

--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -189,7 +189,7 @@ static libusb_testlib_result test_no_discovery(void)
 #endif
 }
 
-static void test_log_cb(libusb_context *ctx, enum libusb_log_level level,
+static void LIBUSB_CALL test_log_cb(libusb_context *ctx, enum libusb_log_level level,
                         const char *str) {
   UNUSED(ctx);
   UNUSED(level);

--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -164,7 +164,7 @@ static libusb_testlib_result test_set_log_level_env(void) {
 
 static libusb_testlib_result test_no_discovery(void)
 {
-#if defined(__linux__)
+#if defined(__linux__) && !defined(CI_WITHOUT_DEVICES)
   libusb_context *test_ctx;
   LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,
                                                   /*num_options=*/0));

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -161,8 +161,12 @@ int main(void)
 
 	printf("Running multithreaded init/exit test...\n");
 	errs += test_multi_init(0);
+#ifdef __EMSCRIPTEN__
+	printf("Skipping enumeration test on Emscripten. Multithreading is not supported yet.\n");
+#else
 	printf("Running multithreaded init/exit test with enumeration...\n");
 	errs += test_multi_init(1);
+#endif
 	printf("All done, %d errors\n", errs);
 
 	return errs != 0;

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -180,5 +180,5 @@ int libusb_testlib_run_tests(int argc, char *argv[],
 	libusb_testlib_logf("Error in %d tests", error_count);
 	libusb_testlib_logf("Skipped %d tests", skip_count);
 
-	return pass_count != run_count;
+	return fail_count + error_count;
 }

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -876,7 +876,7 @@ transfer_submit_all_retry(TestThreadedSubmit *data)
 	return NULL;
 }
 
-static void
+static void LIBUSB_CALL
 test_threaded_submit_transfer_cb(struct libusb_transfer *transfer)
 {
 	TestThreadedSubmit *data = transfer->user_data;
@@ -955,7 +955,7 @@ test_threaded_submit(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 	g_free (c);
 }
 
-static int
+static int LIBUSB_CALL
 hotplug_count_arrival_cb(libusb_context *ctx,
                          libusb_device  *device,
                          libusb_hotplug_event event,
@@ -972,7 +972,7 @@ hotplug_count_arrival_cb(libusb_context *ctx,
 }
 
 #ifdef UMOCKDEV_HOTPLUG
-static int
+static int LIBUSB_CALL
 hotplug_count_removal_cb(libusb_context *ctx,
                          libusb_device  *device,
                          libusb_hotplug_event event,

--- a/tests/webusb-test-shim/.gitignore
+++ b/tests/webusb-test-shim/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/tests/webusb-test-shim/index.js
+++ b/tests/webusb-test-shim/index.js
@@ -1,0 +1,20 @@
+// It's not yet possible to automate actual Chrome's device selection, so
+// for now run automated tests via Node.js WebUSB implementation.
+//
+// It might differ from browser one, but should be enough to catch most obvious issues.
+
+const { WebUSB } = require('usb');
+
+globalThis.navigator = {
+  usb: new WebUSB({
+    allowAllDevices: true
+  })
+};
+
+// events_posix uses Web events on the global scope (for now), but Node.js doesn't have them.
+
+const fakeEventTarget = new EventTarget();
+
+for (let method in fakeEventTarget) {
+  globalThis[method] = fakeEventTarget[method].bind(fakeEventTarget);
+}

--- a/tests/webusb-test-shim/package-lock.json
+++ b/tests/webusb-test-shim/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "webusb-test-runner",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webusb-test-runner",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "usb": "^2.11.0"
+      }
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.0.tgz",
+      "integrity": "sha512-PbZERfeFdrHQOOXiAKOY0VPbykZy90ndPKk0d+CFDegTKmWp1VgOTz2xACVbr1BjCWxrQp68CXtvNsveFhqDJg==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.11.0.tgz",
+      "integrity": "sha512-u5+NZ6DtoW8TIBtuSArQGAZZ/K15i3lYvZBAYmcgI+RcDS9G50/KPrUd3CrU8M92ahyCvg5e0gc8BDvr5Hwejg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    }
+  }
+}

--- a/tests/webusb-test-shim/package.json
+++ b/tests/webusb-test-shim/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "webusb-test-runner",
+  "private": true,
+  "license": "LGPL-2.1",
+  "main": "index.js",
+  "author": "Ingvar Stepanyan <me@rreverser.com>",
+  "dependencies": {
+    "usb": "^2.11.0"
+  }
+}


### PR DESCRIPTION
It's not yet possible to automate WebUSB in Chromium unfortunately, but at least we can test the backend via Node.js `node-usb` module's implementation.

In theory it might potentially have its own bugs different from real browser, but in practice it works well enough and still better than having no automated testing.

Note that this PR is based off #1349.

Also it disables `stress_mt` because multithreading is not supported until #1339 is merged. I'll re-enable the test in that PR once this one is merged.

(This PR interdependency is getting out of hand though 😅)