### PR TITLE
windows: Fix bus number assignment corner case

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1902,8 +1902,12 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 			case HUB_PASS:
 			case DEV_PASS:
 				// If the device has already been setup, don't do it again
-				if (priv->path != NULL)
+				if (priv->path != NULL) {
+					// If the skipped device is a root hub, don't reuse its bus number
+					if (api == USB_API_HUB && (get_ancestor(ctx, dev_info_data.DevInst, NULL) == NULL))
+						bus_number++;
 					break;
+				}
 				// Take care of API initialization
 				priv->path = dev_interface_path;
 				dev_interface_path = NULL;


### PR DESCRIPTION
Hi everyone,

Sorry about the duplicate pull request, I messed up my commit signature on the first one.

WinUSB assignes bus numbers sequentially to USB root hubs at enumeration time. In some corner cases, one root hub may be skipped by the enumeration loop due to it having been handled by a previous enumeration. The next enumerated root hub will then be assigned the skipped bus number, which will result in two different root hubs sharing the same bus number.

When skipping a root hub during enumeration, make sure to avoid reusing its bus number.

I discovered this issue while interacting with multiple different USB devices through pyusb. One device was on bus 3, port 3 and the other was on bus 4, port 3. Sometimes, in the same Python interpreter run, usb.core.find(bus=3, port_numbers=(3,), find_all=True) would return the device on bus 3 on the first call, and add the device on bus 4 to the returned results on the second call, claiming that both devices were on bus 3. This behavior only appeared if a reference to the first usb.core.find() call was kept in the Python script.
