### PR TITLE
umockdev: immediately abort when ENABLE_DEBUG_LOGGING is defined

### DIFF
--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -1120,6 +1120,11 @@ test_hotplug_add_remove(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 int
 main(int argc, char **argv)
 {
+#if defined ENABLE_DEBUG_LOGGING
+	fprintf(stderr, "ENABLE_DEBUG_LOGGING is defined and UMockdev doesn't support it since tests rely on per context callbacks, aborting.\n");
+	exit(-1);
+#endif
+
 	g_test_init(&argc, &argv, NULL);
 
 	g_test_add("/libusb/open-close", UMockdevTestbedFixture, NULL,


### PR DESCRIPTION
Umockdev tests rely on being able to set per context callbacks for validating functions behaviors. As per documentation:"If ENABLE_DEBUG_LOGGING is defined then per context callback function will never be called." In this case, Umockdev will then incorrectly fails most of the tests, providing erroneous results.

With this commit, Umockdev will immediately exit with an error message when compiled with ENABLE_DEBUG_LOGGING defined.