### PR TITLE
Added libusb_get_device_string() which works with a closed device

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -417,6 +417,7 @@ if (cfg != desired)
   * - libusb_get_device_descriptor()
   * - libusb_get_device_list()
   * - libusb_get_device_speed()
+  * - libusb_get_device_string()
   * - libusb_get_iso_packet_buffer()
   * - libusb_get_iso_packet_buffer_simple()
   * - libusb_get_max_alt_packet_size()
@@ -502,6 +503,7 @@ if (cfg != desired)
   * - \ref libusb_capability
   * - \ref libusb_class_code
   * - \ref libusb_descriptor_type
+  * - \ref libusb_device_string_type
   * - \ref libusb_endpoint_direction
   * - \ref libusb_endpoint_transfer_type
   * - \ref libusb_error
@@ -1318,6 +1320,10 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 		if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
 			/* backend does not support hotplug */
 			usbi_disconnect_device(dev);
+		}
+
+		for (int idx = 0; idx < LIBUSB_DEVICE_STRING_COUNT; ++idx) {
+			free(dev->device_strings_utf8[idx]);
 		}
 
 		free(dev);

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -86,6 +86,8 @@ EXPORTS
   libusb_get_device_list@8 = libusb_get_device_list
   libusb_get_device_speed
   libusb_get_device_speed@4 = libusb_get_device_speed
+  libusb_get_device_string
+  libusb_get_device_string@16 = libusb_get_device_string
   libusb_get_interface_association_descriptors
   libusb_get_interface_association_descriptors@12 = libusb_get_interface_association_descriptors
   libusb_get_max_alt_packet_size

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1647,6 +1647,29 @@ enum libusb_option {
 	LIBUSB_OPTION_MAX = 4
 };
 
+/** \ingroup libusb_desc
+ * The device string type.
+ */
+enum libusb_device_string_type {
+	LIBUSB_DEVICE_STRING_MANUFACTURER,
+	LIBUSB_DEVICE_STRING_PRODUCT,
+	LIBUSB_DEVICE_STRING_SERIAL_NUMBER,
+	LIBUSB_DEVICE_STRING_COUNT  /* The total number of string types. */
+};
+
+/** \ingroup libusb_desc
+ * The maximum length for a device string descriptor in UTF-8.
+ * 
+ * 255 max descriptor length with 2 byte header 
+ *  => 253 bytes UTF-16LE, no null termination (USB 2.0 9.6.7)
+ *  => 126.5 codepoints
+ *  => 126 * 3 + 1
+ *  => 382 bytes
+ * 
+ * Stay with 256 * 2/3 = 384 to be safe.
+ */
+#define LIBUSB_DEVICE_STRING_BYTES_MAX  (384U)
+ 
 /** \ingroup libusb_lib
  * Callback function for handling log messages.
  * \param ctx the context which is related to the log message, or NULL if it
@@ -1694,6 +1717,8 @@ void LIBUSB_CALL libusb_free_device_list(libusb_device **list,
 libusb_device * LIBUSB_CALL libusb_ref_device(libusb_device *dev);
 void LIBUSB_CALL libusb_unref_device(libusb_device *dev);
 
+int LIBUSB_CALL libusb_get_device_string(libusb_device *dev,
+	enum libusb_device_string_type string_type, char *data, int length);
 int LIBUSB_CALL libusb_get_configuration(libusb_device_handle *dev,
 	int *config);
 int LIBUSB_CALL libusb_get_device_descriptor(libusb_device *dev,

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -523,6 +523,8 @@ struct libusb_device {
 
 	struct libusb_device_descriptor device_descriptor;
 	usbi_atomic_t attached;
+
+	char * device_strings_utf8[LIBUSB_DEVICE_STRING_COUNT];
 };
 
 struct libusb_device_handle {
@@ -1025,6 +1027,31 @@ struct usbi_os_backend {
 	 */
 	int (*get_device_list)(struct libusb_context *ctx,
 		struct discovered_devs **discdevs);
+
+	/* Retrieve a device string without needing to open the device.
+	 *
+	 * The string should be retrieved without opening the device
+	 * and ideally without performing USB transactions to the device.
+	 * Most operating systems read and cache the common string 
+	 * descriptors.  Use the OS-specific calls to retrieve these strings.
+	 *
+	 * Since the USB string descriptor could be processed by the OS,
+	 * this function returns a UTF-8 encoded string.
+	 *
+	 * The string will be returned untranslated or in the default OS language
+	 * when supported by the OS and USB device.
+	 *
+	 * This function must not write more than length bytes into data,
+	 * including the null terminator.
+	 *
+	 * Return:
+	 * - The actual length in bytes including the null termintor on success.
+	 * - LIBUSB_ERROR_NO_DEVICE if device not found.
+	 * - LIBUSB_ERROR_INVALID_PARAM if any parameter is invalid.
+	 * - another LIBUSB_ERROR code on other failure
+	 */
+	int (*get_device_string)(libusb_device *dev,
+		enum libusb_device_string_type string_type, char *data, int length);
 
 	/* Apps which were written before hotplug support, may listen for
 	 * hotplug events on their own and call libusb_get_device_list on

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -98,6 +98,8 @@ static int init_count = 0;
 /* Serialize scan-devices, event-thread, and poll */
 usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
 
