### PR TITLE
tests/set_option: avoid use-after-free in case of test failure

### DIFF
--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -174,6 +174,7 @@ static libusb_testlib_result test_no_discovery(void)
   ssize_t num_devices = libusb_get_device_list(test_ctx, &device_list);
   libusb_free_device_list(device_list, /*unref_devices=*/1);
   libusb_exit(test_ctx);
+  test_ctx = NULL;
 
   LIBUSB_EXPECT(>, num_devices, 0);
 


### PR DESCRIPTION
In case num_devices equals 0, LIBUSB_EXPECT() calls LIBUSB_TEST_CLEAN_EXIT(), which calls libusb_exit() on test_ctx which has just been freed a few lines above by a call to libusb_exit(). This might cause a SEGFAULT or SIGBUS depending on the system.

Fixes that by assigning NULL to test_ctx just after calling libusb_exit() like it is done elsewhere in the file.