### PR TITLE
Increased usbi_get_tid() from int to long

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2809,7 +2809,7 @@ static void log_v(struct libusb_context *ctx, enum libusb_log_level level,
 		TIMESPEC_SUB(&timestamp, &timestamp_origin, &timestamp);
 
 		header_len = snprintf(buf, sizeof(buf),
-			"[%2ld.%06ld] [%08x] libusb: %s [%s] ",
+			"[%2ld.%06ld] [%08lx] libusb: %s [%s] ",
 			(long)timestamp.tv_sec, (long)(timestamp.tv_nsec / 1000L), usbi_get_tid(), prefix, function);
 	} else {
 		header_len = snprintf(buf, sizeof(buf),

--- a/libusb/os/threads_posix.c
+++ b/libusb/os/threads_posix.c
@@ -22,6 +22,7 @@
 #include "libusbi.h"
 
 #include <errno.h>
+#include <limits.h>
 #if defined(__ANDROID__)
 # include <unistd.h>
 #elif defined(__HAIKU__)
@@ -79,47 +80,47 @@ int usbi_cond_timedwait(pthread_cond_t *cond,
 		return LIBUSB_ERROR_OTHER;
 }
 
-unsigned int usbi_get_tid(void)
+unsigned long usbi_get_tid(void)
 {
-	static _Thread_local unsigned int tl_tid;
-	int tid;
+	static _Thread_local unsigned long tl_tid;
+    unsigned long tid;
 
 	if (tl_tid)
 		return tl_tid;
 
 #if defined(__ANDROID__)
-	tid = gettid();
+	tid = (unsigned long)gettid();
 #elif defined(__APPLE__)
 #ifdef HAVE_PTHREAD_THREADID_NP
 	uint64_t thread_id;
 
 	if (pthread_threadid_np(NULL, &thread_id) == 0)
-		tid = (int)thread_id;
+		tid = (unsigned long)thread_id;
 	else
-		tid = -1;
+		tid = ULONG_MAX;
 #else
-	tid = (int)pthread_mach_thread_np(pthread_self());
+	tid = (unsigned long)pthread_mach_thread_np(pthread_self());
 #endif
 #elif defined(__HAIKU__)
-	tid = get_pthread_thread_id(pthread_self());
+	tid = (unsigned long)get_pthread_thread_id(pthread_self());
 #elif defined(__linux__)
-	tid = (int)syscall(SYS_gettid);
+	tid = (unsigned long)syscall(SYS_gettid);
 #elif defined(__NetBSD__)
-	tid = _lwp_self();
+	tid = (unsigned long)_lwp_self();
 #elif defined(__OpenBSD__)
-	tid = getthrid();
+	tid = (unsigned long)getthrid();
 #elif defined(__sun__)
-	tid = _lwp_self();
+	tid = (unsigned long)_lwp_self();
 #else
-	tid = -1;
+	tid = ULONG_MAX;
 #endif
 
-	if (tid == -1) {
+	if (tid == ULONG_MAX) {
 		/* If we don't have a thread ID, at least return a unique
 		 * value that can be used to distinguish individual
 		 * threads. */
-		tid = (int)(intptr_t)pthread_self();
+		tid = (unsigned long)(uintptr_t)pthread_self();
 	}
 
-	return tl_tid = (unsigned int)tid;
+	return tl_tid = tid;
 }

--- a/libusb/os/threads_posix.h
+++ b/libusb/os/threads_posix.h
@@ -93,6 +93,6 @@ static inline void usbi_tls_key_delete(usbi_tls_key_t key)
 	PTHREAD_CHECK(pthread_key_delete(key));
 }
 
-unsigned int usbi_get_tid(void);
+unsigned long usbi_get_tid(void);
 
 #endif /* LIBUSB_THREADS_POSIX_H */

--- a/libusb/os/threads_windows.h
+++ b/libusb/os/threads_windows.h
@@ -105,9 +105,9 @@ static inline void usbi_tls_key_delete(usbi_tls_key_t key)
 	WINAPI_CHECK(TlsFree(key));
 }
 
-static inline unsigned int usbi_get_tid(void)
+static inline unsigned long usbi_get_tid(void)
 {
-	return (unsigned int)GetCurrentThreadId();
+	return (unsigned long)GetCurrentThreadId();
 }
 
 #endif /* LIBUSB_THREADS_WINDOWS_H */


### PR DESCRIPTION
This function has different implementations on every OS, but for some, like macOS, it was truncating from 64 to 32 bit by casting to int. So increased its size from int to long.