+static int open_sysfs_attr(struct libusb_context *ctx,
+	const char *sysfs_dir, const char *attr);
 static int linux_scan_devices(struct libusb_context *ctx);
 static int detach_kernel_driver_and_claim(struct libusb_device_handle *, uint8_t);
 
@@ -450,6 +452,44 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 	}
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
+static int op_get_device_string(struct libusb_device *dev, 
+		enum libusb_device_string_type string_type, char *buffer, int length)
+{
+	ssize_t r;
+	int fd;
+	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+	struct libusb_context* ctx = DEVICE_CTX(dev);
+	const char * attr;
+
+	switch (string_type) {
+		case LIBUSB_DEVICE_STRING_MANUFACTURER: attr = "manufacturer"; break;
+		case LIBUSB_DEVICE_STRING_PRODUCT: attr = "product"; break;
+		case LIBUSB_DEVICE_STRING_SERIAL_NUMBER: attr = "serial"; break;
+		default:
+			return LIBUSB_ERROR_INVALID_PARAM;
+	}
+	fd = open_sysfs_attr(ctx, priv->sysfs_dir, attr);
+	if (fd < 0)
+		return LIBUSB_ERROR_IO;
+
+	r = read(fd, buffer, length - 1);  // leave space for null terminator
+	if (r < 0) {
+		r = errno;
+		close(fd);
+		if (r == ENODEV)
+			return LIBUSB_ERROR_NO_DEVICE;
+		usbi_err(ctx, "attribute %s read failed, errno=%zd", attr, r);
+		return LIBUSB_ERROR_IO;
+	}
+	close(fd);
+	buffer[r] = 0;  // add null terminator
+	while (r && ((buffer[r] == 0) || (buffer[r] == '\n'))) {
+		buffer[r--] = 0;
+	}
+	++r;
+	return r;
 }
 
 static int linux_scan_devices(struct libusb_context *ctx)
@@ -2787,6 +2827,7 @@ const struct usbi_os_backend usbi_backend = {
 	.init = op_init,
 	.exit = op_exit,
 	.set_option = op_set_option,
+	.get_device_string = op_get_device_string,
 	.hotplug_poll = op_hotplug_poll,
 	.get_active_config_descriptor = op_get_active_config_descriptor,
 	.get_config_descriptor = op_get_config_descriptor,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -651,6 +651,16 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 }
 #endif
 
+static int windows_get_device_string(libusb_device *dev,
+	enum libusb_device_string_type string_type, char *data, int length)
+{
+	struct windows_context_priv* priv = usbi_get_context_priv(DEVICE_CTX(dev));
+	if (NULL != priv->backend->get_device_string) {
+		return priv->backend->get_device_string(dev, string_type, data, length);
+	}
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int windows_open(struct libusb_device_handle *dev_handle)
 {
 	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
@@ -945,6 +955,7 @@ const struct usbi_os_backend usbi_backend = {
 #else
 	windows_get_device_list,
 #endif
+	windows_get_device_string,
 	NULL,	/* hotplug_poll */
 	NULL,	/* wrap_sys_device */
 	windows_open,

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -320,6 +320,8 @@ struct windows_backend {
 	void (*exit)(struct libusb_context *ctx);
 	int (*get_device_list)(struct libusb_context *ctx,
 		struct discovered_devs **discdevs);
+	int (*get_device_string)(libusb_device *dev,
+		enum libusb_device_string_type string_type, char *data, int length);
 	int (*open)(struct libusb_device_handle *dev_handle);
 	void (*close)(struct libusb_device_handle *dev_handle);
 	int (*get_active_config_descriptor)(struct libusb_device *device,

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -706,6 +706,7 @@ const struct windows_backend usbdk_backend = {
 	usbdk_init,
 	usbdk_exit,
 	usbdk_get_device_list,
+	NULL,  /* usbdk_get_device_string */
 	usbdk_open,
 	usbdk_close,
 	usbdk_get_active_config_descriptor,


### PR DESCRIPTION
Added libusb_get_device_string() which works with a closed device  #866

This new API call provides access to device strings, normally accessed using USB string descriptors, without opening the device.  The common use case is to filter on serial number for selecting one of multiple connected devices.

The commit adds the new API function, documentation, and support for the following platforms:

* Windows WinUSB
* Linux
* macOS

All platforms support manufacturer, product, and serial number strings.

The example/listdevs.c now has a "--verbose" command line argument that prints these strings.

Known issues:

* On one Ubuntu Linux machine, reading the /sys/bus/usb/ files to get the strings takes a variable amount of time on one device,  an xHCI root hub.  While the read can be fast, it can also take seconds.  Using "cat" at the command line has the exact same behavior.

References:

* https://github.com/libusb/libusb/issues/866
* https://github.com/libusb/libusb/pull/875
* https://github.com/libusb/libusb/pull/1258
* https://github.com/hjmallon/libusb/commit/d0f9fd4852dfceaa4f8f55700ed9b74c4e5406dd

Thank you to the prior work that made this much quicker:

* @mcuee
* @sonatique
* @hjmallon

I apologize anyone that I missed.  This feature has been in the works for a long time with multiple starts and stops.

And thank you to @Youw, @seanm and @Mr-Bossman for providing review feedback!