### PR TITLE
Remove MAX_CTRL_BUFFER_LENGTH Limitation From Linux Build

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2237,9 +2237,6 @@ static int submit_control_transfer(struct usbi_transfer *itransfer)
 	struct usbfs_urb *urb;
 	int r;
 
-	if (transfer->length - LIBUSB_CONTROL_SETUP_SIZE > MAX_CTRL_BUFFER_LENGTH)
-		return LIBUSB_ERROR_INVALID_PARAM;
-
 	urb = calloc(1, sizeof(*urb));
 	if (!urb)
 		return LIBUSB_ERROR_NO_MEM;

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -71,7 +71,6 @@ struct usbfs_iso_packet_desc {
 };
 
 #define MAX_BULK_BUFFER_LENGTH		16384
-#define MAX_CTRL_BUFFER_LENGTH		4096
 
 #define MAX_ISO_PACKETS_PER_URB		128
 


### PR DESCRIPTION
Both the Linux and Windows versions of LibUSB have a limitation placed on the size of Control Transfers that can be sent using LibUSB, returning a LIBUSB_ERROR_INVALID_PARAM error if the size of the buffer exceeds 4096 bytes. This is an artificial limitation, as most modern hardware is capable of handling control transfer buffers up to the 65535 byte limit, and in Linux specifically there is nothing in the Kernel to reject larger buffers. I have created this patch specifically for Linux, however it would likely also be viable for Windows.

The presence of this limitation means that users who wish to use LibUSB to identify vulnerabilities in USB devices, or communicate with devices which permit buffer sizes of greater than 4096 bytes, will be presented with an error message that they would have to manually remove from the library. This patch simply removes the limitation, preventing the library from throwing a LIBUSB_ERROR_INVALID_PARAM error when >4096 bytes are used in control transfers on Linux builds.