### PR TITLE
core: add LIBUSB_PACKED_PUSH / LIBUSB_PACKED_POP for portable struct padding

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -81,10 +81,23 @@ typedef SSIZE_T ssize_t;
 #define LIBUSB_DEPRECATED_FOR(f)
 #endif /* __GNUC__ */
 
+/* Deprecated, use LIBUSB_PACKED_PUSH/LIBUSB_PACKED_POP instead. */
 #if defined(__GNUC__)
 #define LIBUSB_PACKED __attribute__ ((packed))
 #else
 #define LIBUSB_PACKED
+#endif /* __GNUC__ */
+
+#if defined(__GNUC__)
+#define LIBUSB_PACKED_PUSH _Pragma("pack(push, 1)")
+#define LIBUSB_PACKED_POP _Pragma("pack(pop)")
+#elif defined(_MSC_VER) || defined(__WATCOMC__)
+#define LIBUSB_PACKED_PUSH __pragma("pack(push, 1)")
+#define LIBUSB_PACKED_POP __pragma("pack(pop)")
+#else
+#warning Compiler not recognised; therefore not possible to pack structs.
+#define LIBUSB_PACKED_PUSH
+#define LIBUSB_PACKED_POP
 #endif /* __GNUC__ */
 
 /** \def LIBUSB_CALL
@@ -1157,9 +1170,7 @@ struct libusb_platform_descriptor {
 
 /** \ingroup libusb_asyncio
  * Setup packet for control transfers. */
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(push, 1)
-#endif
+LIBUSB_PACKED_PUSH
 struct libusb_control_setup {
 	/** Request type. Bits 0:4 determine recipient, see
 	 * \ref libusb_request_recipient. Bits 5:6 determine type, see
@@ -1184,10 +1195,8 @@ struct libusb_control_setup {
 
 	/** Number of bytes to transfer */
 	uint16_t wLength;
-} LIBUSB_PACKED;
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
 
 #define LIBUSB_CONTROL_SETUP_SIZE (sizeof(struct libusb_control_setup))
 

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -83,10 +83,26 @@ typedef SSIZE_T ssize_t;
 #define LIBUSB_DEPRECATED_FOR(f)
 #endif /* __GNUC__ */
 
+/* Deprecated, use LIBUSB_PACKED_PUSH/LIBUSB_PACKED_POP instead. */
 #if defined(__GNUC__)
 #define LIBUSB_PACKED __attribute__ ((packed))
 #else
 #define LIBUSB_PACKED
+#endif /* __GNUC__ */
+
+#if defined(__GNUC__)
+#define LIBUSB_PACKED_PUSH _Pragma("pack(push, 1)")
+#define LIBUSB_PACKED_POP _Pragma("pack(pop)")
+#elif defined(_MSC_VER)
+#define LIBUSB_PACKED_PUSH __pragma(pack(push, 1))
+#define LIBUSB_PACKED_POP __pragma(pack(pop))
+#elif defined(__WATCOMC__)
+#define LIBUSB_PACKED_PUSH pragma pack(__push, 1)
+#define LIBUSB_PACKED_POP pragma pack(__pop, 1)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
+#warning Compiler not recognised; therefore not possible to pack structs as required.
+#define LIBUSB_PACKED_PUSH
+#define LIBUSB_PACKED_POP
 #endif /* __GNUC__ */
 
 /** \def LIBUSB_CALL
@@ -1160,9 +1176,7 @@ struct libusb_platform_descriptor {
 
 /** \ingroup libusb_asyncio
  * Setup packet for control transfers. */
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(push, 1)
-#endif
+LIBUSB_PACKED_PUSH
 struct libusb_control_setup {
 	/** Request type. Bits 0:4 determine recipient, see
 	 * \ref libusb_request_recipient. Bits 5:6 determine type, see
@@ -1187,10 +1201,9 @@ struct libusb_control_setup {
 
 	/** Number of bytes to transfer */
 	uint16_t wLength;
-} LIBUSB_PACKED;
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct libusb_control_setup) == 8, "struct packing failed");
 
 #define LIBUSB_CONTROL_SETUP_SIZE (sizeof(struct libusb_control_setup))
 

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -659,16 +659,15 @@ enum usbi_transfer_timeout_flags {
 	 ((unsigned char *)(transfer)			\
 	  - PTR_ALIGN(sizeof(struct usbi_transfer))))
 
-#ifdef _MSC_VER
-#pragma pack(push, 1)
-#endif
-
 /* All standard descriptors have these 2 fields in common */
