### PR TITLE
Changed remove_from_flying_list() to not lock flying_transfers_lock itself

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1337,7 +1337,7 @@ struct usbi_os_backend {
 	 *
 	 * This function must not block.
 	 *
-	 * This function gets called with the flying_transfers_lock locked!
+	 * This function gets called with itransfer->lock locked!
 	 *
 	 * Return:
 	 * - 0 on success
@@ -1351,6 +1351,8 @@ struct usbi_os_backend {
 	 * This function must not block. The transfer cancellation must complete
 	 * later, resulting in a call to usbi_handle_transfer_cancellation()
 	 * from the context of handle_events.
+	 *
+	 * This function gets called with itransfer->lock locked!
 	 */
 	int (*cancel_transfer)(struct usbi_transfer *itransfer);
 

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -380,7 +380,7 @@ struct libusb_context {
 	struct list_head flying_transfers;
 	/* Note paths taking both this and usbi_transfer->lock must always
 	 * take this lock first */
-	usbi_mutex_t flying_transfers_lock;
+	usbi_mutex_t flying_transfers_lock; /* for flying_transfers and timeout_flags */
 
 #if !defined(PLATFORM_WINDOWS)
 	/* user callbacks for pollfd changes */
@@ -575,7 +575,7 @@ struct usbi_transfer {
 	int transferred;
 	uint32_t stream_id;
 	uint32_t state_flags;   /* Protected by usbi_transfer->lock */
-	uint32_t timeout_flags; /* Protected by the flying_stransfers_lock */
+	uint32_t timeout_flags; /* Protected by the flying_transfers_lock */
 
 	/* The device reference is held until destruction for logging
 	 * even after dev_handle is set to NULL.  */

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1182,6 +1182,8 @@ struct usbi_os_backend {
 	 * claiming, no other drivers/applications can use the interface because
 	 * we now "own" it.
 	 *
+	 * This function gets called with dev_handle->lock locked!
+	 *
 	 * Return:
 	 * - 0 on success
 	 * - LIBUSB_ERROR_NOT_FOUND if the interface does not exist
@@ -1200,6 +1202,8 @@ struct usbi_os_backend {
 	 *
 	 * You will only ever be asked to release an interface which was
 	 * successfully claimed earlier.
+	 *
+	 * This function gets called with dev_handle->lock locked!
 	 *
 	 * Return:
 	 * - 0 on success


### PR DESCRIPTION
This is now symmetric with add_to_flying_list(), which was already requiring that *callers* lock flying_transfers_lock. Updated the only 2 callers.

This also makes the code correspond better to the big comment about locking made in 138b661f.

Also documented at the top of several functions when they require that flying_transfers_lock already be held. Verified by code review that it's actually the case.

This should not change any behaviour at all.