### PR TITLE
darwin: Fix time calculation to handle negative nanosecond deltas

### DIFF
--- a/examples/sam3u_benchmark.c
+++ b/examples/sam3u_benchmark.c
@@ -35,6 +35,10 @@
 
 #include "libusb.h"
 
+#if !defined(USEC_PER_SEC)
+#define USEC_PER_SEC	1000000L
+#endif
+
 #define EP_DATA_IN	0x82
 #define EP_ISO_IN	0x86
 
@@ -161,8 +165,14 @@ static void measure(void)
 
 	get_timestamp(&tv_stop);
 
-	diff_msec = (tv_stop.tv_sec - tv_start.tv_sec) * 1000L;
-	diff_msec += (tv_stop.tv_usec - tv_start.tv_usec) / 1000L;
+	long diff_sec = tv_stop.tv_sec - tv_start.tv_sec;
+	long diff_usec = tv_stop.tv_usec - tv_start.tv_usec;
+	if (diff_usec < 0) {
+		diff_usec += USEC_PER_SEC;
+		diff_sec--;
+	}
+	diff_msec = (unsigned long)diff_sec * 1000UL;
+	diff_msec += (unsigned long)diff_usec / 1000UL;
 
 	printf("%lu transfers (total %lu bytes) in %lu milliseconds => %lu bytes/sec\n",
 		num_xfer, num_bytes, diff_msec, (num_bytes * 1000L) / diff_msec);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2131,12 +2131,11 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
     struct timespec delay = {.tv_sec = 0, .tv_nsec = 1000};
     nanosleep (&delay, NULL);
 
-    struct timespec now;
+    struct timespec now, delta;
     usbi_get_monotonic_time(&now);
-    long delta_sec = now.tv_sec - start.tv_sec;
-    long delta_nsec = now.tv_nsec - start.tv_nsec;
-    unsigned long long elapsed_us = (unsigned long long)delta_sec * USEC_PER_SEC +
-                                    (unsigned long long)delta_nsec / 1000ULL;
+    TIMESPEC_SUB(&now, &start, &delta);
+    unsigned long long elapsed_us = (unsigned long long)delta.tv_sec * USEC_PER_SEC +
+                                    (unsigned long long)delta.tv_nsec / 1000ULL;
 
     if (elapsed_us >= DARWIN_REENUMERATE_TIMEOUT_US) {
       usbi_err (ctx, "darwin/reenumerate_device: timeout waiting for reenumerate");


### PR DESCRIPTION
Fix time calculation to handle negative nanosecond deltas for device re-enumerate

In the original code, the calculation of elapsed time could produce incorrect results when the nanosecond difference (delta_nsec) was negative. This situation occurs when the current time's nanoseconds are less than the start time's nanoseconds. 

The fix introduces a check for negative delta_nsec. If delta_nsec is negative, we adjust delta_sec by decrementing it by 1 and adding NSEC_PER_SEC to delta_nsec to ensure the elapsed time is calculated correctly.

This change ensures accurate time measurement in all scenarios.