### PR TITLE
darwin: use threads_posix.h wrapper functions

### DIFF
--- a/libusb/os/threads_posix.h
+++ b/libusb/os/threads_posix.h
@@ -58,6 +58,7 @@ static inline void usbi_mutex_destroy(usbi_mutex_t *mutex)
 	PTHREAD_CHECK(pthread_mutex_destroy(mutex));
 }
 
+#define USBI_COND_INITIALIZER	PTHREAD_COND_INITIALIZER
 typedef pthread_cond_t usbi_cond_t;
 void usbi_cond_init(pthread_cond_t *cond);
 static inline void usbi_cond_wait(usbi_cond_t *cond, usbi_mutex_t *mutex)
@@ -66,6 +67,10 @@ static inline void usbi_cond_wait(usbi_cond_t *cond, usbi_mutex_t *mutex)
 }
 int usbi_cond_timedwait(usbi_cond_t *cond,
 	usbi_mutex_t *mutex, const struct timeval *tv);
+static inline void usbi_cond_signal(usbi_cond_t *cond)
+{
+	PTHREAD_CHECK(pthread_cond_signal(cond));
+}
 static inline void usbi_cond_broadcast(usbi_cond_t *cond)
 {
 	PTHREAD_CHECK(pthread_cond_broadcast(cond));


### PR DESCRIPTION
Instead of using pthread API directly, use the threads_posix.h wrapper functions.

This is handy because those can be tagged with Clang Thread Safety annotations (we can't change system header files).

Introduce usbi_cond_signal as a wrapper for pthread_cond_signal.