### PR TITLE
winusb: fix winusb_get_device_list() failing to find port numbers

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1229,9 +1229,10 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 static bool get_dev_port_number(HDEVINFO dev_info, SP_DEVINFO_DATA *dev_info_data, DWORD *port_nr)
 {
 	char buffer[MAX_KEY_LENGTH];
-	DWORD size, port;
-	const char *start;
+	DWORD size;
+	const char *start = NULL;
 	char *end = NULL;
+	long long port;
 
 	// First try SPDRP_LOCATION_INFORMATION, which returns a REG_SZ. The string *may* have a format
 	// similar to "Port_#0002.Hub_#000D", in which case we can extract the port number. However, we
@@ -1241,11 +1242,14 @@ static bool get_dev_port_number(HDEVINFO dev_info, SP_DEVINFO_DATA *dev_info_dat
 		// Check for the required format.
 		if (strncmp(buffer, "Port_#", 6) == 0) {
 			start = buffer + 6;
-			port = strtoul(start, &end, 10);
-			if (port == 0 || port == ULONG_MAX || end == start || (*end != '.' && *end != '\0')) {
+			// Note that 0 is both strtoll's sentinel return value to indicate failure, as well
+			// as (obviously) the return value for the literal "0". Fortunately we can always treat
+			// 0 as a failure, since Windows USB port numbers are numbered 1..n.
+			port = strtoll(start, &end, 10);
+			if (port <= 0 || port >= ULONG_MAX || end == start || (*end != '.' && *end != '\0')) {
 				return false;
 			}
-			*port_nr = port;
+			*port_nr = (DWORD)port;
 			return true;
 		}
 	}
@@ -1260,11 +1264,11 @@ static bool get_dev_port_number(HDEVINFO dev_info, SP_DEVINFO_DATA *dev_info_dat
 		for (char *token = strrchr(buffer, '#'); token != NULL; token = strrchr(buffer, '#')) {
 			if (strncmp(token, "#USB(", 5) == 0) {
 				start = token + 5;
-				port = strtoul(start, &end, 10);
-				if (port == 0 || port == ULONG_MAX || end == start || (*end != ')' && *end != '\0')) {
+				port = strtoll(start, &end, 10);
+				if (port <= 0 || port >= ULONG_MAX || end == start || (*end != ')' && *end != '\0')) {
 					return false;
 				}
-				*port_nr = port;
+				*port_nr = (DWORD)port;
 				return true;
 			}
 			// Shorten the string and try again.


### PR DESCRIPTION
9d595d4 introduced a regression that causes usage with winusb devices to fail. Sample code to reproduce:
```
libusb_init(NULL);
libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
libusb_open_device_with_vid_pid(NULL, 0x1A86, 0x55DB);
```
Result on my machine:
```
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_03F0&PID_5488\B&296CF2FA&0&2': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_03F0&PID_5488\B&296CF2FA&0&2': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_03F0&PID_5488\B&296CF2FA&0&2'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_03F0&PID_0488\11AD1D0A528E7D0B2F0E0B00': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_03F0&PID_0488\11AD1D0A528E7D0B2F0E0B00': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_03F0&PID_0488\11AD1D0A528E7D0B2F0E0B00'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_03F0&PID_2488\A&521A507&0&4': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_03F0&PID_2488\A&521A507&0&4': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_03F0&PID_2488\A&521A507&0&4'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_8087&PID_0B40\9&262EACF6&0&1': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_8087&PID_0B40\9&262EACF6&0&1': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_8087&PID_0B40\9&262EACF6&0&1'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_046D&PID_C093\206D324F4646': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_046D&PID_C093\206D324F4646': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_046D&PID_C093\206D324F4646'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_05E3&PID_0610\8&384B90AF&0&3': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_05E3&PID_0610\8&384B90AF&0&3': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_05E3&PID_0610\8&384B90AF&0&3'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_05E3&PID_0625\8&384B90AF&0&7': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_05E3&PID_0625\8&384B90AF&0&7': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_05E3&PID_0625\8&384B90AF&0&7'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_1D5C&PID_5801\9&34C4E5CC&0&1': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_1D5C&PID_5801\9&34C4E5CC&0&1': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_1D5C&PID_5801\9&34C4E5CC&0&1'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_1A86&PID_55DB\0123456789': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_1A86&PID_55DB\0123456789': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_1A86&PID_55DB\0123456789'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_30BE&PID_1014\6&C1A2E2F&0&4': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_30BE&PID_1014\6&C1A2E2F&0&4': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_30BE&PID_1014\6&C1A2E2F&0&4'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_03F0&PID_4488\B&24EB38C9&0&2': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_03F0&PID_4488\B&24EB38C9&0&2': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_03F0&PID_4488\B&24EB38C9&0&2'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_3233&PID_1311\DK-V1.12-230201': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_3233&PID_1311\DK-V1.12-230201': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_3233&PID_1311\DK-V1.12-230201'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_0BDA&PID_8153\102000001': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_0BDA&PID_8153\102000001': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_0BDA&PID_8153\102000001'
libusb: warning [winusb_get_device_list] could not retrieve port number for device 'USB\VID_03F0&PID_3488\A&6D75A6C&0&4': [0] The operation completed successfully.
libusb: warning [init_device] could not get node connection information for device 'USB\VID_03F0&PID_3488\A&6D75A6C&0&4': [87] The parameter is incorrect.
libusb: warning [winusb_get_device_list] failed to initialize device 'USB\VID_03F0&PID_3488\A&6D75A6C&0&4'
```
This commit keeps the `strtoll` (well, `strtoul` now) based parsing introduced in 9d595d4 but fixes some incorrect assumptions about this API that were causing `get_dev_port_number()` to fail.

NB: I dislike checking for 0 as the error condition, but the API is [documented](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strtoul-strtoul-l-wcstoul-wcstoul-l) to return 0 on failure, and `ULONG_MAX` on overflow.
The Microsoft documentation also states that `errno` will be set if underflow or overflow occurs, but after testing this with the MS CRT I found that `errno` does not get set for cases of obviously invalid input, which makes checking this value fairly useless. Fortunately, MS also documents that [USB ports will always be numbered `1..n`](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usbioctl/ns-usbioctl-_usb_node_connection_information_ex_v2#members) - i.e. 0 is in fact an invalid port number.