### PR TITLE
Support for reporting USB 3.2 Gen2x2 speeds over libusb

### DIFF
--- a/android/examples/unrooted_android.c
+++ b/android/examples/unrooted_android.c
@@ -210,6 +210,7 @@ static void print_device(libusb_device *dev, libusb_device_handle *handle)
         case LIBUSB_SPEED_HIGH:		speed = "480M"; break;
         case LIBUSB_SPEED_SUPER:	speed = "5G"; break;
         case LIBUSB_SPEED_SUPER_PLUS:	speed = "10G"; break;
+        case LIBUSB_SPEED_SUPER_PLUS_X2:	speed = "20G"; break;
         default:			speed = "Unknown";
     }
 

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -174,6 +174,7 @@ static void print_device(libusb_device *dev, libusb_device_handle *handle)
 	case LIBUSB_SPEED_HIGH:		speed = "480M"; break;
 	case LIBUSB_SPEED_SUPER:	speed = "5G"; break;
 	case LIBUSB_SPEED_SUPER_PLUS:	speed = "10G"; break;
+	case LIBUSB_SPEED_SUPER_PLUS_X2:	speed = "20G"; break;
 	default:			speed = "Unknown";
 	}
 

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -37,6 +37,10 @@
 // in libusb_config_descriptor => catter for that
 #define usb_interface interface
 
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
+#endif
+
 // Global variables
 static bool binary_dump = false;
 static bool extra_info = false;
@@ -826,8 +830,9 @@ static int test_device(uint16_t vid, uint16_t pid)
 	int i, j, k, r;
 	int iface, nb_ifaces, first_iface = -1;
 	struct libusb_device_descriptor dev_desc;
-	const char* const speed_name[6] = { "Unknown", "1.5 Mbit/s (USB LowSpeed)", "12 Mbit/s (USB FullSpeed)",
-		"480 Mbit/s (USB HighSpeed)", "5000 Mbit/s (USB SuperSpeed)", "10000 Mbit/s (USB SuperSpeedPlus)" };
+	const char* const speed_name[] = { "Unknown", "1.5 Mbit/s (USB LowSpeed)", "12 Mbit/s (USB FullSpeed)",
+		"480 Mbit/s (USB HighSpeed)", "5000 Mbit/s (USB SuperSpeed)", "10000 Mbit/s (USB SuperSpeedPlus)",
+		"20000 Mbit/s (USB SuperSpeedPlus x2)" };
 	unsigned char string[128];
 	uint8_t string_index[3];	// indexes of the string descriptors
 	uint8_t endpoint_in = 0, endpoint_out = 0;	// default IN and OUT endpoints
@@ -854,7 +859,8 @@ static int test_device(uint16_t vid, uint16_t pid)
 			printf(" (from root hub)\n");
 		}
 		r = libusb_get_device_speed(dev);
-		if ((r<0) || (r>5)) r=0;
+		if ((r < 0) || ((size_t)r >= ARRAYSIZE(speed_name)))
+			r = 0;
 		printf("             speed: %s\n", speed_name[r]);
 	}
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1167,7 +1167,10 @@ enum libusb_speed {
 	LIBUSB_SPEED_SUPER = 4,
 
 	/** The device is operating at super speed plus (10000MBit/s). */
-	LIBUSB_SPEED_SUPER_PLUS = 5
+	LIBUSB_SPEED_SUPER_PLUS = 5,
+
+	/** The device is operating at super speed plus x2 (20000MBit/s). */
+	LIBUSB_SPEED_SUPER_PLUS_X2 = 6,
 };
 
 /** \ingroup libusb_misc

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1438,6 +1438,9 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
     case kUSBDeviceSpeedSuperPlus: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
 #endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+    case kUSBDeviceSpeedSuperPlusBy2: dev->speed = LIBUSB_SPEED_SUPER_PLUS_X2; break;
+#endif
     default:
       usbi_warn (ctx, "Got unknown device speed %d", devSpeed);
     }

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -933,6 +933,7 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 			case   480: dev->speed = LIBUSB_SPEED_HIGH; break;
 			case  5000: dev->speed = LIBUSB_SPEED_SUPER; break;
 			case 10000: dev->speed = LIBUSB_SPEED_SUPER_PLUS; break;
+			case 20000: dev->speed = LIBUSB_SPEED_SUPER_PLUS_X2; break;
 			default:
 				usbi_warn(ctx, "unknown device speed: %d Mbps", speed);
 			}


### PR DESCRIPTION
This is a much simpler stab at https://github.com/libusb/libusb/pull/680

It reports the correct information on Linux (tested on kernel 5.15), and on macOS (tested with a USB 3.2 gen2x2 card in a Mac Pro on the latest macOS)