### PR TITLE
Replace remaining strcpy() with snprintf()

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ clang-analyzer-*,\
 -clang-analyzer-deadcode.DeadStores,\
 -clang-analyzer-optin.portability.UnixAPI,\
 -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,\
--clang-analyzer-security.insecureAPI.strcpy,\
 -clang-analyzer-unix.Malloc,\
 misc-*,\
 -misc-no-recursion,\

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2917,7 +2917,7 @@ static void log_str(enum libusb_log_level level, const char *str)
 static void log_v(struct libusb_context *ctx, enum libusb_log_level level,
 	const char *function, const char *format, va_list args)
 {
-	const char *prefix;
+	const char *prefix = NULL;
 	char buf[USBI_MAX_LOG_LEN];
 	int global_debug, header_len, text_len;
 	static int has_debug_header_been_displayed = 0;
@@ -2944,6 +2944,7 @@ static void log_v(struct libusb_context *ctx, enum libusb_log_level level,
 
 	switch (level) {
 	case LIBUSB_LOG_LEVEL_NONE:	/* Impossible, but keeps compiler happy */
+		assert(0);
 		return;
 	case LIBUSB_LOG_LEVEL_ERROR:
 		prefix = "error";
@@ -2982,24 +2983,35 @@ static void log_v(struct libusb_context *ctx, enum libusb_log_level level,
 			"libusb: %s [%s] ", prefix, function);
 	}
 
-	if (header_len < 0 || header_len >= (int)sizeof(buf)) {
-		/* Somehow snprintf() failed to write to the buffer,
+	if ((header_len < 0) || (header_len >= (int)sizeof(buf)))
+	{
+		/* If somehow an error occurred, skip having a header and carry on.
+		 * If the buffer was too small and the write was truncated,
 		 * remove the header so something useful is output. */
 		header_len = 0;
 	}
 
-	text_len = vsnprintf(buf + header_len, sizeof(buf) - (size_t)header_len,
-		format, args);
-	if (text_len < 0 || text_len + header_len >= (int)sizeof(buf)) {
-		/* Truncated log output. On some platforms a -1 return value means
-		 * that the output was truncated. */
-		text_len = (int)sizeof(buf) - header_len;
+	/* starting right after the end of the header, append the rest, but leave room for the terminator. */
+	int space = (int)sizeof(buf) - header_len - (int)strlen(USBI_LOG_LINE_END);
+	text_len = vsnprintf(buf + header_len, space, format, args);
+
+	if (text_len < 0) {
+		/* If somehow an error occurred, give up. */
+		return;
 	}
-	if (header_len + text_len + (int)sizeof(USBI_LOG_LINE_END) >= (int)sizeof(buf)) {
-		/* Need to truncate the text slightly to fit on the terminator. */
-		text_len -= (header_len + text_len + (int)sizeof(USBI_LOG_LINE_END)) - (int)sizeof(buf);
+
+	if (text_len >= space) {
+		/* The space was too small and the write was truncated.
+		 * Add our terminator in the space we left at the end. */
+		(void)snprintf(buf + sizeof(buf) - 1 - strlen(USBI_LOG_LINE_END),
+				 1 + strlen(USBI_LOG_LINE_END),
+				 "%s", USBI_LOG_LINE_END);
+	} else {
+		/* Just append the terminator. */
+		(void)snprintf(buf + header_len + text_len,
+				 sizeof(buf) - (size_t)header_len - (size_t)text_len,
+				 "%s", USBI_LOG_LINE_END);
 	}
-	strcpy(buf + header_len + text_len, USBI_LOG_LINE_END);
 
 	log_str(level, buf);
 

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1856,7 +1856,7 @@ static int detach_kernel_driver_and_claim(struct libusb_device_handle *handle,
 	int r, fd = hpriv->fd;
 
 	dc.interface = interface;
-	strcpy(dc.driver, "usbfs");
+	snprintf(dc.driver, sizeof(dc.driver), "%s", "usbfs");
 	dc.flags = USBFS_DISCONNECT_CLAIM_EXCEPT_DRIVER;
 	r = ioctl(fd, IOCTL_USBFS_DISCONNECT_CLAIM, &dc);
 	if (r == 0)


### PR DESCRIPTION
strcpy() is dangerous because it's too easy to overrun a buffer.  snprintf is safer because the buffer size can be specified. Also, strcpy() is not allowed with -fbounds-safety.