### PR TITLE
ci: do not hard code test names for CI

### DIFF
--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -82,11 +82,7 @@ make -j4 -k
 if [ "${test}" = "yes" ]; then
 	# Load custom shim for WebUSB tests that simulates Web environment.
 	export NODE_OPTIONS="--require ${scriptdir}/../tests/webusb-test-shim/"
-	for test_name in init_context set_option stress stress_mt; do
-		echo ""
-		echo "Running test '${test_name}' ..."
-		./tests/${test_name}
-	done
+	make check
 fi
 
 if [ "${install}" = "yes" ]; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,3 +31,5 @@ umockdev_SOURCES = umockdev.c
 
 noinst_PROGRAMS += umockdev
 endif
+
+TESTS=$(noinst_PROGRAMS)


### PR DESCRIPTION
automake has built-in support for running unit test with make check. This commit sets the TESTS variable in tests/Makefile.am to enable this support and updates the CI script to use make check instead of hard-coded test names.