### PR TITLE
Windows Github actions: specify supported architectures explicitly.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,8 +13,9 @@ jobs:
           - 'Debug'
           - 'Release'
         architecture:
-          - 'x86'
+          - 'Win32'
           - 'x64'
+          - 'ARM64'
 
     runs-on: ${{ matrix.os }}
 
@@ -24,9 +25,7 @@ jobs:
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.3
-        with:
-          msbuild-architecture: ${{ matrix.architecture }}
-
+        
       - name: Build solution
         run: |
-          msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }}
+          msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }}


### PR DESCRIPTION
Windows Github actions use Windows SDK version 10.0.26100.0+ that does
not support 32-bit ARM development any longer. When letting build action
iterates over all possible platforms (i.e. architectures) included in
libusb.sln, builds fail when trying "ARM" (i.e. ARM 32-bit). Moreover
libusb.sln solution does not define "x86" but uses "Win32" instead.

This commit resolves these issues by explicitly iterating over:
Win32, x64, ARM64.

Note: ARM 32-bit is therefore not tested by Windows Gith actions, though
still supported by libusb solution, enabling ARM 32-bit build on machine
with earlier Windows SDK installed.