### PR TITLE
Fix typo mantisa -> mantissa

### DIFF
--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -770,7 +770,7 @@ static void print_sublink_speed_attribute(struct libusb_ssplus_sublink_attribute
 	static const char exponent[] = " KMG";
 	printf("                  id=%u speed=%u%cbs %s %s SuperSpeed%s",
 		ss_attr->ssid,
-		ss_attr->mantisa,
+		ss_attr->mantissa,
 		(exponent[ss_attr->exponent]),
 		(ss_attr->type == LIBUSB_SSPLUS_ATTR_TYPE_ASYM)? "Asym" : "Sym",
 		(ss_attr->direction == LIBUSB_SSPLUS_ATTR_DIR_TX)? "TX" : "RX",

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1070,7 +1070,7 @@ int API_EXPORTED libusb_get_ssplus_usb_device_capability_descriptor(
 	for(uint8_t i = 0 ; i < _ssplus_cap->numSublinkSpeedAttributes ; i++) {
 		uint32_t attr = READ_LE32(base + i * sizeof(uint32_t));
 		_ssplus_cap->sublinkSpeedAttributes[i].ssid = attr & 0x0f;
-		_ssplus_cap->sublinkSpeedAttributes[i].mantisa = attr >> 16;
+		_ssplus_cap->sublinkSpeedAttributes[i].mantissa = attr >> 16;
 		_ssplus_cap->sublinkSpeedAttributes[i].exponent = (attr >> 4) & 0x3 ;
 		_ssplus_cap->sublinkSpeedAttributes[i].type = attr & 0x40 ? 	LIBUSB_SSPLUS_ATTR_TYPE_ASYM : LIBUSB_SSPLUS_ATTR_TYPE_SYM;
 		_ssplus_cap->sublinkSpeedAttributes[i].direction = attr & 0x80 ? 	LIBUSB_SSPLUS_ATTR_DIR_TX : 	LIBUSB_SSPLUS_ATTR_DIR_RX;

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1051,7 +1051,7 @@ struct libusb_ssplus_sublink_attribute {
 
 	/** This field defines the mantissa that shall be applied to the exponent when
      calculating the maximum bit rate. */
-	uint16_t mantisa;
+	uint16_t mantissa;
 };
 
 /** \ingroup libusb_desc


### PR DESCRIPTION
The correct spelling is "mantisSa"