### PR TITLE
Fix SSP descriptor documentation

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1012,12 +1012,25 @@ int API_EXPORTED libusb_get_ss_usb_device_capability_descriptor(
  * We don't expose it.
  */
 struct internal_ssplus_capability_descriptor {
+	/** The length of the descriptor. Must be equal to LIBUSB_BT_SSPLUS_USB_DEVICE_CAPABILITY_SIZE */
 	uint8_t  bLength;
+	
+	/** The type of the descriptor */
 	uint8_t  bDescriptorType;
+	
+	/** Must be equal to LIBUSB_BT_SUPERSPEED_PLUS_CAPABILITY*/
 	uint8_t  bDevCapabilityType;
+	
+	/** Unused */
 	uint8_t  bReserved;
+	
+	/** Contains the number of SublinkSpeedIDs*/
 	uint32_t bmAttributes;
+	
+	/** Contains the ssid, minRxLaneCount, and minTxLaneCount */
 	uint16_t wFunctionalitySupport;
+	
+	/** Unused */
 	uint16_t wReserved;
 };
 /// @endcond

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1005,9 +1005,12 @@ int API_EXPORTED libusb_get_ss_usb_device_capability_descriptor(
 	return LIBUSB_SUCCESS;
 }
 
-/* We use this private struct only to parse a SuperSpeedPlus device capability
-   descriptor according to section 9.6.2.5 of the USB 3.1 specification.
-   We don't expose it. */
+/// @cond DEV
+/** \internal \ingroup libusb_desc
+ * We use this private struct only to parse a SuperSpeedPlus device capability
+ * descriptor according to section 9.6.2.5 of the USB 3.1 specification.
+ * We don't expose it.
+ */
 struct internal_ssplus_capability_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
@@ -1017,6 +1020,7 @@ struct internal_ssplus_capability_descriptor {
 	uint16_t wFunctionalitySupport;
 	uint16_t wReserved;
 };
+/// @endcond
 
 int API_EXPORTED libusb_get_ssplus_usb_device_capability_descriptor(
 	libusb_context *ctx,

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -566,7 +566,7 @@ enum libusb_bos_type {
 	/** Platform descriptor */
 	LIBUSB_BT_PLATFORM_DESCRIPTOR = 0x05,
 
-	/* SuperSpeedPlus device capability */
+	/** SuperSpeedPlus device capability */
 	LIBUSB_BT_SUPERSPEED_PLUS_CAPABILITY = 0x0A,
 };
 
@@ -1075,7 +1075,7 @@ struct libusb_ssplus_usb_device_capability_descriptor {
 	/** This field indicates the minimum transmit lane count*/
 	uint8_t minTxLaneCount;
 
-	/** num attrtibutes=  \ref libusb_ssplus_usb_device_capability_descriptor.numSublinkSpeedAttributes= */
+	/** num attributes=  \ref libusb_ssplus_usb_device_capability_descriptor.numSublinkSpeedAttributes */
 	struct libusb_ssplus_sublink_attribute sublinkSpeedAttributes[];
 };
 


### PR DESCRIPTION
Sorry about the extra `=`. This was an oversight.