### PR TITLE
ss_usb_cap: rename wU2devExitLat from bU2devExitLat

### DIFF
--- a/android/examples/unrooted_android.c
+++ b/android/examples/unrooted_android.c
@@ -128,7 +128,7 @@ static void print_ss_usb_cap(struct libusb_ss_usb_device_capability_descriptor *
     LOGD("      wSpeedSupported:       %u\n", ss_usb_cap->wSpeedSupported);
     LOGD("      bFunctionalitySupport: %u\n", ss_usb_cap->bFunctionalitySupport);
     LOGD("      bU1devExitLat:         %u\n", ss_usb_cap->bU1DevExitLat);
-    LOGD("      bU2devExitLat:         %u\n", ss_usb_cap->bU2DevExitLat);
+    LOGD("      wU2devExitLat:         %u\n", ss_usb_cap->wU2DevExitLat);
 }
 
 static void print_bos(libusb_device_handle *handle)

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -92,7 +92,7 @@ static void print_ss_usb_cap(struct libusb_ss_usb_device_capability_descriptor *
 	printf("      wSpeedSupported:       %u\n", ss_usb_cap->wSpeedSupported);
 	printf("      bFunctionalitySupport: %u\n", ss_usb_cap->bFunctionalitySupport);
 	printf("      bU1devExitLat:         %u\n", ss_usb_cap->bU1DevExitLat);
-	printf("      bU2devExitLat:         %u\n", ss_usb_cap->bU2DevExitLat);
+	printf("      wU2devExitLat:         %u\n", ss_usb_cap->wU2DevExitLat);
 }
 
 static void print_bos(libusb_device_handle *handle)

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -999,7 +999,7 @@ int API_EXPORTED libusb_get_ss_usb_device_capability_descriptor(
 	_ss_usb_device_cap->wSpeedSupported = ReadLittleEndian16(&dev_cap->dev_capability_data[1]);
 	_ss_usb_device_cap->bFunctionalitySupport = dev_cap->dev_capability_data[3];
 	_ss_usb_device_cap->bU1DevExitLat = dev_cap->dev_capability_data[4];
-	_ss_usb_device_cap->bU2DevExitLat = ReadLittleEndian16(&dev_cap->dev_capability_data[5]);
+	_ss_usb_device_cap->wU2DevExitLat = ReadLittleEndian16(&dev_cap->dev_capability_data[5]);
 
 	*ss_usb_device_cap = _ss_usb_device_cap;
 	return LIBUSB_SUCCESS;

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "libusbi.h"
+// #include "libusbi.h"
 
 /**
  * @defgroup libusb_hotplug Device hotplug event notification

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -984,7 +984,7 @@ struct libusb_ss_usb_device_capability_descriptor {
 	uint8_t  bU1DevExitLat;
 
 	/** U2 Device Exit Latency. */
-	uint16_t bU2DevExitLat;
+	uint16_t wU2DevExitLat;
 };
 
 /** \ingroup libusb_desc


### PR DESCRIPTION
According to the naming convention of libusb, a 2 byte member shoud be "w" prefix instead of "b"