### PR TITLE
Added an API call to check the connection status of a device handle

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -372,6 +372,7 @@ if (cfg != desired)
   * - libusb_attach_kernel_driver()
   * - libusb_bulk_transfer()
   * - libusb_cancel_transfer()
+  * - libusb_check_connected()
   * - libusb_claim_interface()
   * - libusb_clear_halt()
   * - libusb_close()
@@ -1436,6 +1437,23 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 	list_add(&_dev_handle->list, &ctx->open_devs);
 	usbi_mutex_unlock(&ctx->open_devs_lock);
 	*dev_handle = _dev_handle;
+
+	return 0;
+}
+
+/** \ingroup libusb_dev
+ * Checks if a device handle is still connected to the system.
+ *
+ * This is a non-blocking function; no requests are sent over the bus.
+ *
+ * \param dev_handle device handle to be checked.
+ * \returns 0 if the device is connected
+ * \returns \ref LIBUSB_ERROR_NO_DEVICE if the device has been disconnected
+ */
+int API_EXPORTED libusb_check_connected(libusb_device_handle * dev_handle)
+{
+	if (!usbi_atomic_load(&dev_handle->dev->attached))
+		return LIBUSB_ERROR_NO_DEVICE;
 
 	return 0;
 }

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -10,6 +10,8 @@ EXPORTS
   libusb_bulk_transfer@24 = libusb_bulk_transfer
   libusb_cancel_transfer
   libusb_cancel_transfer@4 = libusb_cancel_transfer
+  libusb_check_connected
+  libusb_check_connected@4 = libusb_check_connected
   libusb_claim_interface
   libusb_claim_interface@8 = libusb_claim_interface
   libusb_clear_halt

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1592,6 +1592,7 @@ void LIBUSB_CALL libusb_free_device_list(libusb_device **list,
 libusb_device * LIBUSB_CALL libusb_ref_device(libusb_device *dev);
 void LIBUSB_CALL libusb_unref_device(libusb_device *dev);
 
+int LIBUSB_CALL libusb_check_connected(libusb_device_handle * dev);
 int LIBUSB_CALL libusb_get_configuration(libusb_device_handle *dev,
 	int *config);
 int LIBUSB_CALL libusb_get_device_descriptor(libusb_device *dev,

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -546,6 +546,8 @@ test_open_close(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 	/* Open and close */
 	g_assert_cmpint(libusb_open(devs[0], &handle), ==, 0);
 	assert_libusb_log_msg(fixture, LIBUSB_LOG_LEVEL_DEBUG, "usbi_add_event_source");
+	g_assert_cmpint(libusb_check_connected(handle), ==, 0);
+	assert_libusb_log_msg(fixture, LIBUSB_LOG_LEVEL_DEBUG, "libusb_check_connected");
 	g_assert_nonnull(handle);
 	libusb_close(handle);
 	assert_libusb_log_msg(fixture, LIBUSB_LOG_LEVEL_DEBUG, "usbi_remove_event_source");


### PR DESCRIPTION
Aside from hot-plug events there is no good way to quickly check if a device handle is still attached to the system. I believe the only way to currently check if a device handle is still attached in a non-blocking manner is by attempting to claim an already claimed interface. This new API call adds a convenient method by which to check this.

```
int libusb_check_connected(libusb_device_handle * dev_handle)
```