### PR TITLE
Enable linux netlink event monitoring for Android OS platform services

### DIFF
--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -174,7 +174,17 @@ static inline int linux_start_event_monitor(void)
 {
 #if defined(HAVE_LIBUDEV)
 	return linux_udev_start_event_monitor();
-#elif !defined(__ANDROID__)
+/*
+* __ANDROID__: preprocessor macro defined automatically by GCC for all Android
+*              targets (i.e. both Android native applications, and Android OS-level
+*              services)
+*
+* ANDROID_OS: compilation flag that should be set for using libusb from programs
+*             running on Android at OS level (e.g. Android platform services).
+*             The programs using libusb built with the ANDROID_OS flag must have
+*             permission to access netlink sockets.
+*/
+#elif !defined(__ANDROID__) || defined(ANDROID_OS)
 	return linux_netlink_start_event_monitor();
 #else
 	return LIBUSB_SUCCESS;
@@ -185,7 +195,7 @@ static inline void linux_stop_event_monitor(void)
 {
 #if defined(HAVE_LIBUDEV)
 	linux_udev_stop_event_monitor();
-#elif !defined(__ANDROID__)
+#elif !defined(__ANDROID__) || defined(ANDROID_OS)
 	linux_netlink_stop_event_monitor();
 #endif
 }
@@ -194,7 +204,7 @@ static inline void linux_hotplug_poll(void)
 {
 #if defined(HAVE_LIBUDEV)
 	linux_udev_hotplug_poll();
-#elif !defined(__ANDROID__)
+#elif !defined(__ANDROID__) || defined(ANDROID_OS)
 	linux_netlink_hotplug_poll();
 #endif
 }


### PR DESCRIPTION
Introducing the ANDROID_OS macro that is supposed to be set by clients
of libusb that are running on Android at the OS level.

If Android_OS is set (and HAVE_LIBUDEV is not) then linux netlink event
monitoring (and consequently hotplug functionality) is enabled. This
works for Android services or simple binaries running at the OS level as
they have the necessary permissions, in contrast to usual Android apps
(see commit https://github.com/libusb/libusb/commit/2f3bc98b0d0f4766496df53c855685a5f0e5e7cf).

Note: the \_\_ANDROID\_\_ macro is set by GCC for all targets running on
Android (both OS-level services and apps).

---

I noticed there have been previous discussions about this topic in the 2f3bc98b0d commit comments and  #1168.  

---

Closes #1578
