### PR TITLE
examples: fixed error checking regression

### DIFF
--- a/examples/ezusb.c
+++ b/examples/ezusb.c
@@ -816,7 +816,7 @@ int ezusb_load_ram(libusb_device_handle *device, const char *path, int fx_type, 
 
 		/* at least write the interrupt vectors (at 0x0000) for reset! */
 		status = fseek(image, 0L, SEEK_SET);
-		if (ret < 0) {
+		if (status < 0) {
 			logerror("unable to rewind file %s\n", path);
 			ret = status;
 			goto exit;


### PR DESCRIPTION
00454ab087774a62b314805b51215bba81a99aa8 accidently botched error checking when replacing rewind() with fseek().

Thanks to @anotheruserofgithub for noticing.