### PR TITLE
tests/stress_mt: ignore errors in threads for checking device counts

### DIFF
--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -230,7 +230,8 @@ static int test_multi_init(int enumerate)
 				tinfo[t].number,
 				tinfo[t].iteration,
 				libusb_error_name(tinfo[t].err));
-		} else if (enumerate) {
+		}
+		if (enumerate) {
 			if (t > 0 && tinfo[t].devcount != last_devcount) {
 				devcount_mismatch++;
 				printf("Device count mismatch: Thread %d discovered %ld devices instead of %ld\n",


### PR DESCRIPTION
This fixes an issue where an error that occurred in thread #X will create a false error message stating that thread #X+1 did not discover the correct number of devices