### PR TITLE
CI: Add clang-tidy to linux workflow 

### DIFF
--- a/.github/workflows/clang-tidy-post.yml
+++ b/.github/workflows/clang-tidy-post.yml
@@ -1,0 +1,21 @@
+name: clang-tidy-post
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.23.1
+        with:
+          lgtm_comment_body: '' # An empty string means it won't post a LGTM message
+          annotations: false
+          max_comments: 10
+          num_comments_as_exitcode: 'false'

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,24 @@
+name: clang-tidy-review
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ZedThree/clang-tidy-review@v0.23.1
+        with:
+          apt_packages: libudev-dev,libumockdev-dev,umockdev,autoconf,automake,libtool,pkg-config,clang,libclang-rt-dev
+          split_workflow: true
+          config_file: '/github/workspace/.clang-tidy'
+          clang_tidy_version: 21
+          build_dir: build-tidy
+          install_commands: >-
+            /github/workspace/bootstrap.sh &&
+            /github/workspace/.private/ci-build.sh
+            --clang-tidy --build-dir build-tidy
+            --no-test -- --disable-udev --srcdir=/github/workspace
+      - uses: ZedThree/clang-tidy-review/upload@v0.23.1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,12 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job
+      # can access it
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: setup prerequisites
         run: |
           sudo apt update
-          sudo apt install -y autoconf automake libtool libudev-dev m4 pkg-config clang llvm
+          sudo apt install -y autoconf automake libtool libudev-dev m4 pkg-config clang llvm clang-tidy wget
 
       - name: bootstrap
         run: ./bootstrap.sh
@@ -80,3 +84,11 @@ jobs:
           ./fuzz_bos_descriptor tests/fuzz/corpus/bos \
             -seed=1 -runs=200 -max_total_time=15 -timeout=5 -rss_limit_mb=1536 -print_final_stats=1
       # --- end sanitizers + fuzzer smoke ---
+
+      - name: clang-tidy
+        continue-on-error: true
+        env:
+          current_sha: ${{ github.sha }}
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          .private/ci-build.sh --clang-tidy --build-dir build-tidy --no-test -- --disable-udev

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -7,6 +7,7 @@ scriptdir=$(dirname $(readlink -f "$0"))
 install=no
 test=yes
 asan=yes
+tidy=no
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -34,6 +35,10 @@ while [ $# -gt 0 ]; do
 		cflags+=" -Werror"
 		shift
 		;;
+	--clang-tidy)
+		tidy=yes
+		shift
+		;;
 	--)
 		shift
 		break;
@@ -53,6 +58,8 @@ if [ -e "${builddir}" ]; then
 	echo "ERROR: directory entry named '${builddir}' already exists" >&2
 	exit 1
 fi
+
+gitdir=$(git rev-parse --show-toplevel)
 
 mkdir "${builddir}"
 cd "${builddir}"
@@ -74,10 +81,51 @@ fi
 
 echo ""
 echo "Configuring ..."
-CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure --enable-examples-build --enable-tests-build "$@"
+if [ "${tidy}" = "yes" ]; then
+	# Clang-Tidy needs to be run with Clang compiler
+	CFLAGS="${cflags}" CXXFLAGS="${cflags}" CC="clang" CXX="clang++" ../configure \
+		--enable-examples-build --enable-tests-build "$@"
+else
+	CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure --enable-examples-build \
+		--enable-tests-build "$@"
+fi
 
 echo ""
 echo "Building ..."
