### PR TITLE
libusb.h: Avoid UNREFERENCED_PARAMETER on GCC/clang

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -73,7 +73,7 @@
 #endif
 
 /* The following is used to silence warnings for unused variables */
-#if defined(UNREFERENCED_PARAMETER)
+#if defined(UNREFERENCED_PARAMETER) && !defined(__GNUC__)
 #define UNUSED(var)	UNREFERENCED_PARAMETER(var)
 #else
 #define UNUSED(var)	do { (void)(var); } while(0)


### PR DESCRIPTION
It interferes with -Wuninitialized on recent clang.

Fixes #1381


This might be nice to get in before 1.0.27 (or even an RC2).