### PR TITLE
Fix calls to libusb_set_option() on PowerPC

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2492,7 +2492,7 @@ int API_EXPORTED libusb_init_context(libusb_context **ctx, const struct libusb_i
 			r = libusb_set_option(_ctx, options[i].option, options[i].value.log_cbval);
 			break;
 		default:
-			r = libusb_set_option(_ctx, options[i].option, options[i].value.ival);
+			r = libusb_set_option(_ctx, options[i].option, (int)options[i].value.ival);
 		}
 		if (LIBUSB_SUCCESS != r)
 			goto err_free_ctx;


### PR DESCRIPTION
libusb_set_option() is a variadic function, so the type of the arguments are not clearly defined. When called with LIBUSB_OPTION_LOG_LEVEL, the argument is read with va_arg() as an int, which matches the type used
when passing constants, and also most of the internal calls and the calls in the examples.
    
However the internal call site in libusb_init_context() passes the ival element of the libusb_init_option struct directly, which is of type int64_t. This causes ssues on PowerPC, likely because it is 32-bit big endian:

```
Starting test run: test_init_context_basic...
Success (0)
Starting test run: test_init_context_log_level...
Expected test_ctx->debug (0) == LIBUSB_LOG_LEVEL_ERROR (1) at init_context.c:107 Failure (1)
Starting test run: test_init_context_log_cb...
Success (0)
---
Ran 3 tests
Passed 2 tests
Failed 1 tests
Error in 0 tests
Skipped 0 tests
```

Fix that by explicitly casting the value to int, which is anyway what happens on little endian.
