### PR TITLE
Do not enumerate devices not initialized by udev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,14 +209,10 @@ linux)
 		AC_CHECK_HEADER([libudev.h], [], [AC_MSG_ERROR([udev support requested but libudev header not installed])])
 		AC_CHECK_LIB([udev], [udev_new], [], [AC_MSG_ERROR([udev support requested but libudev not installed])])
 
-		# We can build umockdev tests (if available)
+		# We can build umockdev tests (if available); need 0.17.7 because hotplug was racy before
 		m4_ifdef([PKG_PROG_PKG_CONFIG],[
 			PKG_PROG_PKG_CONFIG
-		   	PKG_CHECK_MODULES([UMOCKDEV], [umockdev-1.0 >= 0.16.0], [ac_have_umockdev=yes], [ac_have_umockdev=no])
-		   	PKG_CHECK_MODULES([UMOCKDEV_HOTPLUG], [umockdev-1.0 >= 0.17.7], [ac_umockdev_hotplug=yes], [ac_umockdev_hotplug=no])
-			if test $ac_umockdev_hotplug = yes; then
-			   AC_DEFINE([UMOCKDEV_HOTPLUG], [1], [UMockdev hotplug code is not racy])
-			fi
+			PKG_CHECK_MODULES([UMOCKDEV], [umockdev-1.0 >= 0.17.7], [ac_have_umockdev=yes], [ac_have_umockdev=no])
 		], [])
 	else
 		AC_CHECK_HEADERS([asm/types.h])

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -278,6 +278,11 @@ int linux_udev_scan_devices(struct libusb_context *ctx)
 		return LIBUSB_ERROR_OTHER;
 	}
 
+	/* Only return initialized devices if udev is running. If it is not
+	 * running, devices will never be marked as "initialized".
+	 */
+	if (access("/run/udev/control", F_OK) == 0)
+		udev_enumerate_add_match_is_initialized(enumerator);
 	udev_enumerate_add_match_subsystem(enumerator, "usb");
 	udev_enumerate_add_match_property(enumerator, "DEVTYPE", "usb_device");
 	udev_enumerate_scan_devices(enumerator);

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -267,6 +267,8 @@ int linux_udev_scan_devices(struct libusb_context *ctx)
 	struct udev_enumerate *enumerator;
 	struct udev_list_entry *devices, *entry;
 	struct udev_device *udev_dev;
+	int require_initialized = 0;
+	const char *udev_devpath = NULL;
 	const char *sys_name;
 	int r;
 
@@ -278,11 +280,17 @@ int linux_udev_scan_devices(struct libusb_context *ctx)
 		return LIBUSB_ERROR_OTHER;
 	}
 
-	/* Only return initialized devices if udev is running. If it is not
-	 * running, devices will never be marked as "initialized".
+	/* We should just add udev_enumerate_add_match_is_initialized when
+	 * udev is running. However, e.g. libmtp is buggy and relies on being
+	 * able to enumerate the device from within a udev rule.
 	 */
-	if (access("/run/udev/control", F_OK) == 0)
-		udev_enumerate_add_match_is_initialized(enumerator);
+	if (access("/run/udev/control", F_OK) == 0) {
+		require_initialized = 1;
+
+		/* Check we are running from a udev rule and store DEVPATH */
+		if (getenv("DEVTYPE") && getenv("DRIVER"))
+			udev_devpath = getenv("DEVPATH");
+	}
 	udev_enumerate_add_match_subsystem(enumerator, "usb");
 	udev_enumerate_add_match_property(enumerator, "DEVTYPE", "usb_device");
 	udev_enumerate_scan_devices(enumerator);
@@ -294,6 +302,24 @@ int linux_udev_scan_devices(struct libusb_context *ctx)
 		uint8_t busnum = 0, devaddr = 0;
 
 		udev_dev = udev_device_new_from_syspath(udev_ctx, path);
+
+		if (require_initialized &&
+		    !udev_device_get_is_initialized(udev_dev)) {
+			/* The device should not be reported as it is not
+			 * initialized by udev.
+			 * However, as a work around, let the API user discover
+			 * the device if we seem to be running from within a
+			 * udev rule and this is the device from the
+			 * environment.
+			 */
+			if (udev_devpath && strcmp(udev_devpath, path) == 0)
+				usbi_warn(ctx,
+					  "Allowing device %s to be discovered from within udev rule. "
+					  "Please fix the application to disable device discovery and use libusb_wrap_sys_device",
+					  udev_devpath);
+			else
+				continue;
+		}
 
 		r = udev_device_info(ctx, 0, udev_dev, &busnum, &devaddr, &sys_name);
 		if (r) {

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -971,7 +971,6 @@ hotplug_count_arrival_cb(libusb_context *ctx,
 	return 0;
 }
 
-#ifdef UMOCKDEV_HOTPLUG
 static int LIBUSB_CALL
 hotplug_count_removal_cb(libusb_context *ctx,
                          libusb_device  *device,
@@ -987,7 +986,6 @@ hotplug_count_removal_cb(libusb_context *ctx,
 
 	return 0;
 }
-#endif
 
 static void
 test_hotplug_enumerate(UMockdevTestbedFixture * fixture, UNUSED_DATA)
@@ -1041,7 +1039,6 @@ test_hotplug_enumerate(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 static void
 test_hotplug_add_remove(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 {
-#ifdef UMOCKDEV_HOTPLUG
 	libusb_device **devs = NULL;
 	libusb_hotplug_callback_handle handle_add;
 	libusb_hotplug_callback_handle handle_remove;
@@ -1111,10 +1108,6 @@ test_hotplug_add_remove(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 
 	libusb_hotplug_deregister_callback(fixture->ctx, handle_add);
 	libusb_hotplug_deregister_callback(fixture->ctx, handle_remove);
-#else
-	(void) fixture;
-	g_test_skip("UMockdev is too old to test hotplug");
-#endif
 }
 
 int


### PR DESCRIPTION
Doing that can cause weird issues with permissions. One example is fprintd trying to open the fingerprint reader but selinux has not yet been tagged and it is not allowed to do so. Other scenarios can also be possible as it is not uncommon to change the user/group of devices using udev.

This should fix it, unfortunately the umockdev testing is not really optimal …

EDIT: Downstream bug report is https://bugzilla.redhat.com/show_bug.cgi?id=2346771