### PR TITLE
Reintroduce RAW_IO support in WinUSB backend

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -382,6 +382,8 @@ if (cfg != desired)
   * - libusb_detach_kernel_driver()
   * - libusb_dev_mem_alloc()
   * - libusb_dev_mem_free()
+  * - libusb_endpoint_set_raw_io()
+  * - libusb_endpoint_supports_raw_io()
   * - libusb_error_name()
   * - libusb_event_handler_active()
   * - libusb_event_handling_ok()
@@ -419,6 +421,7 @@ if (cfg != desired)
   * - libusb_get_iso_packet_buffer_simple()
   * - libusb_get_max_alt_packet_size()
   * - libusb_get_max_iso_packet_size()
+  * - libusb_get_max_raw_io_transfer_size()
   * - libusb_get_max_packet_size()
   * - libusb_get_next_timeout()
   * - libusb_get_parent()
@@ -2202,6 +2205,111 @@ int API_EXPORTED libusb_set_auto_detach_kernel_driver(
 
 	dev_handle->auto_detach_kernel_driver = enable;
 	return LIBUSB_SUCCESS;
+}
+
+/** \ingroup libusb_dev
+ * Check if the endpoint supports RAW_IO.
+ * \param dev_handle a device handle
+ * \param endpoint the endpoint to check
+ *
+ * \returns 1 if the endpoint supports RAW_IO
+ * \returns 0 if the endpoint does not support RAW_IO
+ * \returns a LIBUSB_ERROR code on failure
+ *
+ * Only endpoints using the WinUSB driver support RAW_IO,
+ * for all other backends/drivers this function will return 0.
+ *
+ * Fails if the interface the endpoint belongs to isn't claimed,
+ * \see libusb_claim_interface().
+ *
+ * \see libusb_endpoint_set_raw_io()
+ *
+ * Since version 1.0.28, \ref LIBUSB_API_VERSION >= 0x0100010B
+ */
+int API_EXPORTED libusb_endpoint_supports_raw_io(libusb_device_handle* dev_handle,
+	uint8_t endpoint)
+{
+	if (usbi_backend.endpoint_supports_raw_io == NULL)
+	{
+		return 0;
+	}
+
+	// If the `endpoint_supports_raw_io` function is present, these two should be too:
+	assert(usbi_backend.endpoint_set_raw_io != NULL);
+	assert(usbi_backend.get_max_raw_io_transfer_size != NULL);
+
+	return usbi_backend.endpoint_supports_raw_io(dev_handle, endpoint);
+}
+
+/** \ingroup libusb_dev
+ * Enable/disable RAW_IO for an endpoint on an open device.
+ *
+ * Only endpoints using the WinUSB driver support RAW_IO,
+ * for all other backends/drivers this function will return an error code.
+ *
+ * Using RAW_IO can greatly improve USB throughput by directly passing
+ * transfer requests to the underlying USB driver instead of queuing them
+ * in WinUSB. This can be particularly useful for high-throughput devices
+ * like cameras or oscilloscopes.
+ *
+ * Transfers submitted to the endpoint while RAW_IO is enabled will fail unless
+ * they adhere to the following rules :
+ * - The buffer length must be a multiple of the maximum endpoint packet size
+ *   \see libusb_get_max_packet_size.
+ * - The buffer length must be less than or equal to the value returned by
+ *   \ref libusb_get_max_raw_io_transfer_size.
+ *
+ * This option should not be changed when any transfer is in progress on
+ * the specified endpoint.
+ *
+ * Fails if the interface the endpoint belongs to isn't claimed,
+ * \see libusb_claim_interface().
+ *
+ * \param dev_handle a device handle
+ * \param endpoint the endpoint to set RAW_IO for
+ * \param enable 1 to enable RAW_IO, 0 to disable it
+ *
+ * \returns \ref LIBUSB_SUCCESS on success
+ * \returns \ref LIBUSB_ERROR_NOT_SUPPORTED if the backend does not support RAW_IO.
+ * \returns another LIBUSB_ERROR code on other failure
+ *
+ * \see libusb_endpoint_supports_raw_io()
+ * \seealso https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/winusb-functions-for-pipe-policy-modification
+ *
+ * Since version 1.0.28, \ref LIBUSB_API_VERSION >= 0x0100010B
+ */
+int API_EXPORTED libusb_endpoint_set_raw_io(libusb_device_handle* dev_handle,
+	uint8_t endpoint, int enable)
+{
+	if (!usbi_backend.endpoint_set_raw_io)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	return usbi_backend.endpoint_set_raw_io(dev_handle, endpoint, enable);
+}
+
+/** \ingroup libusb_dev
+ * Retrieve the maximum transfer size in bytes supported for WinUSB RAW_IO
+ * for an inbound bulk or interrupt endpoint on an open device.
+ *
+ * Returns a maximum transfer size in bytes, or a negative error code.
+ * If the backend does not support WinUSB RAW_IO, returns
+ * \ref LIBUSB_ERROR_NOT_SUPPORTED.
+ *
+ * Fails if the interface the endpoint belongs to isn't claimed,
+ * \see libusb_claim_interface().
+ *
+ * \see libusb_endpoint_set_raw_io()
+ *
+ * Since version 1.0.28, \ref LIBUSB_API_VERSION >= 0x0100010B
+ */
+int API_EXPORTED libusb_get_max_raw_io_transfer_size(
+	libusb_device_handle *dev_handle, uint8_t endpoint)
+{
+	if (!usbi_backend.get_max_raw_io_transfer_size)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	return usbi_backend.get_max_raw_io_transfer_size(
+		dev_handle, endpoint);
 }
 
 /** \ingroup libusb_lib

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -24,6 +24,8 @@ EXPORTS
   libusb_dev_mem_alloc@8 = libusb_dev_mem_alloc
   libusb_dev_mem_free
   libusb_dev_mem_free@12 = libusb_dev_mem_free
+  libusb_endpoint_set_raw_io
+  libusb_endpoint_supports_raw_io
   libusb_error_name
   libusb_error_name@4 = libusb_error_name
   libusb_event_handler_active
@@ -90,6 +92,7 @@ EXPORTS
   libusb_get_max_alt_packet_size@16 = libusb_get_max_alt_packet_size
   libusb_get_max_iso_packet_size
   libusb_get_max_iso_packet_size@8 = libusb_get_max_iso_packet_size
+  libusb_get_max_raw_io_transfer_size
   libusb_get_max_packet_size
   libusb_get_max_packet_size@8 = libusb_get_max_packet_size
   libusb_get_next_timeout

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1805,6 +1805,14 @@ int LIBUSB_CALL libusb_attach_kernel_driver(libusb_device_handle *dev_handle,
 int LIBUSB_CALL libusb_set_auto_detach_kernel_driver(
 	libusb_device_handle *dev_handle, int enable);
 
+int LIBUSB_CALL libusb_endpoint_supports_raw_io(libusb_device_handle* dev_handle,
+	uint8_t endpoint);
+int LIBUSB_CALL libusb_endpoint_set_raw_io(libusb_device_handle *dev_handle,
+	uint8_t endpoint, int enable);
+int LIBUSB_CALL libusb_get_max_raw_io_transfer_size(
+	libusb_device_handle *dev_handle,
+	uint8_t endpoint);
+
 /* async I/O */
 
 /** \ingroup libusb_asyncio

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1353,6 +1353,37 @@ struct usbi_os_backend {
 	int (*attach_kernel_driver)(struct libusb_device_handle *dev_handle,
 		uint8_t interface_number);
 
+	/** Check if RAW_IO is supported by an endpoint.
+	 *
+	 * Return:
+	 * - 1 if yes
+	 * - 0 if no
+	 * - a LIBUSB_ERROR code on failure
+	 */
+	int (*endpoint_supports_raw_io)(struct libusb_device_handle* dev_handle,
+		uint8_t endpoint);
+
+	/** Enable/disable RAW_IO for an endpoint.
+	 *
+	 * Return:
+	 * - 0 on success
+	 * - LIBUSB_ERROR_NOT_SUPPORTED if RAW_IO is not supported by the endpoint
+	 * - another LIBUSB_ERROR code on other failure
+	 */
+	int (*endpoint_set_raw_io)(struct libusb_device_handle* dev_handle,
+		uint8_t endpoint, int enable);
+
+	/* Retrieve the maximum transfer size in bytes supported for WinUSB RAW_IO
+	 * for an inbound bulk or interrupt endpoint on an open device. Optional.
+	 *
+	 * Return:
+	 * - a positive maximum transfer size on success
+	 * - a LIBUSB_ERROR code on failure
+	 */
+	int (*get_max_raw_io_transfer_size)(
+		struct libusb_device_handle *dev_handle,
+		uint8_t endpoint);
+
 	/* Destroy a device. Optional.
 	 *
 	 * This function is called when the last reference to a device is

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -717,6 +717,37 @@ static void windows_destroy_device(struct libusb_device *dev)
 	priv->backend->destroy_device(dev);
 }
 
+static int windows_endpoint_supports_raw_io(libusb_device_handle* dev_handle,
+	uint8_t endpoint)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	if (priv->backend->endpoint_supports_raw_io)
+		return priv->backend->endpoint_supports_raw_io(dev_handle, endpoint);
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+static int windows_endpoint_set_raw_io(libusb_device_handle* dev_handle,
+	uint8_t endpoint, int enable)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
+
+	if (priv->backend->endpoint_supports_raw_io == NULL
+		|| priv->backend->endpoint_supports_raw_io(dev_handle, endpoint) != 1
+		|| priv->backend->endpoint_set_raw_io == NULL)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	return priv->backend->endpoint_set_raw_io(dev_handle, endpoint, enable);
+}
+
+static int windows_get_max_raw_io_transfer_size(struct libusb_device_handle *dev_handle,
+	uint8_t endpoint)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	if (priv->backend->get_max_raw_io_transfer_size)
+		return priv->backend->get_max_raw_io_transfer_size(dev_handle, endpoint);
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int windows_submit_transfer(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
@@ -910,6 +941,9 @@ const struct usbi_os_backend usbi_backend = {
 	NULL,	/* kernel_driver_active */
 	NULL,	/* detach_kernel_driver */
 	NULL,	/* attach_kernel_driver */
