### PR TITLE
linux: change usbi_handle_disconnect signature to take ctx

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2811,9 +2811,8 @@ void API_EXPORTED libusb_free_pollfds(const struct libusb_pollfd **pollfds)
  * device. This function ensures transfers get cancelled appropriately.
  * Callers of this function must hold the events_lock.
  */
-void usbi_handle_disconnect(struct libusb_device_handle *dev_handle)
+void usbi_handle_disconnect(struct libusb_context *ctx, struct libusb_device_handle *dev_handle)
 {
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
 	struct usbi_transfer *cur;
 	struct usbi_transfer *to_cancel;
 

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -814,7 +814,7 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 struct libusb_device *usbi_get_device_by_session_id(struct libusb_context *ctx,
 	unsigned long session_id);
 int usbi_sanitize_device(struct libusb_device *dev);
-void usbi_handle_disconnect(struct libusb_device_handle *dev_handle);
+void usbi_handle_disconnect(struct libusb_context *ctx, struct libusb_device_handle *dev_handle);
 
 int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 	enum libusb_transfer_status status);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2760,7 +2760,7 @@ static int op_handle_events(struct libusb_context *ctx,
 				} while (r == 0);
 			}
 
-			usbi_handle_disconnect(handle);
+			usbi_handle_disconnect(ctx, handle);
 			continue;
 		}
 


### PR DESCRIPTION
Change the signature of private function usbi_handle_disconnect() to take the context as a parameter so that it can eventually use a Clang Thread Safety REQUIRES(ctx->event_lock) decoration.