### PR TITLE
Change libusb_init_option to fix libusb_set_option() on big-endian

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1538,7 +1538,7 @@ struct libusb_init_option {
   enum libusb_option option;
   /** An integer value used by the option (if applicable). */
   union {
-    int64_t ival;
+    int ival;
     libusb_log_cb log_cbval;
   } value;
 };


### PR DESCRIPTION
libusb_set_option() is a variadic function, so the type of the arguments is not clearly defined. When called with LIBUSB_OPTION_LOG_LEVEL, the argument is read with va_arg() as an int, which matches the type used when passing constants, and also most of the internal calls and the calls in the examples.

However the internal call site in libusb_init_context() passes the ival element of the libusb_init_option struct directly, which is of type int64_t. This breaks on big-endian architectures like PowerPC, as detected by tests/set_option.

Therefore change the libusb_init_option struct to use int here as well.

Thanks to Aurelien Jarno for reporting and initial patch.

Closes #1416