+	windows_endpoint_supports_raw_io,
+	windows_endpoint_set_raw_io,
+	windows_get_max_raw_io_transfer_size,
 	windows_destroy_device,
 	windows_submit_transfer,
 	windows_cancel_transfer,

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -342,6 +342,13 @@ struct windows_backend {
 	int (*cancel_transfer)(struct usbi_transfer *itransfer);
 	void (*clear_transfer_priv)(struct usbi_transfer *itransfer);
 	enum libusb_transfer_status (*copy_transfer_data)(struct usbi_transfer *itransfer, DWORD length);
+	int (*endpoint_supports_raw_io)(struct libusb_device_handle *dev_handle,
+		uint8_t endpoint);
+	int (*endpoint_set_raw_io)(struct libusb_device_handle *dev_handle,
+		uint8_t endpoint, int enable);
+	int (*get_max_raw_io_transfer_size)(
+                struct libusb_device_handle *dev_handle,
+		uint8_t endpoint);
 };
 
 struct windows_context_priv {

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -721,4 +721,7 @@ const struct windows_backend usbdk_backend = {
 	NULL,	/* cancel_transfer */
 	usbdk_clear_transfer_priv,
 	usbdk_copy_transfer_data,
+	NULL,	/* endpoint_supports_raw_io */
+	NULL,	/* endpoint_set_raw_io */
+	NULL,	/* get_max_raw_io_transfer_size */
 };

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -87,6 +87,9 @@ struct windows_usb_api_backend {
 	int (*submit_control_transfer)(int sub_api, struct usbi_transfer *itransfer);
 	int (*cancel_transfer)(int sub_api, struct usbi_transfer *itransfer);
 	enum libusb_transfer_status (*copy_transfer_data)(int sub_api, struct usbi_transfer *itransfer, DWORD length);
+	int (*endpoint_supports_raw_io)(int sub_api, struct libusb_device_handle *dev_handle, uint8_t endpoint);
+	int (*endpoint_set_raw_io)(int sub_api, struct libusb_device_handle *dev_handle, uint8_t endpoint, int enable);
+	int (*get_max_raw_io_transfer_size)(int sub_api, struct libusb_device_handle *dev_handle, uint8_t endpoint);
 };
 
 extern const struct windows_usb_api_backend usb_api_backend[USB_API_MAX];


### PR DESCRIPTION
This is a continuation of PR #1297 which also supports composite devices, using the same mechanism as other functions which support composite devices, e.g. `libusb_submit_transfer()`.

It provides RAW_IO support by introducing three new API functions:
```c
int libusb_endpoint_supports_raw_io(libusb_device_handle* dev_handle, uint8_t endpoint);
int libusb_endpoint_set_raw_io(libusb_device_handle* dev_handle, uint8_t endpoint, int enable);
int libusb_get_max_raw_io_transfer_size(libusb_device_handle *dev_handle, uint8_t endpoint);
```
