### PR TITLE
xusb: Fix error reporting on interface claim

### DIFF
--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -982,25 +982,23 @@ static int test_device(uint16_t vid, uint16_t pid)
 	libusb_set_auto_detach_kernel_driver(handle, 1);
 	for (iface = 0; iface < nb_ifaces; iface++)
 	{
-		int ret;
-
 		printf("\nKernel driver attached for interface %d: ", iface);
-		ret = libusb_kernel_driver_active(handle, iface);
-		if (ret == 0)
+		r = libusb_kernel_driver_active(handle, iface);
+		if (r == 0)
 			printf("none\n");
-		else if (ret == 1)
+		else if (r == 1)
 			printf("yes\n");
-		else if (ret == LIBUSB_ERROR_NOT_SUPPORTED)
+		else if (r == LIBUSB_ERROR_NOT_SUPPORTED)
 			printf("(not supported)\n");
 		else
-			perr("\n   Failed (error %d) %s\n", ret,
-			     libusb_strerror((enum libusb_error) ret));
+			perr("\n   Failed (error %d) %s\n", r,
+			     libusb_strerror((enum libusb_error) r));
 
 		printf("\nClaiming interface %d...\n", iface);
 		r = libusb_claim_interface(handle, iface);
 		if (r != LIBUSB_SUCCESS) {
-			perr("   Failed (error %d) %s\n", ret,
-			     libusb_strerror((enum libusb_error) ret));
+			perr("   Failed (error %d) %s\n", r,
+			     libusb_strerror((enum libusb_error) r));
 		}
 	}
 


### PR DESCRIPTION
There was a mixup of "ret" and "r", so use "r" consistently as in the rest of the function.