### PR TITLE
darwin I/O-less enumeration

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1209,10 +1209,10 @@ static IOReturn darwin_request_descriptor (usb_device_t device, UInt8 desc, UInt
   return (*device)->DeviceRequestTO (device, &req);
 }
 
-/* device is passed explicitly because this is called from
+/* device and service are passed explicitly because this is called from
    darwin_get_cached_device with darwin_cached_devices_mutex held, before the
-   pending replacement (if any) has been adopted into dev->device */
-static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device) {
+   pending replacement (if any) has been adopted into dev->device and dev->service */
+static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device, io_service_t service) {
   int retries = 1;
   long delay = 30000; /* microseconds */
   int unsuspended = 0, try_unsuspend = 1, try_reconfigure = 1;
@@ -1233,10 +1233,10 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     IOUSBDeviceDescriptor *desc = &dev->dev_descriptor;
     UInt16 bcdDevice, bcdUSB;
 
-    if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
+    if (!get_ioregistry_value_number (service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
 
-    if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
+    if (!get_ioregistry_value_number (service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
     usbi_dbg (ctx, "synthesizing device descriptor from cached OS values");
@@ -1529,7 +1529,7 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
     IOObjectRetain (service);
 
     /* cache the device descriptor */
-    ret = darwin_cache_device_descriptor(ctx, new_device, device);
+    ret = darwin_cache_device_descriptor(ctx, new_device, device, service);
     if (ret)
       break;
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1227,12 +1227,47 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
   (*device)->GetDeviceProduct (device, &idProduct);
   (*device)->GetDeviceVendor (device, &idVendor);
 
+  /* Try synthesize a device descriptor from OS cached values.
+     If anything fails, fall back to requesting descriptor from device. */
+  do {
+    IOUSBDeviceDescriptor *desc = &dev->dev_descriptor;
+    UInt16 bcdDevice, bcdUSB;
+
+    if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
+      break;
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB); // TODO: verify on BE
+
+    if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
+      break;
+
+    desc->bDeviceClass = bDeviceClass;
+    (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
+    (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);
+
+    desc->idVendor = libusb_cpu_to_le16(idVendor); // TODO: verify on BE
+    desc->idProduct = libusb_cpu_to_le16(idProduct);
+    (*device)->GetDeviceReleaseNumber (device, &bcdDevice);
+    desc->bcdDevice = libusb_cpu_to_le16(bcdDevice);
+
+    (*device)->USBGetManufacturerStringIndex (device, &desc->iManufacturer);
+    (*device)->USBGetProductStringIndex (device, &desc->iProduct);
+    (*device)->USBGetSerialNumberStringIndex (device, &desc->iSerialNumber);
+    (*device)->GetNumberOfConfigurations (device, &desc->bNumConfigurations);
+
+    // if needed do validity checks here (and reset descriptor on failure?)
+
+    desc->bDescriptorType = LIBUSB_DT_DEVICE;
+    desc->bLength = LIBUSB_DT_DEVICE_SIZE;
+    goto done_desc;
+  } while (0);
+
   /* According to Apple's documentation the device must be open for DeviceRequest but we may not be able to open some
    * devices and Apple's USB Prober doesn't bother to open the device before issuing a descriptor request.  Still,
    * to follow the spec as closely as possible, try opening the device */
   is_open = ((*device)->USBDeviceOpenSeize(device) == kIOReturnSuccess);
 
   do {
+    usbi_dbg (ctx, "requesting device descriptor from device");
     /**** retrieve device descriptor ****/
     ret = darwin_request_descriptor (device, kUSBDeviceDesc, 0, &dev->dev_descriptor, sizeof(dev->dev_descriptor));
 
@@ -1324,6 +1359,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     return LIBUSB_ERROR_NO_DEVICE;
   }
 
+done_desc:
   usbi_dbg (ctx, "cached device descriptor:");
   usbi_dbg (ctx, "  bDescriptorType:    0x%02x", dev->dev_descriptor.bDescriptorType);
   usbi_dbg (ctx, "  bcdUSB:             0x%04x", libusb_le16_to_cpu (dev->dev_descriptor.bcdUSB));

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1235,7 +1235,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
-    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB); // TODO: verify on BE
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
@@ -1244,7 +1244,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
     (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);
 
-    desc->idVendor = libusb_cpu_to_le16(idVendor); // TODO: verify on BE
+    desc->idVendor = libusb_cpu_to_le16(idVendor);
     desc->idProduct = libusb_cpu_to_le16(idProduct);
     (*device)->GetDeviceReleaseNumber (device, &bcdDevice);
     desc->bcdDevice = libusb_cpu_to_le16(bcdDevice);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1239,6 +1239,8 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
+    usbi_dbg (ctx, "synthesizing device descriptor from cached OS values");
+
     desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
     desc->bDeviceClass = bDeviceClass;
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
@@ -1254,8 +1256,6 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     (*device)->USBGetSerialNumberStringIndex (device, &desc->iSerialNumber);
     (*device)->GetNumberOfConfigurations (device, &desc->bNumConfigurations);
 
-    // if needed do validity checks here (and reset descriptor on failure?)
-
     desc->bDescriptorType = LIBUSB_DT_DEVICE;
     desc->bLength = LIBUSB_DT_DEVICE_SIZE;
     goto done_desc;
@@ -1267,7 +1267,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
   is_open = ((*device)->USBDeviceOpenSeize(device) == kIOReturnSuccess);
 
   do {
-    usbi_dbg (ctx, "requesting device descriptor from device");
+    usbi_info (ctx, "requesting device descriptor from device");
     /**** retrieve device descriptor ****/
     ret = darwin_request_descriptor (device, kUSBDeviceDesc, 0, &dev->dev_descriptor, sizeof(dev->dev_descriptor));
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1235,11 +1235,11 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
-    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
     desc->bDeviceClass = bDeviceClass;
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
     (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1435,11 +1435,11 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
-    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
     desc->bDeviceClass = bDeviceClass;
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
     (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1409,10 +1409,10 @@ static IOReturn darwin_request_descriptor (usb_device_t device, UInt8 desc, UInt
   return (*device)->DeviceRequestTO (device, &req);
 }
 
-/* device is passed explicitly because this is called from
+/* device and service are passed explicitly because this is called from
    darwin_get_cached_device with darwin_cached_devices_mutex held, before the
-   pending replacement (if any) has been adopted into dev->device */
-static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device) {
+   pending replacement (if any) has been adopted into dev->device and dev->service */
+static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device, io_service_t service) {
   int retries = 1;
   long delay = 30000; /* microseconds */
   int unsuspended = 0, try_unsuspend = 1, try_reconfigure = 1;
@@ -1433,10 +1433,10 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     IOUSBDeviceDescriptor *desc = &dev->dev_descriptor;
     UInt16 bcdDevice, bcdUSB;
 
-    if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
+    if (!get_ioregistry_value_number (service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
 
-    if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
+    if (!get_ioregistry_value_number (service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
     usbi_dbg (ctx, "synthesizing device descriptor from cached OS values");
@@ -1736,7 +1736,7 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
     IOObjectRetain (service);
 
     /* cache the device descriptor */
-    ret = darwin_cache_device_descriptor(ctx, new_device, device);
+    ret = darwin_cache_device_descriptor(ctx, new_device, device, service);
     if (ret)
       break;
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1439,6 +1439,8 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
 
+    usbi_dbg (ctx, "synthesizing device descriptor from cached OS values");
+
     desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
     desc->bDeviceClass = bDeviceClass;
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
@@ -1454,8 +1456,6 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     (*device)->USBGetSerialNumberStringIndex (device, &desc->iSerialNumber);
     (*device)->GetNumberOfConfigurations (device, &desc->bNumConfigurations);
 
-    // if needed do validity checks here (and reset descriptor on failure?)
-
     desc->bDescriptorType = LIBUSB_DT_DEVICE;
     desc->bLength = LIBUSB_DT_DEVICE_SIZE;
     goto done_desc;
@@ -1467,7 +1467,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
   is_open = ((*device)->USBDeviceOpenSeize(device) == kIOReturnSuccess);
 
   do {
-    usbi_dbg (ctx, "requesting device descriptor from device");
+    usbi_info (ctx, "requesting device descriptor from device");
     /**** retrieve device descriptor ****/
     ret = darwin_request_descriptor (device, kUSBDeviceDesc, 0, &dev->dev_descriptor, sizeof(dev->dev_descriptor));
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1427,12 +1427,47 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
   (*device)->GetDeviceProduct (device, &idProduct);
   (*device)->GetDeviceVendor (device, &idVendor);
 
+  /* Try synthesize a device descriptor from OS cached values.
+     If anything fails, fall back to requesting descriptor from device. */
+  do {
+    IOUSBDeviceDescriptor *desc = &dev->dev_descriptor;
+    UInt16 bcdDevice, bcdUSB;
+
+    if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
+      break;
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB); // TODO: verify on BE
+
+    if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
+      break;
+
+    desc->bDeviceClass = bDeviceClass;
+    (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
+    (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);
+
+    desc->idVendor = libusb_cpu_to_le16(idVendor); // TODO: verify on BE
+    desc->idProduct = libusb_cpu_to_le16(idProduct);
+    (*device)->GetDeviceReleaseNumber (device, &bcdDevice);
+    desc->bcdDevice = libusb_cpu_to_le16(bcdDevice);
+
+    (*device)->USBGetManufacturerStringIndex (device, &desc->iManufacturer);
+    (*device)->USBGetProductStringIndex (device, &desc->iProduct);
+    (*device)->USBGetSerialNumberStringIndex (device, &desc->iSerialNumber);
+    (*device)->GetNumberOfConfigurations (device, &desc->bNumConfigurations);
+
+    // if needed do validity checks here (and reset descriptor on failure?)
+
+    desc->bDescriptorType = LIBUSB_DT_DEVICE;
+    desc->bLength = LIBUSB_DT_DEVICE_SIZE;
+    goto done_desc;
+  } while (0);
+
   /* According to Apple's documentation the device must be open for DeviceRequest but we may not be able to open some
    * devices and Apple's USB Prober doesn't bother to open the device before issuing a descriptor request.  Still,
    * to follow the spec as closely as possible, try opening the device */
   is_open = ((*device)->USBDeviceOpenSeize(device) == kIOReturnSuccess);
 
   do {
+    usbi_dbg (ctx, "requesting device descriptor from device");
     /**** retrieve device descriptor ****/
     ret = darwin_request_descriptor (device, kUSBDeviceDesc, 0, &dev->dev_descriptor, sizeof(dev->dev_descriptor));
 
@@ -1524,6 +1559,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     return LIBUSB_ERROR_NO_DEVICE;
   }
 
+done_desc:
   usbi_dbg (ctx, "cached device descriptor:");
   usbi_dbg (ctx, "  bDescriptorType:    0x%02x", dev->dev_descriptor.bDescriptorType);
   usbi_dbg (ctx, "  bcdUSB:             0x%04x", libusb_le16_to_cpu (dev->dev_descriptor.bcdUSB));

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1412,7 +1412,7 @@ static IOReturn darwin_request_descriptor (usb_device_t device, UInt8 desc, UInt
 /* device and service are passed explicitly because this is called from
    darwin_get_cached_device with darwin_cached_devices_mutex held, before the
    pending replacement (if any) has been adopted into dev->device and dev->service */
-static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device, io_service_t service) {
+static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device, io_service_t service) REQUIRES(darwin_cached_devices_mutex) {
   int retries = 1;
   long delay = 30000; /* microseconds */
   int unsuspended = 0, try_unsuspend = 1, try_reconfigure = 1;

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1458,6 +1458,10 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
 
     desc->bDescriptorType = LIBUSB_DT_DEVICE;
     desc->bLength = LIBUSB_DT_DEVICE_SIZE;
+
+    if (desc->bNumConfigurations == 0)
+      break;
+
     goto done_desc;
   } while (0);
 

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1435,7 +1435,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bcdUSB"), kCFNumberSInt16Type, &bcdUSB))
       break;
-    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB); // TODO: verify on BE
+    desc->bcdUSB = libusb_cpu_to_le16(bcdUSB);
 
     if (!get_ioregistry_value_number (dev->service, CFSTR("bMaxPacketSize0"), kCFNumberSInt8Type, &desc->bMaxPacketSize0))
       break;
@@ -1444,7 +1444,7 @@ static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *
     (*device)->GetDeviceSubClass (device, &desc->bDeviceSubClass);
     (*device)->GetDeviceProtocol (device, &desc->bDeviceProtocol);
 
-    desc->idVendor = libusb_cpu_to_le16(idVendor); // TODO: verify on BE
+    desc->idVendor = libusb_cpu_to_le16(idVendor);
     desc->idProduct = libusb_cpu_to_le16(idProduct);
     (*device)->GetDeviceReleaseNumber (device, &bcdDevice);
     desc->bcdDevice = libusb_cpu_to_le16(bcdDevice);


### PR DESCRIPTION
This could potentially speed up things. Not tested.

Seems like there is a bcdUSB property from SDK 10.15 and on, defined as kUSBHostDevicePropertyStandardVersion in IOUSBHostFamilyDefinitions.h . Or as kUSBSpecReleaseNumber already from 10.10?
    
