### PR TITLE
core: Return an internal handle for deeper integration

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -422,6 +422,7 @@ if (cfg != desired)
   * - libusb_get_max_packet_size()
   * - libusb_get_next_timeout()
   * - libusb_get_parent()
+  * - libusb_get_platform_device_id()
   * - libusb_get_pollfds()
   * - libusb_get_port_number()
   * - libusb_get_port_numbers()
@@ -1004,6 +1005,29 @@ libusb_device * LIBUSB_CALL libusb_get_parent(libusb_device *dev)
 uint8_t API_EXPORTED libusb_get_device_address(libusb_device *dev)
 {
 	return dev->device_address;
+}
+
+/** \ingroup libusb_dev
+ * Get a platform id string of the device on the bus it is connected to.
+ *
+ * Linux:   udev_device_new_from_subsystem_sysname(,"usb",id);
+ * macOS:   IORegistryEntryIDMatching(id);
+ * Windows: CM_Locate_DevNodeA(,id,);
+ *
+ * \param dev a device
+ * \param data pointer to an allocated string that will contain the id
+ *  the function is successful, or NULL on error
+ * \returns 0 on success
+ * \returns another LIBUSB_ERROR code on error
+ */
+int API_EXPORTED libusb_get_platform_device_id(libusb_device *dev, char **data)
+{
+	*data = NULL;
+
+	if (!usbi_backend.get_platform_device_id)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	return usbi_backend.get_platform_device_id(dev, data);
 }
 
 /** \ingroup libusb_dev

--- a/libusb/libusb-1.0.def
+++ b/libusb/libusb-1.0.def
@@ -98,6 +98,8 @@ EXPORTS
   libusb_get_parent@4 = libusb_get_parent
   libusb_get_platform_descriptor
   libusb_get_platform_descriptor@12 = libusb_get_platform_descriptor
+  libusb_get_platform_device_id
+  libusb_get_platform_device_id@8 = libusb_get_platform_device_id
   libusb_get_pollfds
   libusb_get_pollfds@4 = libusb_get_pollfds
   libusb_get_port_number

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1750,6 +1750,7 @@ LIBUSB_DEPRECATED_FOR(libusb_get_port_numbers)
 int LIBUSB_CALL libusb_get_port_path(libusb_context *ctx, libusb_device *dev, uint8_t *path, uint8_t path_length);
 libusb_device * LIBUSB_CALL libusb_get_parent(libusb_device *dev);
 uint8_t LIBUSB_CALL libusb_get_device_address(libusb_device *dev);
+int LIBUSB_CALL libusb_get_platform_device_id(libusb_device *dev, char **data);
 int LIBUSB_CALL libusb_get_device_speed(libusb_device *dev);
 int LIBUSB_CALL libusb_get_max_packet_size(libusb_device *dev,
 	unsigned char endpoint);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1163,6 +1163,15 @@ struct usbi_os_backend {
 	int (*get_config_descriptor_by_value)(struct libusb_device *device,
 		uint8_t bConfigurationValue, void **buffer);
 
+	/* Get the platform specific string handle. Useful for doing hardware queries
+	 * outside of libusb.
+	 *
+	 * Return:
+	 * - 0 on success
+	 * - LIBUSB_ERROR code on failure.
+	 */
+	int (*get_platform_device_id)(struct libusb_device *device, char **data);
+
 	/* Get the bConfigurationValue for the active configuration for a device.
 	 * Optional. This should only be implemented if you can retrieve it from
 	 * cache (don't generate I/O).

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1027,6 +1027,41 @@ static int darwin_get_config_descriptor(struct libusb_device *dev, uint8_t confi
   return (int) len;
 }
 
+static int darwin_get_platform_device_id (libusb_device *dev, char **data) {
+  struct darwin_cached_device *priv = DARWIN_CACHED_DEVICE(dev);
+  io_iterator_t deviceIterator;
+  io_service_t service;
+  kern_return_t kresult;
+  uint64_t entry_id;
+  int ret;
+
+  kresult = usb_setup_device_iterator (&deviceIterator, priv->location);
+  if (kresult != kIOReturnSuccess)
+    return darwin_to_libusb (kresult);
+
+  service = IOIteratorNext (deviceIterator);
+  if (service == IO_OBJECT_NULL) {
+    IOObjectRelease (deviceIterator);
+    return LIBUSB_ERROR_NOT_FOUND;
+  }
+
+  kresult = IORegistryEntryGetRegistryEntryID(service, &entry_id);
+
+  IOObjectRelease (service);
+  IOObjectRelease (deviceIterator);
+
+  if (kresult != kIOReturnSuccess)
+    return darwin_to_libusb (kresult);
+
+  ret = asprintf(data, "%llu", entry_id);
+  if (ret < 0) {
+	*data = NULL;
+	return LIBUSB_ERROR_OTHER;
+  }
+
+  return LIBUSB_SUCCESS;
+}
+
 /* check whether the os has configured the device */
 static enum libusb_error darwin_check_configuration (struct libusb_context *ctx, struct darwin_cached_device *dev) {
   usb_device_t darwin_device = dev->device;
@@ -2934,6 +2969,7 @@ const struct usbi_os_backend usbi_backend = {
         .get_active_config_descriptor = darwin_get_active_config_descriptor,
         .get_config_descriptor = darwin_get_config_descriptor,
         .get_config_descriptor_by_value = NULL,
+        .get_platform_device_id = darwin_get_platform_device_id,
         .get_configuration = darwin_get_configuration,
         .set_configuration = darwin_set_configuration,
 

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -194,6 +194,7 @@ const struct usbi_os_backend usbi_backend = {
 	/*.get_active_config_descriptor =*/ haiku_get_active_config_descriptor,
 	/*.get_config_descriptor =*/ haiku_get_config_descriptor,
 	/*.get_config_descriptor_by_value =*/ NULL,
+	/*.get_platform_device_id =*/ NULL,
 
 	/*.get_configuration =*/ NULL,
 	/*.set_configuration =*/ haiku_set_configuration,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -794,6 +794,18 @@ static int op_get_config_descriptor_by_value(struct libusb_device *dev,
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
+static int op_get_platform_device_id(libusb_device *dev, char **data)
+{
+	struct linux_device_priv *priv = usbi_get_device_priv(dev);
+
+	if (!priv->sysfs_dir)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	*data = strdup(priv->sysfs_dir);
+
+	return LIBUSB_SUCCESS;
+}
+
 static int op_get_active_config_descriptor(struct libusb_device *dev,
 	void *buffer, size_t len)
 {
@@ -2791,6 +2803,7 @@ const struct usbi_os_backend usbi_backend = {
 	.get_active_config_descriptor = op_get_active_config_descriptor,
 	.get_config_descriptor = op_get_config_descriptor,
 	.get_config_descriptor_by_value = op_get_config_descriptor_by_value,
+	.get_platform_device_id = op_get_platform_device_id,
 
 	.wrap_sys_device = op_wrap_sys_device,
 	.open = op_open,

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -666,6 +666,12 @@ static int windows_get_config_descriptor_by_value(struct libusb_device *dev,
 	return priv->backend->get_config_descriptor_by_value(dev, bConfigurationValue, buffer);
 }
 
+static int windows_get_platform_device_id(struct libusb_device *dev, char **data)
+{
+	struct windows_context_priv *priv = usbi_get_context_priv(DEVICE_CTX(dev));
+	return priv->backend->get_platform_device_id(dev, data);
+}
+
 static int windows_get_configuration(struct libusb_device_handle *dev_handle, uint8_t *config)
 {
 	struct windows_context_priv *priv = usbi_get_context_priv(HANDLE_CTX(dev_handle));
@@ -896,6 +902,7 @@ const struct usbi_os_backend usbi_backend = {
 	windows_get_active_config_descriptor,
 	windows_get_config_descriptor,
 	windows_get_config_descriptor_by_value,
+	windows_get_platform_device_id,
 	windows_get_configuration,
 	windows_set_configuration,
 	windows_claim_interface,

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -328,6 +328,7 @@ struct windows_backend {
 		uint8_t config_index, void *buffer, size_t len);
 	int (*get_config_descriptor_by_value)(struct libusb_device *device,
 		uint8_t bConfigurationValue, void **buffer);
+	int (*get_platform_device_id)(struct libusb_device *dev, char **data);
 	int (*get_configuration)(struct libusb_device_handle *dev_handle, uint8_t *config);
 	int (*set_configuration)(struct libusb_device_handle *dev_handle, uint8_t config);
 	int (*claim_interface)(struct libusb_device_handle *dev_handle, uint8_t interface_number);

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -435,6 +435,11 @@ static void usbdk_close(struct libusb_device_handle *dev_handle)
 	priv->redirector_handle = NULL;
 }
 
+static int usbdk_get_platform_device_id(struct libusb_device *dev, char **data)
+{
+	return LIBUSB_ERROR_NOT_SUPPORTED;
+}
+
 static int usbdk_get_configuration(struct libusb_device_handle *dev_handle, uint8_t *config)
 {
 	struct usbdk_device_priv *priv = usbi_get_device_priv(dev_handle->dev);
@@ -709,6 +714,7 @@ const struct windows_backend usbdk_backend = {
 	usbdk_get_active_config_descriptor,
 	usbdk_get_config_descriptor,
 	usbdk_get_config_descriptor_by_value,
+	usbdk_get_platform_device_id,
 	usbdk_get_configuration,
 	usbdk_set_configuration,
 	usbdk_claim_interface,

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2072,6 +2072,15 @@ static int winusb_get_config_descriptor_by_value(struct libusb_device *dev, uint
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
+static int winusb_get_platform_device_id(struct libusb_device *dev, char **data)
+{
+	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
+
+	*data = strdup(priv->dev_id);
+
+	return LIBUSB_SUCCESS;
+}
+
 /*
  * return the cached copy of the active config descriptor
  */
@@ -2299,6 +2308,7 @@ const struct windows_backend winusb_backend = {
 	winusb_get_active_config_descriptor,
 	winusb_get_config_descriptor,
 	winusb_get_config_descriptor_by_value,
+	winusb_get_platform_device_id,
 	winusb_get_configuration,
 	winusb_set_configuration,
 	winusb_claim_interface,


### PR DESCRIPTION
This is an updated version of https://github.com/libusb/libusb/pull/537. I got pointed to this from https://github.com/libusb/libusb/issues/1575, this more fitting with the existing libusb ecosystem, which the original issue wasn't. 

Also two side notes
Most of the code and comments/docs are rewritten so i was contemplating re-authoring it even thought I did just edit the original pull request.

Second. I didn't really find this out online, but is the USB bus and port numbering is OS independent as its part of the spec? Is this true, if so it could be possible to use this to accomplish this task too.