+LIBUSB_PACKED_PUSH
 struct usbi_descriptor_header {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
 
+LIBUSB_PACKED_PUSH
 struct usbi_device_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -684,8 +683,10 @@ struct usbi_device_descriptor {
 	uint8_t  iProduct;
 	uint8_t  iSerialNumber;
 	uint8_t  bNumConfigurations;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
 
+LIBUSB_PACKED_PUSH
 struct usbi_configuration_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -695,8 +696,10 @@ struct usbi_configuration_descriptor {
 	uint8_t  iConfiguration;
 	uint8_t  bmAttributes;
 	uint8_t  bMaxPower;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
 
+LIBUSB_PACKED_PUSH
 struct usbi_interface_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -707,24 +710,25 @@ struct usbi_interface_descriptor {
 	uint8_t  bInterfaceSubClass;
 	uint8_t  bInterfaceProtocol;
 	uint8_t  iInterface;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
 
+LIBUSB_PACKED_PUSH
 struct usbi_string_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wData[LIBUSB_FLEXIBLE_ARRAY];
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
 
+LIBUSB_PACKED_PUSH
 struct usbi_bos_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wTotalLength;
 	uint8_t  bNumDeviceCaps;
-} LIBUSB_PACKED;
-
-#ifdef _MSC_VER
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
 
 union usbi_config_desc_buf {
 	struct usbi_configuration_descriptor desc;

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -650,16 +650,16 @@ enum usbi_transfer_timeout_flags {
 	USBI_TRANSFER_TIMED_OUT = 1U << 2,
 };
 
-#ifdef _MSC_VER
-#pragma pack(push, 1)
-#endif
-
 /* All standard descriptors have these 2 fields in common */
+LIBUSB_PACKED_PUSH
 struct usbi_descriptor_header {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_descriptor_header) == 2, "struct packing failed");
 
+LIBUSB_PACKED_PUSH
 struct usbi_device_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -675,8 +675,11 @@ struct usbi_device_descriptor {
 	uint8_t  iProduct;
 	uint8_t  iSerialNumber;
 	uint8_t  bNumConfigurations;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_device_descriptor) == 18, "struct packing failed");
 
+LIBUSB_PACKED_PUSH
 struct usbi_configuration_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -686,8 +689,11 @@ struct usbi_configuration_descriptor {
 	uint8_t  iConfiguration;
 	uint8_t  bmAttributes;
 	uint8_t  bMaxPower;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_configuration_descriptor) == 9, "struct packing failed");
 
+LIBUSB_PACKED_PUSH
 struct usbi_interface_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -698,24 +704,28 @@ struct usbi_interface_descriptor {
 	uint8_t  bInterfaceSubClass;
 	uint8_t  bInterfaceProtocol;
 	uint8_t  iInterface;
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_interface_descriptor) == 9, "struct packing failed");
 
+LIBUSB_PACKED_PUSH
 struct usbi_string_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wData[LIBUSB_FLEXIBLE_ARRAY];
-} LIBUSB_PACKED;
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_string_descriptor) >= 2, "struct packing failed");
 
+LIBUSB_PACKED_PUSH
 struct usbi_bos_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wTotalLength;
 	uint8_t  bNumDeviceCaps;
-} LIBUSB_PACKED;
-
-#ifdef _MSC_VER
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_bos_descriptor) == 5, "struct packing failed");
 
 union usbi_config_desc_buf {
 	struct usbi_configuration_descriptor desc;

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2132,19 +2132,13 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 	return r;
 }
 
-#ifdef _MSC_VER
-#pragma pack(push, 1)
-#endif
-
+LIBUSB_PACKED_PUSH
 struct string_descriptor_s {
 	UCHAR bLength;
 	UCHAR bDescriptorType;
 	uint8_t bString[252];  // UTF-16LE, must be even length
-} LIBUSB_PACKED;
-
-#ifdef _MSC_VER
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
 
 struct string_descriptor_req_s {
 	USB_DESCRIPTOR_REQUEST req;

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2470,19 +2470,14 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 	return r;
 }
 
-#ifdef _MSC_VER
-#pragma pack(push, 1)
-#endif
-
+LIBUSB_PACKED_PUSH
 struct string_descriptor_s {
 	UCHAR bLength;
 	UCHAR bDescriptorType;
 	uint8_t bString[252];  // UTF-16LE, must be even length
-} LIBUSB_PACKED;
-
-#ifdef _MSC_VER
-#pragma pack(pop)
-#endif
+};
+LIBUSB_PACKED_POP
+static_assert(sizeof(struct usbi_string_descriptor) == 254, "struct packing failed");
 
 struct string_descriptor_req_s {
 	USB_DESCRIPTOR_REQUEST req;


### PR DESCRIPTION
…padding

GCC/Clang support MSVC syntax for struct packing, so we can use that everywhere instead of having two different techniques.