### PR TITLE
Handle size is 0 in usbi_reallocf() in libusbi.h

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -263,7 +263,7 @@ static inline void *usbi_reallocf(void *ptr, size_t size)
 {
 	void *ret = realloc(ptr, size);
 
-	if (!ret)
+	if (!ret && size != 0)
 		free(ptr);
 	return ret;
 }


### PR DESCRIPTION
Double Free Risk:
The original usbi_reallocf function does not handle the case where size is 0 correctly. When realloc is called with a size of 0, it is equivalent to calling free(ptr), and realloc returns NULL. If the function then checks !ret and calls free(ptr) again, it results in a double free error, which can lead to undefined behavior and potential crashes.

[Tormod added]
Note this can't happen with the current code, because usbi_reallocf() is only used in one place (in Linux-only code), and _size_ will never be zero here.