### PR TITLE
descriptor: Warn on invalid langid descriptor

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1268,9 +1268,10 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	r = libusb_get_string_descriptor(dev_handle, 0, 0, str.buf, 4);
 	if (r < 0)
 		return r;
-	else if (r != 4 || str.desc.bLength < 4 || str.desc.bDescriptorType != LIBUSB_DT_STRING)
+	else if (r != 4 || str.desc.bLength < 4 || str.desc.bDescriptorType != LIBUSB_DT_STRING) {
+		usbi_warn(HANDLE_CTX(dev_handle), "invalid language ID string descriptor");
 		return LIBUSB_ERROR_IO;
-	else if (str.desc.bLength & 1)
+	} else if (str.desc.bLength & 1)
 		usbi_warn(HANDLE_CTX(dev_handle), "suspicious bLength %u for language ID string descriptor", str.desc.bLength);
 
 	langid = libusb_le16_to_cpu(str.desc.wData[0]);


### PR DESCRIPTION
Closes #1548

Since we were just silently erring out on a failing langid retrieval, it was not easy to see if the problem is with the langid descriptor or with the wanted string descriptor.