### PR TITLE
Fix Compilation with Microsoft Visual Studio 2026

### DIFF
--- a/msvc/Configuration.Base.props
+++ b/msvc/Configuration.Base.props
@@ -7,6 +7,7 @@
     <PlatformToolset Condition="$(VisualStudioVersion)=='15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="$(VisualStudioVersion)=='16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="$(VisualStudioVersion)=='17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="$(VisualStudioVersion)=='18.0'">v145</PlatformToolset>
     <!--We may need the equivalent of PlatformToolsetVersion before it's ready, so create it ourself-->
     <LibusbPlatformToolsetVersion>$(PlatformToolset.Substring(1))</LibusbPlatformToolsetVersion>
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
Fix compilation while using MSVC v145 (Included in Visual Studio 2026 Insiders)