### PR TITLE
windows: Remove winsock include from libusb.h

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -65,9 +65,6 @@ typedef SSIZE_T ssize_t;
 #if defined(interface)
 #undef interface
 #endif
-#if !defined(__CYGWIN__)
-#include <winsock.h>
-#endif
 #endif /* _WIN32 || __CYGWIN__ */
 
 #if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))


### PR DESCRIPTION
From looking up commit 0ded9c1 , commit eea7ebe , commit 2442719 it seems winsock was introduced only for WinCE and for WDK, which we don't support any longer.

References #1509