### PR TITLE
descriptor: fixed clang -Wimplicit-int-conversion warnings

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -32,16 +32,16 @@
 
 static inline uint16_t ReadLittleEndian16(const uint8_t p[2])
 {
-	return (uint16_t)p[1] << 8 |
-	       (uint16_t)p[0];
+	return (uint16_t)((uint16_t)p[1] << 8 |
+			  (uint16_t)p[0]);
 }
 
 static inline uint32_t ReadLittleEndian32(const uint8_t p[4])
 {
-	return (uint32_t)p[3] << 24 |
-	       (uint32_t)p[2] << 16 |
-	       (uint32_t)p[1] << 8 |
-	       (uint32_t)p[0];
+	return (uint32_t)((uint32_t)p[3] << 24 |
+			  (uint32_t)p[2] << 16 |
+			  (uint32_t)p[1] << 8 |
+			  (uint32_t)p[0]);
 }
 
 static void clear_endpoint(struct libusb_endpoint_descriptor *endpoint)


### PR DESCRIPTION
For the 16 bit case especially, the result of the `or` is implicitly promoted to `int`, then when returned was warning:

warning: implicit conversion loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]

Added more casts to shut it up.