### PR TITLE
Emscripten: Fix Uncaught TypeError on Firefox

### DIFF
--- a/libusb/os/emscripten_webusb.cpp
+++ b/libusb/os/emscripten_webusb.cpp
@@ -586,12 +586,17 @@ unsigned long getDeviceSessionId(val& web_usb_device) {
 }
 
 val getDeviceList(libusb_context* ctx, discovered_devs** devs) {
+	// Check if browser supports USB
+	val navigator_usb = val::global("navigator")["usb"];
+	if (navigator_usb == val::undefined()) {
+		co_return (int) LIBUSB_ERROR_NOT_SUPPORTED;
+	}
 	// C++ equivalent of `await navigator.usb.getDevices()`. Note: at this point
 	// we must already have some devices exposed - caller must have called
 	// `await navigator.usb.requestDevice(...)` in response to user interaction
 	// before going to LibUSB. Otherwise this list will be empty.
 	auto web_usb_devices =
-		co_await_try(val::global("navigator")["usb"].call<val>("getDevices"));
+		co_await_try(navigator_usb.call<val>("getDevices"));
 	for (auto&& web_usb_device : web_usb_devices) {
 		auto session_id = getDeviceSessionId(web_usb_device);
 


### PR DESCRIPTION
If libusb_get_device_list() is called using the Emscripten port of libusb when running in the Firefox browser, an application will be terminated with:

    Uncaught TypeError: objHandle is undefined

This is because Firefox doesn't support the navigator.usb object, used by getDeviceList() in emscripten_webusb.cpp.

This patch checks if the object is undefined before using it and will return an error instead.
