### PR TITLE
xusb: Define proper exit status 

### DIFF
--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -1077,9 +1077,25 @@ static int test_device(uint16_t vid, uint16_t pid)
 	return 0;
 }
 
+static void display_help(const char *progname)
+{
+	printf("usage: %s [-h] [-d] [-i] [-k] [-b file] [-l lang] [-j] [-x] [-s] [-p] [-w] [vid:pid]\n", progname);
+	printf("   -h      : display usage\n");
+	printf("   -d      : enable debug output\n");
+	printf("   -i      : print topology and speed info\n");
+	printf("   -j      : test composite FTDI based JTAG device\n");
+	printf("   -k      : test Mass Storage device\n");
+	printf("   -b file : dump Mass Storage data to file 'file'\n");
+	printf("   -p      : test Sony PS3 SixAxis controller\n");
+	printf("   -s      : test Microsoft Sidewinder Precision Pro (HID)\n");
+	printf("   -x      : test Microsoft XBox Controller Type S\n");
+	printf("   -l lang : language to report errors in (ISO 639-1)\n");
+	printf("   -w      : force the use of device requests when querying WCID descriptors\n");
+	printf("If only the vid:pid is provided, xusb attempts to run the most appropriate test\n");
+}
+
 int main(int argc, char** argv)
 {
-	bool show_help = false;
 	bool debug_mode = false;
 	const struct libusb_version* version;
 	int j, r;
@@ -1096,7 +1112,12 @@ int main(int argc, char** argv)
 	if (((uint8_t*)&endian_test)[0] == 0xBE) {
 		printf("Despite their natural superiority for end users, big endian\n"
 			"CPUs are not supported with this program, sorry.\n");
-		return 0;
+		return EXIT_FAILURE;
+	}
+
+	if ((argc == 1) || (argc > 7)) {
+		display_help(argv[0]);
+		return EXIT_FAILURE;
 	}
 
 	if (argc >= 2) {
@@ -1117,7 +1138,7 @@ int main(int argc, char** argv)
 				case 'b':
 					if ((j+1 >= argc) || (argv[j+1][0] == '-') || (argv[j+1][0] == '/')) {
 						printf("   Option -b requires a file name\n");
-						return 1;
+						return EXIT_FAILURE;
 					}
 					binary_name = argv[++j];
 					binary_dump = true;
@@ -1125,7 +1146,7 @@ int main(int argc, char** argv)
 				case 'l':
 					if ((j+1 >= argc) || (argv[j+1][0] == '-') || (argv[j+1][0] == '/')) {
 						printf("   Option -l requires an ISO 639-1 language parameter\n");
-						return 1;
+						return EXIT_FAILURE;
 					}
 					error_lang = argv[++j];
 					break;
@@ -1162,9 +1183,12 @@ int main(int argc, char** argv)
 					PID = 0x0289;
 					test_mode = USE_XBOX;
 					break;
+				case 'h':
+					display_help(argv[0]);
+					return EXIT_SUCCESS;
 				default:
-					show_help = true;
-					break;
+					display_help(argv[0]);
+					return EXIT_FAILURE;
 				}
 			} else {
 				for (i=0; i<arglen; i++) {
@@ -1174,32 +1198,16 @@ int main(int argc, char** argv)
 				if (i != arglen) {
 					if (sscanf(argv[j], "%x:%x" , &tmp_vid, &tmp_pid) != 2) {
 						printf("   Please specify VID & PID as \"vid:pid\" in hexadecimal format\n");
-						return 1;
+						return EXIT_FAILURE;
 					}
 					VID = (uint16_t)tmp_vid;
 					PID = (uint16_t)tmp_pid;
 				} else {
-					show_help = true;
+					display_help(argv[0]);
+					return EXIT_FAILURE;
 				}
 			}
 		}
-	}
-
-	if ((show_help) || (argc == 1) || (argc > 7)) {
-		printf("usage: %s [-h] [-d] [-i] [-k] [-b file] [-l lang] [-j] [-x] [-s] [-p] [-w] [vid:pid]\n", argv[0]);
-		printf("   -h      : display usage\n");
-		printf("   -d      : enable debug output\n");
-		printf("   -i      : print topology and speed info\n");
-		printf("   -j      : test composite FTDI based JTAG device\n");
-		printf("   -k      : test Mass Storage device\n");
-		printf("   -b file : dump Mass Storage data to file 'file'\n");
-		printf("   -p      : test Sony PS3 SixAxis controller\n");
-		printf("   -s      : test Microsoft Sidewinder Precision Pro (HID)\n");
-		printf("   -x      : test Microsoft XBox Controller Type S\n");
-		printf("   -l lang : language to report errors in (ISO 639-1)\n");
-		printf("   -w      : force the use of device requests when querying WCID descriptors\n");
-		printf("If only the vid:pid is provided, xusb attempts to run the most appropriate test\n");
-		return 0;
 	}
 
 	version = libusb_get_version();
@@ -1214,7 +1222,7 @@ int main(int argc, char** argv)
 	}
 
 	if (r < 0)
-		return r;
+		return EXIT_FAILURE;
 
 	// If not set externally, and no debug option was given, use info log level
 	if ((old_dbg_str == NULL) && (!debug_mode))
@@ -1225,14 +1233,18 @@ int main(int argc, char** argv)
 			printf("Invalid or unsupported locale '%s': %s\n", error_lang, libusb_strerror((enum libusb_error)r));
 	}
 
-	test_device(VID, PID);
+	r = test_device(VID, PID);
 
 	libusb_exit(NULL);
+
+	if (r < 0)
+		return EXIT_FAILURE;
+
 
 	if (debug_mode) {
 		snprintf(str, sizeof(str), "LIBUSB_DEBUG=%s", (old_dbg_str == NULL)?"":old_dbg_str);
 		str[sizeof(str) - 1] = 0;	// Windows may not NUL terminate the string
 	}
 
-	return 0;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Can we consider to propagate the return value from test_device() to main()? In this way, we can easily check the return code directly like `echo $?` in Linux to know whether the test is failed.