### PR TITLE
tests/set_option: Allow no devices in test_no_discovery

### DIFF
--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -63,9 +63,6 @@ cflags+=" -Wpointer-arith"
 cflags+=" -Wredundant-decls"
 cflags+=" -Wswitch-enum"
 
-# Tell tests that we don't have any devices.
-cflags+=" -DCI_WITHOUT_DEVICES"
-
 # enable address sanitizer
 if [ "${asan}" = "yes" ]; then
 	cflags+=" -fsanitize=address"

--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -166,7 +166,7 @@ static libusb_testlib_result test_set_log_level_env(void) {
 
 static libusb_testlib_result test_no_discovery(void)
 {
-#if defined(__linux__) && !defined(CI_WITHOUT_DEVICES)
+#if defined(__linux__)
   libusb_context *test_ctx;
   LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,
                                                   /*num_options=*/0));
@@ -176,7 +176,11 @@ static libusb_testlib_result test_no_discovery(void)
   libusb_exit(test_ctx);
   test_ctx = NULL;
 
-  LIBUSB_EXPECT(>, num_devices, 0);
+  if (num_devices == 0) {
+    libusb_testlib_logf("Warning: no devices found, the test will only verify that setting LIBUSB_OPTION_NO_DEVICE_DISCOVERY succeeds.");
+  }
+
+  LIBUSB_EXPECT(>=, num_devices, 0);
 
   LIBUSB_TEST_RETURN_ON_ERROR(libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY));
   LIBUSB_TEST_RETURN_ON_ERROR(libusb_init_context(&test_ctx, /*options=*/NULL,


### PR DESCRIPTION
As per discussion in #1374.