### PR TITLE
.gitignore: Ignore test binaries and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ depcomp
 configure
 aclocal.m4
 compile
+test-driver
 config.guess
 config.h*
 !msvc/config.h
@@ -41,7 +42,14 @@ examples/fxload
 examples/hotplugtest
 examples/sam3u_benchmark
 examples/testlibusb
+tests/init_context
+tests/macos
+tests/set_option
 tests/stress
+tests/stress_mt
+tests/stress_mt
+tests/*.log
+tests/*.trs
 android/libs
 android/obj
 *.exe


### PR DESCRIPTION
For those who build in the tree. Just to make it consistent since we also ignore binaries in the example folder.