### PR TITLE
Fix setting the global log callback per `libusb_set_option()`

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2327,16 +2327,14 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 				default_context_options[option].arg.ival = arg;
 			} else if (LIBUSB_OPTION_LOG_CB == option) {
 				default_context_options[option].arg.log_cbval = log_cb;
+				libusb_set_log_cb_internal(NULL, log_cb, LIBUSB_LOG_CB_GLOBAL);
 			}
 			usbi_mutex_static_unlock(&default_context_lock);
 		}
 
 		ctx = usbi_get_context(ctx);
-		if (NULL == ctx) {
-			if (LIBUSB_OPTION_LOG_CB == option)
-				libusb_set_log_cb_internal(NULL, log_cb, LIBUSB_LOG_CB_GLOBAL);
+		if (NULL == ctx)
 			break;
-		}
 
 		switch (option) {
 		case LIBUSB_OPTION_LOG_LEVEL:

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2333,7 +2333,8 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 
 		ctx = usbi_get_context(ctx);
 		if (NULL == ctx) {
-			libusb_set_log_cb_internal(NULL, log_cb, LIBUSB_LOG_CB_GLOBAL);
+			if (LIBUSB_OPTION_LOG_CB == option)
+				libusb_set_log_cb_internal(NULL, log_cb, LIBUSB_LOG_CB_GLOBAL);
 			break;
 		}
 


### PR DESCRIPTION
There are two problems with setting the global callback per `libusb_set_option()` currently:
1. The callback is overwritten by subsequent calls to `libusb_set_option()`.
2. After the first `libusb_init()` the callback is not set globally but for the default context only. There is no way to set the global callback through `libusb_set_option()` then.

Both issues are fixed by the attached commits. See the commit description for the details.
