### PR TITLE
ci: disable set -e when running make check

### DIFF
--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -82,9 +82,9 @@ make -j4 -k
 if [ "${test}" = "yes" ]; then
 	# Load custom shim for WebUSB tests that simulates Web environment.
 	export NODE_OPTIONS="--require ${scriptdir}/../tests/webusb-test-shim/"
-	make check
-	if test "$?" != "0" ; then
+	if ! make check ; then
 	    cat tests/test-suite.log
+	    exit 1
 	fi
 fi
 

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 11837
+#define LIBUSB_NANO 11838


### PR DESCRIPTION
In order to dump the test log need to temporarily disable set -e to ensure the script runs the next line. This commit adds set +e before running the tests and set -e after.