### PR TITLE
Added codespell config file and corrected some spelling

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = strerror.c
+ignore-words-list = hart,maked,mis,mot,numer,ser,xwindows

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1501,7 +1501,7 @@ enum libusb_option {
 
 #define LIBUSB_OPTION_WEAK_AUTHORITY LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 
-	/** Set the context log callback functon.
+	/** Set the context log callback function.
 	 *
 	 * Set the log callback function either on a context or globally. This
 	 * option must be provided an argument of type libusb_log_cb. Using this

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -82,7 +82,7 @@ static int sunos_usb_ioctl(struct libusb_device *dev, int cmd);
 
 static int sunos_get_link(di_devlink_t devlink, void *arg)
 {
-	walk_link_t *larg = (walk_link_t *)arg;
+	walk_link_t *link_arg = (walk_link_t *)arg;
 	const char *p;
 	const char *q;
 
@@ -112,21 +112,21 @@ static int sunos_get_link(di_devlink_t devlink, void *arg)
 static int sunos_physpath_to_devlink(
 	const char *node_path, const char *match, char **link_path)
 {
-	walk_link_t larg;
+	walk_link_t link_arg;
 	di_devlink_handle_t hdl;
 
 	*link_path = NULL;
-	larg.linkpp = link_path;
+	link_arg.linkpp = link_path;
 	if ((hdl = di_devlink_init(NULL, 0)) == NULL) {
 		usbi_dbg(NULL, "di_devlink_init failure");
 		return (-1);
 	}
 
-	larg.len = strlen(node_path);
-	larg.path = (char *)node_path;
+	link_arg.len = strlen(node_path);
+	link_arg.path = (char *)node_path;
 
 	(void) di_devlink_walk(hdl, match, NULL, DI_PRIMARY_LINK,
-	    (void *)&larg, sunos_get_link);
+	    (void *)&link_arg, sunos_get_link);
 
 	(void) di_devlink_fini(&hdl);
 

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -89,7 +89,7 @@ typedef struct {
 	GList *flying_urbs;
 	GList *discarded_urbs;
 
-	/* GMutex confuses tsan unecessarily */
+	/* GMutex confuses tsan unnecessarily */
 	pthread_mutex_t mutex;
 } UMockdevTestbedFixture;
 
@@ -432,7 +432,7 @@ test_fixture_setup_libusb(UMockdevTestbedFixture * fixture, int devcount)
 
 	libusb_init_context(/*ctx=*/&fixture->ctx, /*options=*/NULL, /*num_options=*/0);
 
-	/* Supress global log messages completely
+	/* Suppress global log messages completely
 	 * (though, in some tests it might be interesting to check there are no real ones).
 	 */
 	libusb_set_log_cb (NULL, log_handler_null, LIBUSB_LOG_CB_GLOBAL);


### PR DESCRIPTION
In one case, renamed a variable from `larg` which codespell thought was a typo for `large`.