### PR TITLE
core: add new option to disable reap after usb is disconnected

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2350,6 +2350,7 @@ int API_EXPORTEDV libusb_set_option(libusb_context *ctx,
 			/* Handle all backend-specific options here */
 		case LIBUSB_OPTION_USE_USBDK:
 		case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+		case LIBUSB_OPTION_NO_REAP_AFTER_DISCONNECT:
 			if (usbi_backend.set_option) {
 				r = usbi_backend.set_option(ctx, option, ap);
 				break;
@@ -2494,6 +2495,7 @@ int API_EXPORTED libusb_init_context(libusb_context **ctx, const struct libusb_i
 		case LIBUSB_OPTION_LOG_LEVEL:
 		case LIBUSB_OPTION_USE_USBDK:
 		case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+		case LIBUSB_OPTION_NO_REAP_AFTER_DISCONNECT:
 		case LIBUSB_OPTION_MAX:
 		default:
 			r = libusb_set_option(_ctx, options[i].option, options[i].value.ival);

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1644,7 +1644,21 @@ enum libusb_option {
 	 */
 	LIBUSB_OPTION_LOG_CB = 3,
 
-	LIBUSB_OPTION_MAX = 4
+	/** Don't reap data after usb is disconnected
+	 *
+	 * This option will prohibit Reap operation after disconnection, 
+	 * even if the system has USBFS_CAP_REAP_AFTER_DISCONNECT capability. 
+	 * This method is used to avoid data loss issues caused by competition 
+	 * between the Kernel thread and the thread where the 
+	 * \ref libusb_handle_events_timeout_completed related function is located
+	 * after the device is unplugged in some millisecond level communication 
+	 * situations.
+	 * 
+	 * Only valid on Linux. Ignored on all other platforms.
+	 */
+	LIBUSB_OPTION_NO_REAP_AFTER_DISCONNECT = 4,
+
+	LIBUSB_OPTION_MAX = 5
 };
 
 /** \ingroup libusb_lib


### PR DESCRIPTION
linux:

On some Linux systems (such as Linux 6.5 and Linux 6.8), after unplugging some USB devices, the execution time of the usb_disconnect() function in the kernel is too long, causing competition between the thread where handle_event() is located and the thread in the kernel, resulting in handle_event() thread blocking.

This option will disable Reap operation after disconnection, even if the system has the capability. This method is used to avoid the problem of competition between the kernel thread and the thread where the handle_event() related function is located after the device is unplugged, resulting in the loss of USB data that is still online in some millisecond level communication situations.