### PR TITLE
tests/umockdev: Avoid unknown option warning on older gcc

### DIFF
--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -33,7 +33,7 @@
 #define UNUSED_DATA __attribute__ ((unused)) gconstpointer unused_data
 
 /* avoid leak reports inside assertions; leaking stuff on assertion failures does not matter in tests */
-#if !defined(__clang__)
+#if !defined(__clang__) && __GNUC__ > 9
 #pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
 #pragma GCC diagnostic ignored "-Wanalyzer-file-leak"
 #endif


### PR DESCRIPTION
This is normally just a warning, below is with -Werror:  

```
CC       umockdev-umockdev.o
../../libusb-git/tests/umockdev.c:37:32: error: unknown option after ‘#pragma GCC diagnostic’ kind [-Werror=pragmas]
   37 | #pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~
../../libusb-git/tests/umockdev.c:38:32: error: unknown option after ‘#pragma GCC diagnostic’ kind [-Werror=pragmas]
   38 | #pragma GCC diagnostic ignored "-Wanalyzer-file-leak"
      |                                ^~~~~~~~~~~~~~~~~~~~~~
```

I am not sure if GCC 10 or 11 warns about this, but surely 9 does.