### PR TITLE
umockdev: do not build when ENABLE_DEBUG_LOGGING is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,7 @@ AC_ARG_ENABLE([tests-build],
 
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$build_examples" != xno])
 AM_CONDITIONAL([BUILD_TESTS], [test "x$build_tests" != xno])
-AM_CONDITIONAL([BUILD_UMOCKDEV_TEST], [test "x$ac_have_umockdev" = xyes -a "x$log_enabled" != xno])
+AM_CONDITIONAL([BUILD_UMOCKDEV_TEST], [test "x$ac_have_umockdev" = xyes -a "x$log_enabled" != xno -a "x$debug_log_enabled" != xyes])
 AM_CONDITIONAL([CREATE_IMPORT_LIB], [test "x$create_import_lib" = xyes])
 AM_CONDITIONAL([OS_DARWIN], [test "x$backend" = xdarwin])
 AM_CONDITIONAL([OS_HAIKU], [test "x$backend" = xhaiku])


### PR DESCRIPTION
Umockdev tests rely on being able to set per context callbacks for validating functions behaviors. As per documentation: "If ENABLE_DEBUG_LOGGING is defined then per context callback function will never be called." When this is this case, Umockdev will therefore incorrectly fails, providing erroneous results, such that it is better not to build it at all.