### PR TITLE
hotplug_exit: removes all parents with a single child remaining in parent tree + lock device list

### DIFF
--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <config.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -51,7 +53,13 @@ static int LIBUSB_CALL hotplug_callback(libusb_context *ctx, libusb_device *dev,
 	}
 
 	rc = libusb_open (dev, &handle);
-	if (LIBUSB_SUCCESS != rc) {
+	if (LIBUSB_SUCCESS != rc
+		&& LIBUSB_ERROR_ACCESS != rc
+#if defined(PLATFORM_WINDOWS)
+		&& LIBUSB_ERROR_NOT_SUPPORTED != rc
+		&& LIBUSB_ERROR_NOT_FOUND != rc
+#endif
+		) {
 		fprintf (stderr, "No access to device: %s\n",
 			 libusb_strerror((enum libusb_error)rc));
 	}

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -214,6 +214,7 @@ void usbi_hotplug_exit(struct libusb_context *ctx)
 		free(msg);
 	}
 
+	usbi_mutex_lock(&ctx->usb_devs_lock); /* hotplug thread might still be processing an already triggered event, possibly accessing this list as well */
 	/* free all discovered devices */
 	for_each_device_safe(ctx, dev, next_dev) {
 		/* remove the device from the usb_devs list only if there are no
@@ -222,11 +223,12 @@ void usbi_hotplug_exit(struct libusb_context *ctx)
 		if (usbi_atomic_load(&dev->refcnt) == 1) {
 			list_del(&dev->list);
 		}
-		
+
 		usbi_recursively_remove_parents(dev, next_dev);
-		
+
 		libusb_unref_device(dev);
 	}
+	usbi_mutex_unlock(&ctx->usb_devs_lock);
 
 	usbi_mutex_destroy(&ctx->hotplug_cbs_lock);
 }

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -161,6 +161,27 @@ void usbi_hotplug_init(struct libusb_context *ctx)
 	usbi_atomic_store(&ctx->hotplug_ready, 1);
 }
 
+static void usbi_recursively_remove_parents(struct libusb_device *dev, struct libusb_device *next_dev)
+{
+	if (dev && dev->parent_dev) {
+		if (usbi_atomic_load(&dev->parent_dev->refcnt) == 1) {
+			/* the parent was processed before this device in the list
+			 * and therefore has its ref count already decrement for its own ref.
+			 * The only remaining counted ref come from its remaining single child.
+			 * It will thus be released when its child will be released.
+			 * We remove it from the list. This is safe as parent_dev can not be
+			 * equal to next_dev given we know at this point that it was
+			 * previously seen in the list. */
+			assert (dev->parent_dev != next_dev);
+			if(dev->parent_dev->list.next && dev->parent_dev->list.prev) {
+				list_del(&dev->parent_dev->list);
+			}
+		}
+
+		usbi_recursively_remove_parents(dev->parent_dev, next_dev);
+	}
+}
+
 void usbi_hotplug_exit(struct libusb_context *ctx)
 {
 	struct usbi_hotplug_callback *hotplug_cb, *next_cb;
@@ -193,7 +214,7 @@ void usbi_hotplug_exit(struct libusb_context *ctx)
 		free(msg);
 	}
 
-	/* free all discovered devices. due to parent references loop until no devices are freed. */
+	/* free all discovered devices */
 	for_each_device_safe(ctx, dev, next_dev) {
 		/* remove the device from the usb_devs list only if there are no
 		 * references held, otherwise leave it on the list so that a
@@ -201,13 +222,9 @@ void usbi_hotplug_exit(struct libusb_context *ctx)
 		if (usbi_atomic_load(&dev->refcnt) == 1) {
 			list_del(&dev->list);
 		}
-		if (dev->parent_dev && usbi_atomic_load(&dev->parent_dev->refcnt) == 1) {
-			/* the parent was before this device in the list and will be released.
-			   remove it from the list. this is safe as parent_dev can not be
-			   equal to next_dev. */
-			assert (dev->parent_dev != next_dev);
-			list_del(&dev->parent_dev->list);
-		}
+		
+		usbi_recursively_remove_parents(dev, next_dev);
+		
 		libusb_unref_device(dev);
 	}
 

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -228,7 +228,8 @@ static int test_multi_init(int enumerate)
 				tinfo[t].number,
 				tinfo[t].iteration,
 				libusb_error_name(tinfo[t].err));
-		} else if (enumerate) {
+		}
+		if (enumerate) {
 			if (t > 0 && tinfo[t].devcount != last_devcount) {
 				devcount_mismatch++;
 				printf("Device count mismatch: Thread %d discovered %ld devices instead of %ld\n",


### PR DESCRIPTION
1) Removes all parents with a single child remaining in parent tree
This ensure that no parents of the direct parent of the device being considered
are left in the list, when appearing before their child in the processing order
of the context device list.

2) mutex protection of context device list while cleaning it

This prevents concurrent access to the list by the event background
thread, which could still be processing a previous hotplug event and
having to modify the list

Note: this PR is based on to other PR given these other fixes are needed for proper testing. Please only consider the last commit as part of this PR.