### PR TITLE
Addition of missing class codes

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -263,16 +263,13 @@ enum libusb_class_code {
 	LIBUSB_CLASS_PERSONAL_HEALTHCARE = 0x0f,
 
 	/** Audio & Video */
-	 LIBUSB_CLASS_AUDIO_VIDEO = 0x10,
+	LIBUSB_CLASS_AUDIO_VIDEO = 0x10,
 
 	/** Billboard */
 	LIBUSB_CLASS_BILLBOARD = 0x11,
 
 	/** Interface class */
-	LIBUSB_CLASS_INTERFACE = 0x12,
-
-	/** Diagnostic Device */
-	LIBUSB_CLASS_DIAGNOSTIC_DEVICE = 0xdc,
+	LIBUSB_CLASS_TYPE_C_BRIDGE = 0x12,
 
 	/** Bulk display */
 	LIBUSB_CLASS_BULK_DISPLAY_PROTOCOL = 0x13,
@@ -282,6 +279,9 @@ enum libusb_class_code {
 
 	/** I3C */
 	LIBUSB_CLASS_I3C = 0x3c,
+
+	/** Diagnostic Device */
+	LIBUSB_CLASS_DIAGNOSTIC_DEVICE = 0xdc,
 
 	/** Wireless class */
 	LIBUSB_CLASS_WIRELESS = 0xe0,


### PR DESCRIPTION
According to the documents a couple of class codes are missing (reference: [www.usb.org/defined-class-codes](https://github.com/libusb/libusb/compare/url)).

This pull request is related to issue #1716.
