### PR TITLE
Clarify return value of usbi_mutex_trylock with named temporary variable

### DIFF
--- a/libusb/os/threads_posix.h
+++ b/libusb/os/threads_posix.h
@@ -51,7 +51,8 @@ static inline void usbi_mutex_unlock(usbi_mutex_t *mutex)
 }
 static inline int usbi_mutex_trylock(usbi_mutex_t *mutex)
 {
-	return pthread_mutex_trylock(mutex) == 0;
+	int mutexIsLocked = pthread_mutex_trylock(mutex) == 0;
+	return mutexIsLocked;
 }
 static inline void usbi_mutex_destroy(usbi_mutex_t *mutex)
 {

--- a/libusb/os/threads_windows.h
+++ b/libusb/os/threads_windows.h
@@ -50,7 +50,8 @@ static inline void usbi_mutex_unlock(usbi_mutex_t *mutex)
 }
 static inline int usbi_mutex_trylock(usbi_mutex_t *mutex)
 {
-	return TryEnterCriticalSection(mutex) != 0;
+    int mutexIsLocked = TryEnterCriticalSection(mutex) != 0;
+    return mutexIsLocked;
 }
 static inline void usbi_mutex_destroy(usbi_mutex_t *mutex)
 {


### PR DESCRIPTION
There mutex wrapping functions are clearly thin wrappers over pthreads, yet the return value of usbi_mutex_trylock() is opposite that of the pthread_mutex_trylock() it wraps. Make the return value meaning clearer by introducing a named variable.