### PR TITLE
ci: dump test suite output on test failure

### DIFF
--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -83,6 +83,9 @@ if [ "${test}" = "yes" ]; then
 	# Load custom shim for WebUSB tests that simulates Web environment.
 	export NODE_OPTIONS="--require ${scriptdir}/../tests/webusb-test-shim/"
 	make check
+	if test "$?" != "0" ; then
+	    cat tests/test-suite.log
+	fi
 fi
 
 if [ "${install}" = "yes" ]; then

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11836
+#define LIBUSB_NANO 11837


### PR DESCRIPTION
The test output is hidden by default with make check so we need to explicitly dump the test suite log on failure.