### PR TITLE
CI: Add MSYS2 Clang64 AArch64 workflow

### DIFF
--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -1,0 +1,21 @@
+name: MSYS2 aarch64 clang64 build
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: clangarm64
+          update: true
+          install: git mingw-w64-clang-aarch64-cc mingw-w64-clang-aarch64-autotools
+      - name: CI-Build
+        run: |
+          echo 'Running in MSYS2!'
+          ./bootstrap.sh
+          ./.private/ci-build.sh --no-asan --build-dir build-msys2-clang64-aarch64


### PR DESCRIPTION
Add a new GitHub Actions workflow for arm64 Windows builds.