### PR TITLE
tests: Use AM_LDFLAGS for -static flag

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I$(top_srcdir)/libusb
 LDADD = ../libusb/libusb-1.0.la
-LDFLAGS = -static
+AM_LDFLAGS = -static
 
 stress_SOURCES = stress.c testlib.c
 stress_mt_SOURCES = stress_mt.c
@@ -10,13 +10,14 @@ macos_SOURCES = macos.c testlib.c
 
 stress_mt_CFLAGS = $(AM_CFLAGS) $(THREAD_CFLAGS)
 stress_mt_LDADD = $(LDADD) $(THREAD_LIBS)
+stress_mt_LDFLAGS = $(AM_LDFLAGS)
 
 if OS_EMSCRIPTEN
 # On the Web you can't block the main thread as this blocks the event loop itself,
 # causing deadlocks when trying to use async APIs like WebUSB.
 # We use the PROXY_TO_PTHREAD Emscripten's feature to move the main app to a separate thread
 # where it can block safely.
-stress_mt_LDFLAGS = ${AM_LDFLAGS} -s PROXY_TO_PTHREAD -s EXIT_RUNTIME
+stress_mt_LDFLAGS += ${AM_LDFLAGS} -s PROXY_TO_PTHREAD -s EXIT_RUNTIME
 endif
 
 noinst_HEADERS = libusb_testlib.h


### PR DESCRIPTION
autoreconf complains about:
```
tests/Makefile.am:3: warning: 'LDFLAGS' is a user variable, you should not override it;
tests/Makefile.am:3: use 'AM_LDFLAGS' instead
```
So it is tempting to just replace `LDFLAGS` by `AM_LDFLAGS`. However, with only this, it seems that stress_mt, contrary to the others, is built without `-static`, for reasons I don't understand. Any ideas? Adding explicit `stress_mt_LDFLAGS` works around this, but then the OS_EMSCRIPTEN block needs a tweak too.

The `-static` flag was recently added in 1ca2bc14 by @hjelmn 