+
+if [ "${tidy}" = "yes" ]; then
+	# $(@D) and $(<F) are GNU Make automatic variables.
+	# $(@D): '$(@D)' is equivalent to '$(dirname $@)'.
+	# $(<F): '$(<F)' is equivalent to '$(notdir $<)'.
+	# example: 'src/foo.c' -> 'builddir/src/foo.c.compdb.json'
+	# More info: https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html
+	# add CFLAGS here as automake escapes them
+	cflags+=" -MJ \$(@D)/\$(<F).compdb.json"
+	make -j4 -k CFLAGS="${cflags}" CXXFLAGS="${cflags}"
+
+	# Create compile_commands.json from all the .compdb.json files.
+	echo "[" > compile_commands.json
+	find . -name "*compdb.json" -exec cat {} \; >> compile_commands.json
+	echo "]" >> compile_commands.json
+
+	built_files=$(find . -name "*.compdb.json" -printf "${gitdir}/%P " | \
+		sed 's/.compdb.json//g')
+	reldr=$(realpath --relative-to="$(pwd)" "${gitdir}")
+
+	# Get llvmorg-21.1.0-rc3 clang-tidy-diff.py script from LLVM project.
+	wget https://raw.githubusercontent.com/llvm/llvm-project/refs/tags/llvmorg-21.1.0-rc3/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+
+	# Use clang-tidy-diff to check only the files that were built.
+	# clang-tidy-diff expects the files to be relative to the git root.
+	# shellcheck disable=SC2086, SC2154
+	git diff -U0 "${current_sha}^..${current_sha}" --dst-prefix="b/${reldr}/" \
+		--src-prefix="a/${reldr}/" -- $built_files | \
+		python3 clang-tidy-diff.py -p1 -warnings-as-errors="*" \
+		-config-file="${gitdir}/.clang-tidy"
+
+	exit $?
+fi
+
 make -j4 -k
 
 if [ "${test}" = "yes" ]; then

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -8,6 +8,7 @@ install=no
 test=yes
 asan=yes
 docs=no
+tidy=no
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -37,6 +38,10 @@ while [ $# -gt 0 ]; do
 		;;
 	--build-docs)
 		docs=yes
+		shift
+		;;
+	--clang-tidy)
+		tidy=yes
 		shift
 		;;
 	--)
@@ -80,13 +85,40 @@ fi
 echo ""
 echo "Configuring ..."
 configure_args=(--enable-examples-build --enable-tests-build)
+configure_env=(CFLAGS="${cflags}" CXXFLAGS="${cflags}")
+
 if [ -n "${TESTCORE_CONFIGURE_FLAG:-}" ]; then
 	configure_args+=("${TESTCORE_CONFIGURE_FLAG}")
 fi
-CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure "${configure_args[@]}" "$@"
+
+if [ "${tidy}" = "yes" ]; then
+	# Clang-Tidy needs to be run with Clang compiler
+	configure_env+=(CC="clang" CXX="clang++")
+fi
+
+env "${configure_env[@]}" ../configure "${configure_args[@]}" "$@"
 
 echo ""
 echo "Building ..."
+
+if [ "${tidy}" = "yes" ]; then
+	# $(@D) and $(<F) are GNU Make automatic variables.
+	# $(@D): '$(@D)' is equivalent to '$(dirname $@)'.
+	# $(<F): '$(<F)' is equivalent to '$(notdir $<)'.
+	# example: 'src/foo.c' -> 'builddir/src/foo.c.compdb.json'
+	# More info: https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html
+	# add CFLAGS here as automake escapes them
+	cflags+=" -MJ \$(@D)/\$(<F).compdb.json"
+	make -j4 -k CFLAGS="${cflags}" CXXFLAGS="${cflags}"
+
+	# Create compile_commands.json from all the .compdb.json files.
+	echo "[" > compile_commands.json
+	find . -name "*compdb.json" -exec cat {} \; >> compile_commands.json
+	sed -i -z "s/,\n$/\n]\n/g" compile_commands.json
+
+	exit 0
+fi
+
 make -j4 -k
 
 if [ "${docs}" = "yes" ]; then


### PR DESCRIPTION
Attempt to add clang-tidy to linux workflow.

The "example bad commit" will be removed, it is just a demo to show it works.

I also made these three pulls as a demo
https://github.com/Mr-Bossman/libusb/pull/3
https://github.com/Mr-Bossman/libusb/pull/2
https://github.com/Mr-Bossman/libusb/pull/1