### PR TITLE
Convert various macros to functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ For detailed information about the changes below, please see the git log.
 202?-??-??: v1.0.31
 * Add new APIs libusb_get_config_string() and libusb_get_interface_string() to access configuration and interface strings without opening the device
 * LIBUSB_API_VERSION bump to 0x0100010D
+* Various macros in libusbi.h (a private header) were renamed (and changed to functions), if you use them, consider using the new spelling
 
 2026-05-17: v1.0.30
 * Add hotplug support on Microsoft Windows

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -702,7 +702,7 @@ struct discovered_devs *discovered_devs_append(
 	}
 
 	/* exceeded capacity, need to grow */
-	usbi_dbg(DEVICE_CTX(dev), "need to increase capacity");
+	usbi_dbg(usbi_device_ctx(dev), "need to increase capacity");
 	capacity = discdevs->capacity + DISCOVERED_DEVICES_SIZE_STEP;
 	/* can't use usbi_reallocf here because in failure cases it would
 	 * free the existing discdevs without unreferencing its devices. */
@@ -749,7 +749,7 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 
 void usbi_attach_device(struct libusb_device *dev)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 
 	usbi_atomic_store(&dev->attached, 1);
 
@@ -761,12 +761,12 @@ void usbi_attach_device(struct libusb_device *dev)
 void usbi_connect_device(struct libusb_device *dev)
 {
 	usbi_attach_device(dev);
-	usbi_hotplug_notification(DEVICE_CTX(dev), dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
+	usbi_hotplug_notification(usbi_device_ctx(dev), dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
 }
 
 void usbi_detach_device(struct libusb_device *dev)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 
 	usbi_atomic_store(&dev->attached, 0);
 
@@ -778,7 +778,7 @@ void usbi_detach_device(struct libusb_device *dev)
 void usbi_disconnect_device(struct libusb_device *dev)
 {
 	usbi_detach_device(dev);
-	usbi_hotplug_notification(DEVICE_CTX(dev), dev, LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT);
+	usbi_hotplug_notification(usbi_device_ctx(dev), dev, LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT);
 }
 
 /* Perform some final sanity checks on a newly discovered device. If this
@@ -790,16 +790,16 @@ enum libusb_error usbi_sanitize_device(struct libusb_device *dev)
 
 	if (dev->device_descriptor.bLength != LIBUSB_DT_DEVICE_SIZE ||
 	    dev->device_descriptor.bDescriptorType != LIBUSB_DT_DEVICE) {
-		usbi_err(DEVICE_CTX(dev), "invalid device descriptor");
+		usbi_err(usbi_device_ctx(dev), "invalid device descriptor");
 		return LIBUSB_ERROR_IO;
 	}
 
 	num_configurations = dev->device_descriptor.bNumConfigurations;
 	if (num_configurations > USB_MAXCONFIG) {
-		usbi_err(DEVICE_CTX(dev), "too many configurations");
+		usbi_err(usbi_device_ctx(dev), "too many configurations");
 		return LIBUSB_ERROR_IO;
 	} else if (0 == num_configurations) {
-		usbi_dbg(DEVICE_CTX(dev), "zero configurations, maybe an unauthorized device");
+		usbi_dbg(usbi_device_ctx(dev), "zero configurations, maybe an unauthorized device");
 	}
 
 	return LIBUSB_SUCCESS;
@@ -997,7 +997,7 @@ int API_EXPORTED libusb_get_port_numbers(libusb_device *dev,
 {
 	int depth, i;
 	struct libusb_device *iter;
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 
 	if (port_numbers_len <= 0)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -1126,7 +1126,7 @@ int API_EXPORTED libusb_get_max_packet_size(libusb_device *dev,
 
 	r = libusb_get_active_config_descriptor(dev, &config);
 	if (r < 0) {
-		usbi_err(DEVICE_CTX(dev),
+		usbi_err(usbi_device_ctx(dev),
 			"could not retrieve active config descriptor");
 		return LIBUSB_ERROR_OTHER;
 	}
@@ -1245,7 +1245,7 @@ int API_EXPORTED libusb_get_max_iso_packet_size(libusb_device *dev,
 
 	r = libusb_get_active_config_descriptor(dev, &config);
 	if (r < 0) {
-		usbi_err(DEVICE_CTX(dev),
+		usbi_err(usbi_device_ctx(dev),
 			"could not retrieve active config descriptor");
 		return LIBUSB_ERROR_OTHER;
 	}
@@ -1304,7 +1304,7 @@ int API_EXPORTED libusb_get_max_alt_packet_size(libusb_device *dev,
 
 	r = libusb_get_active_config_descriptor(dev, &config);
 	if (r < 0) {
-		usbi_err(DEVICE_CTX(dev),
+		usbi_err(usbi_device_ctx(dev),
 			"could not retrieve active config descriptor");
 		return LIBUSB_ERROR_OTHER;
 	}
@@ -1359,7 +1359,7 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 		 * Without this, a concurrent search could find a device whose
 		 * refcnt has already reached zero and hit the assert in
 		 * libusb_ref_device(). */
-		struct libusb_context *ctx = DEVICE_CTX(dev);
+		struct libusb_context *ctx = usbi_device_ctx(dev);
 
 		usbi_mutex_lock(&ctx->usb_devs_lock);
 		refcnt = usbi_atomic_dec(&dev->refcnt);
@@ -1375,7 +1375,7 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 	}
 
 	if (refcnt == 0) {
-		usbi_dbg(DEVICE_CTX(dev), "destroy device %d.%d", dev->bus_number, dev->device_address);
+		usbi_dbg(usbi_device_ctx(dev), "destroy device %d.%d", dev->bus_number, dev->device_address);
 
 		libusb_unref_device(dev->parent_dev);
 
@@ -1483,12 +1483,12 @@ int API_EXPORTED libusb_wrap_sys_device(libusb_context *ctx, intptr_t sys_dev,
 int API_EXPORTED libusb_open(libusb_device *dev,
 	libusb_device_handle **dev_handle)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct libusb_device_handle *_dev_handle;
 	size_t priv_size = usbi_backend.device_handle_priv_size;
 	int r;
 
-	usbi_dbg(DEVICE_CTX(dev), "open %d.%d", dev->bus_number, dev->device_address);
+	usbi_dbg(usbi_device_ctx(dev), "open %d.%d", dev->bus_number, dev->device_address);
 
 	if (!usbi_atomic_load(&dev->attached))
 		return LIBUSB_ERROR_NO_DEVICE;
@@ -1503,7 +1503,7 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 
 	r = usbi_backend.open(_dev_handle);
 	if (r < 0) {
-		usbi_dbg(DEVICE_CTX(dev), "open %d.%d returns %d", dev->bus_number, dev->device_address, r);
+		usbi_dbg(usbi_device_ctx(dev), "open %d.%d returns %d", dev->bus_number, dev->device_address, r);
 		libusb_unref_device(dev);
 		usbi_mutex_destroy(&_dev_handle->lock);
 		free(_dev_handle);
@@ -1582,7 +1582,7 @@ static void do_close(struct libusb_context *ctx,
 	/* safe iteration because transfers may be being deleted */
 	for_each_transfer_safe(ctx, itransfer, tmp) {
 		struct libusb_transfer *transfer =
-			USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+			usbi_transfer_to_libusb_transfer(itransfer);
 		uint32_t state_flags;
 
 		if (transfer->dev_handle != dev_handle)
@@ -1645,7 +1645,7 @@ void API_EXPORTED libusb_close(libusb_device_handle *dev_handle)
 
 	if (!dev_handle)
 		return;
-	ctx = HANDLE_CTX(dev_handle);
+	ctx = usbi_handle_ctx(dev_handle);
 	usbi_dbg(ctx, " ");
 
 	handling_events = usbi_handling_events(ctx);
@@ -1729,7 +1729,7 @@ int API_EXPORTED libusb_get_configuration(libusb_device_handle *dev_handle,
 {
 	int r = LIBUSB_ERROR_NOT_SUPPORTED;
 	uint8_t tmp = 0;
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 
 	usbi_dbg(ctx, " ");
 	if (usbi_backend.get_configuration)
@@ -1814,7 +1814,7 @@ int API_EXPORTED libusb_get_configuration(libusb_device_handle *dev_handle,
 int API_EXPORTED libusb_set_configuration(libusb_device_handle *dev_handle,
 	int configuration)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "configuration %d", configuration);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "configuration %d", configuration);
 	if (configuration < -1 || configuration > (int)UINT8_MAX)
 		return LIBUSB_ERROR_INVALID_PARAM;
 	return usbi_backend.set_configuration(dev_handle, configuration);
@@ -1853,7 +1853,7 @@ int API_EXPORTED libusb_claim_interface(libusb_device_handle *dev_handle,
 {
 	int r = 0;
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d", interface_number);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d", interface_number);
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;
 
@@ -1897,7 +1897,7 @@ int API_EXPORTED libusb_release_interface(libusb_device_handle *dev_handle,
 {
 	int r;
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d", interface_number);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d", interface_number);
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;
 
@@ -1940,7 +1940,7 @@ out:
 int API_EXPORTED libusb_set_interface_alt_setting(libusb_device_handle *dev_handle,
 	int interface_number, int alternate_setting) EXCLUDES(dev_handle->lock)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d altsetting %d",
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d altsetting %d",
 		interface_number, alternate_setting);
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -1981,7 +1981,7 @@ int API_EXPORTED libusb_set_interface_alt_setting(libusb_device_handle *dev_hand
 int API_EXPORTED libusb_clear_halt(libusb_device_handle *dev_handle,
 	unsigned char endpoint)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "endpoint 0x%x", endpoint);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "endpoint 0x%x", endpoint);
 	if (!usbi_atomic_load(&dev_handle->dev->attached))
 		return LIBUSB_ERROR_NO_DEVICE;
 
@@ -2009,7 +2009,7 @@ int API_EXPORTED libusb_clear_halt(libusb_device_handle *dev_handle,
  */
 int API_EXPORTED libusb_reset_device(libusb_device_handle *dev_handle)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), " ");
+	usbi_dbg(usbi_handle_ctx(dev_handle), " ");
 	if (!usbi_atomic_load(&dev_handle->dev->attached))
 		return LIBUSB_ERROR_NO_DEVICE;
 
@@ -2043,7 +2043,7 @@ int API_EXPORTED libusb_reset_device(libusb_device_handle *dev_handle)
 int API_EXPORTED libusb_alloc_streams(libusb_device_handle *dev_handle,
 	uint32_t num_streams, unsigned char *endpoints, int num_endpoints)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "streams %u eps %d", (unsigned)num_streams, num_endpoints);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "streams %u eps %d", (unsigned)num_streams, num_endpoints);
 
 	if (!num_streams || !endpoints || num_endpoints <= 0)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -2073,7 +2073,7 @@ int API_EXPORTED libusb_alloc_streams(libusb_device_handle *dev_handle,
 int API_EXPORTED libusb_free_streams(libusb_device_handle *dev_handle,
 	unsigned char *endpoints, int num_endpoints)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "eps %d", num_endpoints);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "eps %d", num_endpoints);
 
 	if (!endpoints || num_endpoints <= 0)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -2162,7 +2162,7 @@ int API_EXPORTED libusb_dev_mem_free(libusb_device_handle *dev_handle,
 int API_EXPORTED libusb_kernel_driver_active(libusb_device_handle *dev_handle,
 	int interface_number)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d", interface_number);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d", interface_number);
 
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -2200,7 +2200,7 @@ int API_EXPORTED libusb_kernel_driver_active(libusb_device_handle *dev_handle,
 int API_EXPORTED libusb_detach_kernel_driver(libusb_device_handle *dev_handle,
 	int interface_number) EXCLUDES(dev_handle->lock)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d", interface_number);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d", interface_number);
 
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -2236,7 +2236,7 @@ int API_EXPORTED libusb_detach_kernel_driver(libusb_device_handle *dev_handle,
 int API_EXPORTED libusb_attach_kernel_driver(libusb_device_handle *dev_handle,
 	int interface_number) EXCLUDES(dev_handle->lock)
 {
-	usbi_dbg(HANDLE_CTX(dev_handle), "interface %d", interface_number);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "interface %d", interface_number);
 
 	if (interface_number < 0 || interface_number >= USB_MAXINTERFACES)
 		return LIBUSB_ERROR_INVALID_PARAM;

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2810,7 +2810,7 @@ void API_EXPORTED libusb_exit(libusb_context *ctx)
 	for_each_device(_ctx, dev) {
 		usbi_warn(_ctx, "device %d.%d still referenced",
 			dev->bus_number, dev->device_address);
-		DEVICE_CTX(dev) = NULL;
+		dev->ctx = NULL;
 	}
 
 	if (!list_empty(&_ctx->open_devs))

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -512,11 +512,11 @@ static int get_active_config_descriptor(struct libusb_device *dev,
 		return r;
 
 	if (r < LIBUSB_DT_CONFIG_SIZE) {
-		usbi_err(DEVICE_CTX(dev), "short config descriptor read %d/%d",
+		usbi_err(usbi_device_ctx(dev), "short config descriptor read %d/%d",
 			 r, LIBUSB_DT_CONFIG_SIZE);
 		return LIBUSB_ERROR_IO;
 	} else if (r != (int)size) {
-		usbi_warn(DEVICE_CTX(dev), "short config descriptor read %d/%d",
+		usbi_warn(usbi_device_ctx(dev), "short config descriptor read %d/%d",
 			 r, (int)size);
 	}
 
@@ -531,11 +531,11 @@ static int get_config_descriptor(struct libusb_device *dev, uint8_t config_idx,
 	if (r < 0)
 		return r;
 	if (r < LIBUSB_DT_CONFIG_SIZE) {
-		usbi_err(DEVICE_CTX(dev), "short config descriptor read %d/%d",
+		usbi_err(usbi_device_ctx(dev), "short config descriptor read %d/%d",
 			 r, LIBUSB_DT_CONFIG_SIZE);
 		return LIBUSB_ERROR_IO;
 	} else if (r != (int)size) {
-		usbi_warn(DEVICE_CTX(dev), "short config descriptor read %d/%d",
+		usbi_warn(usbi_device_ctx(dev), "short config descriptor read %d/%d",
 			 r, (int)size);
 	}
 
@@ -557,7 +557,7 @@ static int get_config_descriptor(struct libusb_device *dev, uint8_t config_idx,
 int API_EXPORTED libusb_get_device_descriptor(libusb_device *dev,
 	struct libusb_device_descriptor *desc)
 {
-	usbi_dbg(DEVICE_CTX(dev), " ");
+	usbi_dbg(usbi_device_ctx(dev), " ");
 	static_assert(sizeof(dev->device_descriptor) == LIBUSB_DT_DEVICE_SIZE,
 		      "struct libusb_device_descriptor is not expected size");
 	*desc = dev->device_descriptor;
@@ -597,7 +597,7 @@ int API_EXPORTED libusb_get_active_config_descriptor(libusb_device *dev,
 
 	r = get_active_config_descriptor(dev, buf, config_len);
 	if (r >= 0)
-		r = raw_desc_to_config(DEVICE_CTX(dev), buf, r, config);
+		r = raw_desc_to_config(usbi_device_ctx(dev), buf, r, config);
 
 	free(buf);
 	return r;
@@ -627,7 +627,7 @@ int API_EXPORTED libusb_get_config_descriptor(libusb_device *dev,
 	uint8_t *buf;
 	int r;
 
-	usbi_dbg(DEVICE_CTX(dev), "index %u", config_index);
+	usbi_dbg(usbi_device_ctx(dev), "index %u", config_index);
 	if (config_index >= dev->device_descriptor.bNumConfigurations)
 		return LIBUSB_ERROR_NOT_FOUND;
 
@@ -642,7 +642,7 @@ int API_EXPORTED libusb_get_config_descriptor(libusb_device *dev,
 
 	r = get_config_descriptor(dev, config_index, buf, config_len);
 	if (r >= 0)
-		r = raw_desc_to_config(DEVICE_CTX(dev), buf, r, config);
+		r = raw_desc_to_config(usbi_device_ctx(dev), buf, r, config);
 
 	free(buf);
 	return r;
@@ -679,10 +679,10 @@ int API_EXPORTED libusb_get_config_descriptor_by_value(libusb_device *dev,
 		if (r < 0)
 			return r;
 
-		return raw_desc_to_config(DEVICE_CTX(dev), (uint8_t *)buf, r, config);
+		return raw_desc_to_config(usbi_device_ctx(dev), (uint8_t *)buf, r, config);
 	}
 
-	usbi_dbg(DEVICE_CTX(dev), "value %u", bConfigurationValue);
+	usbi_dbg(usbi_device_ctx(dev), "value %u", bConfigurationValue);
 	for (idx = 0; idx < dev->device_descriptor.bNumConfigurations; idx++) {
 		union usbi_config_desc_buf _config;
 
@@ -883,7 +883,7 @@ int API_EXPORTED libusb_get_bos_descriptor(libusb_device_handle *dev_handle,
 	uint16_t bos_len;
 	uint8_t *bos_data;
 	int r;
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 
 	/* Read the BOS. This generates 2 requests on the bus,
 	 * one for the header, and one for the full BOS */
@@ -910,7 +910,7 @@ int API_EXPORTED libusb_get_bos_descriptor(libusb_device_handle *dev_handle,
 	if (r >= 0) {
 		if (r != (int)bos_len)
 			usbi_warn(ctx, "short BOS read %d/%u", r, bos_len);
-		r = parse_bos(HANDLE_CTX(dev_handle), bos, bos_data, r);
+		r = parse_bos(usbi_handle_ctx(dev_handle), bos, bos_data, r);
 	} else {
 		usbi_err(ctx, "failed to read BOS (%d)", r);
 	}
@@ -1352,10 +1352,10 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	if (r < 0)
 		return r;
 	else if (r != 4 || str.desc.bLength < 4 || str.desc.bDescriptorType != LIBUSB_DT_STRING) {
-		usbi_warn(HANDLE_CTX(dev_handle), "invalid language ID string descriptor");
+		usbi_warn(usbi_handle_ctx(dev_handle), "invalid language ID string descriptor");
 		return LIBUSB_ERROR_IO;
 	} else if (str.desc.bLength & 1)
-		usbi_warn(HANDLE_CTX(dev_handle), "suspicious bLength %u for language ID string descriptor", str.desc.bLength);
+		usbi_warn(usbi_handle_ctx(dev_handle), "suspicious bLength %u for language ID string descriptor", str.desc.bLength);
 
 	langid = libusb_le16_to_cpu(str.desc.wData[0]);
 	r = libusb_get_string_descriptor(dev_handle, desc_index, langid, str.buf, sizeof(str.buf));
@@ -1364,7 +1364,7 @@ int API_EXPORTED libusb_get_string_descriptor_ascii(libusb_device_handle *dev_ha
 	else if (r < DESC_HEADER_LENGTH || str.desc.bLength > r || str.desc.bDescriptorType != LIBUSB_DT_STRING)
 		return LIBUSB_ERROR_IO;
 	else if ((str.desc.bLength & 1) || str.desc.bLength != r)
-		usbi_warn(HANDLE_CTX(dev_handle), "suspicious bLength %u for string descriptor (read %d)", str.desc.bLength, r);
+		usbi_warn(usbi_handle_ctx(dev_handle), "suspicious bLength %u for string descriptor (read %d)", str.desc.bLength, r);
 
 	/* Stop one byte before the end to leave room for null termination. */
 	int dest_max = length - 1;
@@ -1516,7 +1516,7 @@ int API_EXPORTED libusb_get_interface_association_descriptors(libusb_device *dev
 	if (!iad_array)
 		return LIBUSB_ERROR_INVALID_PARAM;
 
-	usbi_dbg(DEVICE_CTX(dev), "IADs for config index %u", config_index);
+	usbi_dbg(usbi_device_ctx(dev), "IADs for config index %u", config_index);
 	if (config_index >= dev->device_descriptor.bNumConfigurations)
 		return LIBUSB_ERROR_NOT_FOUND;
 
@@ -1531,7 +1531,7 @@ int API_EXPORTED libusb_get_interface_association_descriptors(libusb_device *dev
 
 	r = get_config_descriptor(dev, config_index, buf, config_len);
 	if (r >= 0)
-		r = raw_desc_to_iad_array(DEVICE_CTX(dev), buf, r, iad_array);
+		r = raw_desc_to_iad_array(usbi_device_ctx(dev), buf, r, iad_array);
 
 	free(buf);
 	return r;
@@ -1576,7 +1576,7 @@ int API_EXPORTED libusb_get_active_interface_association_descriptors(libusb_devi
 
 	r = get_active_config_descriptor(dev, buf, config_len);
 	if (r >= 0)
-		r = raw_desc_to_iad_array(DEVICE_CTX(dev), buf, r, iad_array);
+		r = raw_desc_to_iad_array(usbi_device_ctx(dev), buf, r, iad_array);
 	free(buf);
 	return r;
 }

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -257,7 +257,7 @@ static int usbi_hotplug_match_cb(struct libusb_device *dev,
 		return 0;
 	}
 
-	return hotplug_cb->cb(DEVICE_CTX(dev), dev, event, hotplug_cb->user_data);
+	return hotplug_cb->cb(usbi_device_ctx(dev), dev, event, hotplug_cb->user_data);
 }
 
 void usbi_hotplug_notification(struct libusb_context *ctx, struct libusb_device *dev,

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1246,7 +1246,7 @@ void usbi_io_exit(struct libusb_context *ctx)
 
 static void calculate_timeout(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	unsigned int timeout = transfer->timeout;
 
 	if (!timeout) {
@@ -1307,7 +1307,7 @@ struct libusb_transfer * LIBUSB_CALL libusb_alloc_transfer(
 	struct usbi_transfer *itransfer = (struct usbi_transfer *)(ptr + priv_size);
 	itransfer->priv = ptr;
 	usbi_mutex_init(&itransfer->lock);
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	return transfer;
 }
@@ -1334,16 +1334,16 @@ void API_EXPORTED libusb_free_transfer(struct libusb_transfer *transfer)
 	if (!transfer)
 		return;
 
-	usbi_dbg(TRANSFER_CTX(transfer), "transfer %p", (void *) transfer);
+	usbi_dbg(usbi_transfer_ctx(transfer), "transfer %p", (void *) transfer);
 	if (transfer->flags & LIBUSB_TRANSFER_FREE_BUFFER)
 		free(transfer->buffer);
 
-	struct usbi_transfer *itransfer = LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
+	struct usbi_transfer *itransfer = usbi_libusb_transfer_to_usbi_transfer(transfer);
 	usbi_mutex_destroy(&itransfer->lock);
 	if (itransfer->dev)
 		libusb_unref_device(itransfer->dev);
 
-	unsigned char *ptr = USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer);
+	unsigned char *ptr = usbi_transfer_to_transfer_priv(itransfer);
 	assert(ptr == itransfer->priv);
 	free(ptr);
 }
@@ -1372,7 +1372,7 @@ static int arm_timer_for_next_timeout(struct libusb_context *ctx)
 		/* act on first transfer that has not already been handled */
 		if (!(itransfer->timeout_flags & (USBI_TRANSFER_TIMEOUT_HANDLED | USBI_TRANSFER_OS_HANDLES_TIMEOUT))) {
 #ifdef ENABLE_LOGGING
-			struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+			struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 			usbi_dbg(ctx, "next timeout originally %ums", transfer->timeout);
 #endif
 			return usbi_arm_timer(&ctx->timer, cur_ts);
@@ -1398,7 +1398,7 @@ static int add_to_flying_list(struct usbi_transfer *itransfer)
 {
 	struct usbi_transfer *cur;
 	struct timespec *timeout = &itransfer->timeout;
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	int r = 0;
 	int first = 1;
 
@@ -1438,7 +1438,7 @@ out:
 		/* if this transfer has the lowest timeout of all active transfers,
 		 * rearm the timer with this transfer's timeout */
 #ifdef ENABLE_LOGGING
-		struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 		usbi_dbg(ctx, "arm timer for timeout in %ums (first in line)",
 			transfer->timeout);
 #endif
@@ -1461,7 +1461,7 @@ out:
  * NB: flying_transfers_lock MUST be held when calling this. */
 static int remove_from_flying_list(struct usbi_transfer *itransfer)
 {
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	int rearm_timer;
 	int r = 0;
 
@@ -1491,7 +1491,7 @@ static int remove_from_flying_list(struct usbi_transfer *itransfer)
 int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
 {
 	struct usbi_transfer *itransfer =
-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
+		usbi_libusb_transfer_to_usbi_transfer(transfer);
 	struct libusb_context *ctx;
 	int r;
 
@@ -1500,7 +1500,7 @@ int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
 		libusb_unref_device(itransfer->dev);
 	itransfer->dev = libusb_ref_device(transfer->dev_handle->dev);
 
-	ctx = HANDLE_CTX(transfer->dev_handle);
+	ctx = usbi_handle_ctx(transfer->dev_handle);
 	usbi_dbg(ctx, "transfer %p", (void *) transfer);
 
 	/*
@@ -1611,8 +1611,8 @@ int API_EXPORTED libusb_submit_transfer(struct libusb_transfer *transfer)
 int API_EXPORTED libusb_cancel_transfer(struct libusb_transfer *transfer)
 {
 	struct usbi_transfer *itransfer =
-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+		usbi_libusb_transfer_to_usbi_transfer(transfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	int r;
 
 	usbi_dbg(ctx, "transfer %p", (void *) transfer );
@@ -1656,7 +1656,7 @@ void API_EXPORTED libusb_transfer_set_stream_id(
 	struct libusb_transfer *transfer, uint32_t stream_id)
 {
 	struct usbi_transfer *itransfer =
-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
+		usbi_libusb_transfer_to_usbi_transfer(transfer);
 
 	itransfer->stream_id = stream_id;
 }
@@ -1673,7 +1673,7 @@ uint32_t API_EXPORTED libusb_transfer_get_stream_id(
 	struct libusb_transfer *transfer)
 {
 	struct usbi_transfer *itransfer =
-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
+		usbi_libusb_transfer_to_usbi_transfer(transfer);
 
 	return itransfer->stream_id;
 }
@@ -1690,8 +1690,8 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 	enum libusb_transfer_status status)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	uint8_t flags;
 	int r;
 
@@ -1742,7 +1742,7 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
  * will attempt to take the lock. */
 int usbi_handle_transfer_cancellation(struct usbi_transfer *itransfer)
 {
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	uint8_t timed_out;
 
 	usbi_mutex_lock(&ctx->flying_transfers_lock);
@@ -1767,7 +1767,7 @@ void usbi_signal_transfer_completion(struct usbi_transfer *itransfer)
 	struct libusb_device *dev = itransfer->dev;
 
 	if (dev) {
-		struct libusb_context *ctx = DEVICE_CTX(dev);
+		struct libusb_context *ctx = usbi_device_ctx(dev);
 		unsigned int event_flags;
 
 		usbi_mutex_lock(&ctx->event_data_lock);
@@ -2054,7 +2054,7 @@ int API_EXPORTED libusb_wait_for_event(libusb_context *ctx, struct timeval *tv) 
 static void handle_timeout(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	int r;
 
 	itransfer->timeout_flags |= USBI_TRANSFER_TIMEOUT_HANDLED;
@@ -2065,7 +2065,7 @@ static void handle_timeout(struct usbi_transfer *itransfer)
 		usbi_dbg(TRANSFER_CTX(transfer),
 			"transfer already complete");
 	else
-		usbi_warn(TRANSFER_CTX(transfer),
+		usbi_warn(usbi_transfer_ctx(transfer),
 			"async cancel failed %d", r);
 }
 
@@ -2844,7 +2844,7 @@ void usbi_handle_disconnect(struct libusb_context *ctx, struct libusb_device_han
 		to_cancel = NULL;
 		usbi_mutex_lock(&ctx->flying_transfers_lock);
 		for_each_transfer(ctx, cur) {
-			struct libusb_transfer *cur_transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(cur);
+			struct libusb_transfer *cur_transfer = usbi_transfer_to_libusb_transfer(cur);
 			if (cur_transfer->dev_handle == dev_handle) {
 				usbi_mutex_lock(&cur->lock);
 				if (cur->state_flags & USBI_TRANSFER_IN_FLIGHT)
@@ -2861,7 +2861,7 @@ void usbi_handle_disconnect(struct libusb_context *ctx, struct libusb_device_han
 			break;
 
 #ifdef ENABLE_LOGGING
-		struct libusb_transfer *transfer_to_cancel = USBI_TRANSFER_TO_LIBUSB_TRANSFER(to_cancel);
+		struct libusb_transfer *transfer_to_cancel = usbi_transfer_to_libusb_transfer(to_cancel);
 		usbi_dbg(ctx, "cancelling transfer %p from disconnect",
 			 (void *) transfer_to_cancel);
 #endif

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -576,10 +576,10 @@ void usbi_get_real_time(struct timespec *tp);
  * 3. struct libusb_transfer (which includes iso packets) [variable size]
  *
  * You can convert between them with the functions:
- *  TRANSFER_PRIV_TO_USBI_TRANSFER
- *  USBI_TRANSFER_TO_TRANSFER_PRIV
- *  USBI_TRANSFER_TO_LIBUSB_TRANSFER
- *  LIBUSB_TRANSFER_TO_USBI_TRANSFER
+ *  usbi_transfer_priv_to_usbi_transfer
+ *  usbi_transfer_to_transfer_priv
+ *  usbi_transfer_to_libusb_transfer
+ *  usbi_libusb_transfer_to_usbi_transfer
  */
 
 struct usbi_transfer {
@@ -1575,65 +1575,96 @@ int usbi_get_interface_string_index(libusb_device *dev,
 	uint8_t config_value, uint8_t interface_number, uint8_t alt_setting,
 	uint8_t *index_out);
 
-static inline struct usbi_transfer *TRANSFER_PRIV_TO_USBI_TRANSFER(void *transfer_priv)
+static inline struct usbi_transfer *usbi_transfer_priv_to_usbi_transfer(void *transfer_priv)
 {
 	return (struct usbi_transfer *)((unsigned char *)(transfer_priv) + PTR_ALIGN(usbi_backend.transfer_priv_size));
 }
 
-static inline void *USBI_TRANSFER_TO_TRANSFER_PRIV(const struct usbi_transfer *itransfer)
+static inline void *usbi_transfer_to_transfer_priv(const struct usbi_transfer *itransfer)
 {
 	return (void *)((unsigned char *)(itransfer) - PTR_ALIGN(usbi_backend.transfer_priv_size));
 }
 
-static inline struct libusb_transfer *USBI_TRANSFER_TO_LIBUSB_TRANSFER(const struct usbi_transfer *itransfer)
+static inline struct libusb_transfer *usbi_transfer_to_libusb_transfer(const struct usbi_transfer *itransfer)
 {
 	return (struct libusb_transfer *)((unsigned char *)(itransfer) + PTR_ALIGN(sizeof(struct usbi_transfer)));
 }
 
-static inline struct usbi_transfer *LIBUSB_TRANSFER_TO_USBI_TRANSFER(const struct libusb_transfer *transfer)
+static inline struct usbi_transfer *usbi_libusb_transfer_to_usbi_transfer(const struct libusb_transfer *transfer)
 {
 	return (struct usbi_transfer *)((unsigned char *)(transfer) - PTR_ALIGN(sizeof(struct usbi_transfer)));
 }
 
-static inline struct libusb_context *DEVICE_CTX(const struct libusb_device *dev)
+static inline struct libusb_context *usbi_device_ctx(const struct libusb_device *dev)
 {
 	return dev->ctx;
 }
 
-static inline struct libusb_context *HANDLE_CTX(const struct libusb_device_handle *handle)
+static inline struct libusb_context *usbi_handle_ctx(const struct libusb_device_handle *handle)
 {
-	return handle ? DEVICE_CTX(handle->dev) : NULL;
+	return handle ? usbi_device_ctx(handle->dev) : NULL;
 }
 
-static inline struct libusb_context *ITRANSFER_CTX(const struct usbi_transfer *itransfer)
+static inline struct libusb_context *usbi_itransfer_ctx(const struct usbi_transfer *itransfer)
 {
-	return itransfer->dev ? DEVICE_CTX(itransfer->dev) : NULL;
+	return itransfer->dev ? usbi_device_ctx(itransfer->dev) : NULL;
 }
 
-static inline struct libusb_context *TRANSFER_CTX(const struct libusb_transfer *transfer)
+static inline struct libusb_context *usbi_transfer_ctx(const struct libusb_transfer *transfer)
 {
-	return ITRANSFER_CTX(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
+	return usbi_itransfer_ctx(usbi_libusb_transfer_to_usbi_transfer(transfer));
 }
 
-static inline bool IS_EPIN(uint8_t ep)
+static inline bool usbi_is_epin(uint8_t ep)
 {
 	return (0 != (ep & LIBUSB_ENDPOINT_IN));
 }
 
-static inline bool IS_EPOUT(uint8_t ep)
+static inline bool usbi_is_epout(uint8_t ep)
 {
-	return !IS_EPIN(ep);
+	return !usbi_is_epin(ep);
 }
 
-static inline bool IS_XFERIN(const struct libusb_transfer *xfer)
+static inline bool usbi_is_xferin(const struct libusb_transfer *xfer)
 {
 	return (0 != (xfer->endpoint & LIBUSB_ENDPOINT_IN));
 }
 
-static inline bool IS_XFEROUT(const struct libusb_transfer *xfer)
+static inline bool usbi_is_xferout(const struct libusb_transfer *xfer)
 {
-	return !IS_XFERIN(xfer);
+	return !usbi_is_xferin(xfer);
 }
+
+/* DEPRECATED: backwards compatible macros.
+ * Starting with libusb 1.0.31 several macros where changes to proper
+ * functions and renamed to be lowercase. These macros provide the old
+ * spelling for backwards compatibility.
+ */
+#define TRANSFER_PRIV_TO_USBI_TRANSFER(transfer_priv) \
+	usbi_transfer_priv_to_usbi_transfer(transfer_priv)
+#define USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer) \
+	usbi_transfer_to_transfer_priv(itransfer)
+#define USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer) \
+	usbi_transfer_to_libusb_transfer(itransfer)
+#define LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer) \
+	usbi_libusb_transfer_to_usbi_transfer(transfer)
+#define DEVICE_CTX(dev) \
+	usbi_device_ctx(dev)
+#define HANDLE_CTX(handle) \
+	usbi_handle_ctx(handle)
+#define ITRANSFER_CTX(itransfer) \
+	usbi_itransfer_ctx(itransfer)
+#define TRANSFER_CTX(transfer) \
+	usbi_transfer_ctx(transfer)
+#define IS_EPIN(ep) \
+	usbi_is_ep_in(ep)
+#define IS_EPOUT(ep) \
+	usbi_is_ep_out(ep)
+#define IS_XFERIN(xfer) \
+	usbi_is_xfer_in(xfer)
+#define IS_XFEROUT(xfer) \
+	usbi_is_xfer_out(xfer)
+
 
 #define for_each_context(c) \
 	for_each_helper(c, &active_contexts_list, struct libusb_context)

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -349,18 +349,6 @@ void usbi_log(struct libusb_context *ctx, enum libusb_log_level level,
 
 #endif /* ENABLE_LOGGING */
 
-#define DEVICE_CTX(dev)		((dev)->ctx)
-#define HANDLE_CTX(handle)	((handle) ? DEVICE_CTX((handle)->dev) : NULL)
-#define ITRANSFER_CTX(itransfer) \
-	((itransfer)->dev ? DEVICE_CTX((itransfer)->dev) : NULL)
-#define TRANSFER_CTX(transfer) \
-	(ITRANSFER_CTX(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)))
-
-#define IS_EPIN(ep)		(0 != ((ep) & LIBUSB_ENDPOINT_IN))
-#define IS_EPOUT(ep)		(!IS_EPIN(ep))
-#define IS_XFERIN(xfer)		(0 != ((xfer)->endpoint & LIBUSB_ENDPOINT_IN))
-#define IS_XFEROUT(xfer)	(!IS_XFERIN(xfer))
-
 struct libusb_context {
 #if defined(ENABLE_LOGGING) && !defined(ENABLE_DEBUG_LOGGING)
 	enum libusb_log_level debug;
@@ -657,26 +645,6 @@ enum usbi_transfer_timeout_flags {
 	/* The transfer timeout was successfully processed */
 	USBI_TRANSFER_TIMED_OUT = 1U << 2,
 };
-
-#define TRANSFER_PRIV_TO_USBI_TRANSFER(transfer_priv) \
-	((struct usbi_transfer *)			\
-	 ((unsigned char *)(transfer_priv)	\
-	  + PTR_ALIGN(sizeof(*transfer_priv))))
-
-#define USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer) \
-	((unsigned char *)			\
-	 ((unsigned char *)(itransfer)	\
-	  - PTR_ALIGN(usbi_backend.transfer_priv_size)))
-
-#define USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)	\
-	((struct libusb_transfer *)			\
-	 ((unsigned char *)(itransfer)			\
-	  + PTR_ALIGN(sizeof(struct usbi_transfer))))
-
-#define LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)	\
-	((struct usbi_transfer *)			\
-	 ((unsigned char *)(transfer)			\
-	  - PTR_ALIGN(sizeof(struct usbi_transfer))))
 
 #ifdef _MSC_VER
 #pragma pack(push, 1)
@@ -1605,6 +1573,38 @@ int usbi_get_config_string_index(libusb_device *dev,
 int usbi_get_interface_string_index(libusb_device *dev,
 	uint8_t config_value, uint8_t interface_number, uint8_t alt_setting,
 	uint8_t *index_out);
+
+#define TRANSFER_PRIV_TO_USBI_TRANSFER(transfer_priv) \
+	((struct usbi_transfer *)			\
+	 ((unsigned char *)(transfer_priv)	\
+	  + PTR_ALIGN(sizeof(*transfer_priv))))
+
+#define USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer) \
+	((unsigned char *)			\
+	 ((unsigned char *)(itransfer)	\
+	  - PTR_ALIGN(usbi_backend.transfer_priv_size)))
+
+#define USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)	\
+	((struct libusb_transfer *)			\
+	 ((unsigned char *)(itransfer)			\
+	  + PTR_ALIGN(sizeof(struct usbi_transfer))))
+
+#define LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)	\
+	((struct usbi_transfer *)			\
+	 ((unsigned char *)(transfer)			\
+	  - PTR_ALIGN(sizeof(struct usbi_transfer))))
+
+#define DEVICE_CTX(dev)		((dev)->ctx)
+#define HANDLE_CTX(handle)	((handle) ? DEVICE_CTX((handle)->dev) : NULL)
+#define ITRANSFER_CTX(itransfer) \
+	((itransfer)->dev ? DEVICE_CTX((itransfer)->dev) : NULL)
+#define TRANSFER_CTX(transfer) \
+	(ITRANSFER_CTX(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)))
+
+#define IS_EPIN(ep)		(0 != ((ep) & LIBUSB_ENDPOINT_IN))
+#define IS_EPOUT(ep)		(!IS_EPIN(ep))
+#define IS_XFERIN(xfer)		(0 != ((xfer)->endpoint & LIBUSB_ENDPOINT_IN))
+#define IS_XFEROUT(xfer)	(!IS_XFERIN(xfer))
 
 #define for_each_context(c) \
 	for_each_helper(c, &active_contexts_list, struct libusb_context)

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1580,14 +1580,14 @@ int usbi_get_interface_string_index(libusb_device *dev,
 	  + PTR_ALIGN(sizeof(*transfer_priv))))
 
 #define USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer) \
-	((unsigned char *)			\
+	((void *)			\
 	 ((unsigned char *)(itransfer)	\
 	  - PTR_ALIGN(usbi_backend.transfer_priv_size)))
 
 #define USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)	\
 	((struct libusb_transfer *)			\
 	 ((unsigned char *)(itransfer)			\
-	  + PTR_ALIGN(sizeof(struct usbi_transfer))))
+	  + PTR_ALIGN(usbi_backend.transfer_priv_size)))
 
 #define LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)	\
 	((struct usbi_transfer *)			\

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #ifdef HAVE_SYS_TIME_H
@@ -574,7 +575,7 @@ void usbi_get_real_time(struct timespec *tp);
  * 2. struct usbi_transfer
  * 3. struct libusb_transfer (which includes iso packets) [variable size]
  *
- * You can convert between them with the macros:
+ * You can convert between them with the functions:
  *  TRANSFER_PRIV_TO_USBI_TRANSFER
  *  USBI_TRANSFER_TO_TRANSFER_PRIV
  *  USBI_TRANSFER_TO_LIBUSB_TRANSFER
@@ -1574,37 +1575,65 @@ int usbi_get_interface_string_index(libusb_device *dev,
 	uint8_t config_value, uint8_t interface_number, uint8_t alt_setting,
 	uint8_t *index_out);
 
-#define TRANSFER_PRIV_TO_USBI_TRANSFER(transfer_priv) \
-	((struct usbi_transfer *)			\
-	 ((unsigned char *)(transfer_priv)	\
-	  + PTR_ALIGN(sizeof(*transfer_priv))))
+static inline struct usbi_transfer *TRANSFER_PRIV_TO_USBI_TRANSFER(void *transfer_priv)
+{
+	return (struct usbi_transfer *)((unsigned char *)(transfer_priv) + PTR_ALIGN(usbi_backend.transfer_priv_size));
+}
 
-#define USBI_TRANSFER_TO_TRANSFER_PRIV(itransfer) \
-	((void *)			\
-	 ((unsigned char *)(itransfer)	\
-	  - PTR_ALIGN(usbi_backend.transfer_priv_size)))
+static inline void *USBI_TRANSFER_TO_TRANSFER_PRIV(const struct usbi_transfer *itransfer)
+{
+	return (void *)((unsigned char *)(itransfer) - PTR_ALIGN(usbi_backend.transfer_priv_size));
+}
 
-#define USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer)	\
-	((struct libusb_transfer *)			\
-	 ((unsigned char *)(itransfer)			\
-	  + PTR_ALIGN(usbi_backend.transfer_priv_size)))
+static inline struct libusb_transfer *USBI_TRANSFER_TO_LIBUSB_TRANSFER(const struct usbi_transfer *itransfer)
+{
+	return (struct libusb_transfer *)((unsigned char *)(itransfer) + PTR_ALIGN(sizeof(struct usbi_transfer)));
+}
 
-#define LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)	\
-	((struct usbi_transfer *)			\
-	 ((unsigned char *)(transfer)			\
-	  - PTR_ALIGN(sizeof(struct usbi_transfer))))
+static inline struct usbi_transfer *LIBUSB_TRANSFER_TO_USBI_TRANSFER(const struct libusb_transfer *transfer)
+{
+	return (struct usbi_transfer *)((unsigned char *)(transfer) - PTR_ALIGN(sizeof(struct usbi_transfer)));
+}
 
-#define DEVICE_CTX(dev)		((dev)->ctx)
-#define HANDLE_CTX(handle)	((handle) ? DEVICE_CTX((handle)->dev) : NULL)
-#define ITRANSFER_CTX(itransfer) \
-	((itransfer)->dev ? DEVICE_CTX((itransfer)->dev) : NULL)
-#define TRANSFER_CTX(transfer) \
-	(ITRANSFER_CTX(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)))
+static inline struct libusb_context *DEVICE_CTX(const struct libusb_device *dev)
+{
+	return dev->ctx;
+}
 
-#define IS_EPIN(ep)		(0 != ((ep) & LIBUSB_ENDPOINT_IN))
-#define IS_EPOUT(ep)		(!IS_EPIN(ep))
-#define IS_XFERIN(xfer)		(0 != ((xfer)->endpoint & LIBUSB_ENDPOINT_IN))
-#define IS_XFEROUT(xfer)	(!IS_XFERIN(xfer))
+static inline struct libusb_context *HANDLE_CTX(const struct libusb_device_handle *handle)
+{
+	return handle ? DEVICE_CTX(handle->dev) : NULL;
+}
+
+static inline struct libusb_context *ITRANSFER_CTX(const struct usbi_transfer *itransfer)
+{
+	return itransfer->dev ? DEVICE_CTX(itransfer->dev) : NULL;
+}
+
+static inline struct libusb_context *TRANSFER_CTX(const struct libusb_transfer *transfer)
+{
+	return ITRANSFER_CTX(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
+}
+
+static inline bool IS_EPIN(uint8_t ep)
+{
+	return (0 != (ep & LIBUSB_ENDPOINT_IN));
+}
+
+static inline bool IS_EPOUT(uint8_t ep)
+{
+	return !IS_EPIN(ep);
+}
+
+static inline bool IS_XFERIN(const struct libusb_transfer *xfer)
+{
+	return (0 != (xfer->endpoint & LIBUSB_ENDPOINT_IN));
+}
+
+static inline bool IS_XFEROUT(const struct libusb_transfer *xfer)
+{
+	return !IS_XFERIN(xfer);
+}
 
 #define for_each_context(c) \
 	for_each_helper(c, &active_contexts_list, struct libusb_context)

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -523,7 +523,7 @@ static int ep_to_pipeRef_locked(struct libusb_device_handle *dev_handle, uint8_t
 
   uint8_t i, iface;
 
-  struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 
   usbi_dbg (ctx, "converting ep address 0x%02x to pipeRef and interface", ep);
 
@@ -549,7 +549,7 @@ static int ep_to_pipeRef_locked(struct libusb_device_handle *dev_handle, uint8_t
   }
 
   /* No pipe found with the correct endpoint address */
-  usbi_warn (HANDLE_CTX(dev_handle), "no pipeRef found with endpoint address 0x%02x.", ep);
+  usbi_warn (usbi_handle_ctx(dev_handle), "no pipeRef found with endpoint address 0x%02x.", ep);
 
   return LIBUSB_ERROR_NOT_FOUND;
 }
@@ -1230,7 +1230,7 @@ static int darwin_get_config_string (struct libusb_device *dev,
   if (0 == string_index)
     return LIBUSB_ERROR_NOT_FOUND;
 
-  return darwin_fetch_string_descriptor (DEVICE_CTX(dev), dpriv, string_index, buffer, length);
+  return darwin_fetch_string_descriptor (usbi_device_ctx(dev), dpriv, string_index, buffer, length);
 }
 
 static int darwin_get_interface_string (struct libusb_device *dev,
@@ -1249,7 +1249,7 @@ static int darwin_get_interface_string (struct libusb_device *dev,
   if (0 == string_index)
     return LIBUSB_ERROR_NOT_FOUND;
 
-  return darwin_fetch_string_descriptor (DEVICE_CTX(dev), dpriv, string_index, buffer, length);
+  return darwin_fetch_string_descriptor (usbi_device_ctx(dev), dpriv, string_index, buffer, length);
 }
 
 static int get_configuration_index (struct libusb_device *dev, UInt8 config_value) {
@@ -1873,13 +1873,13 @@ static int darwin_open_locked (struct libusb_device_handle *dev_handle) {
 
   if (0 == dpriv->open_count) {
     if (!dpriv->device) {
-      usbi_err(HANDLE_CTX(dev_handle), "device interface is NULL, cannot open");
+      usbi_err(usbi_handle_ctx(dev_handle), "device interface is NULL, cannot open");
       return LIBUSB_ERROR_NO_DEVICE;
     }
     /* try to open the device */
     kresult = (*dpriv->device)->USBDeviceOpenSeize (dpriv->device);
     if (kresult != kIOReturnSuccess) {
-      usbi_warn (HANDLE_CTX (dev_handle), "USBDeviceOpen: %s", darwin_error_str(kresult));
+      usbi_warn (usbi_handle_ctx (dev_handle), "USBDeviceOpen: %s", darwin_error_str(kresult));
 
       if (kIOReturnExclusiveAccess != kresult) {
         return darwin_to_libusb (kresult);
@@ -1895,7 +1895,7 @@ static int darwin_open_locked (struct libusb_device_handle *dev_handle) {
     kresult = (*dpriv->device)->CreateDeviceAsyncEventSource (dpriv->device,
                                                                                 &priv->cfSource);
     if (kresult != kIOReturnSuccess) {
-      usbi_err (HANDLE_CTX (dev_handle), "CreateDeviceAsyncEventSource: %s", darwin_error_str(kresult));
+      usbi_err (usbi_handle_ctx (dev_handle), "CreateDeviceAsyncEventSource: %s", darwin_error_str(kresult));
 
       if (priv->is_open) {
         (*dpriv->device)->USBDeviceClose (dpriv->device);
@@ -1915,7 +1915,7 @@ static int darwin_open_locked (struct libusb_device_handle *dev_handle) {
   /* device opened successfully */
   dpriv->open_count++;
 
-  usbi_dbg (HANDLE_CTX(dev_handle), "device open for access");
+  usbi_dbg (usbi_handle_ctx(dev_handle), "device open for access");
 
   return 0;
 }
@@ -1940,13 +1940,13 @@ static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
 
   if (dpriv->open_count == 0) {
     /* something is probably very wrong if this is the case */
-    usbi_err (HANDLE_CTX (dev_handle), "Close called on a device that was not open!");
+    usbi_err (usbi_handle_ctx (dev_handle), "Close called on a device that was not open!");
     return;
   }
 
   dpriv->open_count--;
   if (NULL == dpriv->device) {
-    usbi_warn (HANDLE_CTX (dev_handle), "darwin_close device missing IOService");
+    usbi_warn (usbi_handle_ctx (dev_handle), "darwin_close device missing IOService");
     return;
   }
 
@@ -1965,7 +1965,7 @@ static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
       if (kresult != kIOReturnSuccess) {
         /* Log the fact that we had a problem closing the file, however failing a
          * close isn't really an error, so return success anyway */
-        usbi_warn (HANDLE_CTX (dev_handle), "USBDeviceClose: %s", darwin_error_str(kresult));
+        usbi_warn (usbi_handle_ctx (dev_handle), "USBDeviceClose: %s", darwin_error_str(kresult));
       }
     }
   }
@@ -2097,7 +2097,7 @@ static const struct libusb_interface_descriptor *get_interface_descriptor_by_num
     }
   }
 
-  usbi_err(HANDLE_CTX(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
+  usbi_err(usbi_handle_ctx(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
   return NULL;
 }
 
@@ -2109,7 +2109,7 @@ static int get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface
   IOReturn kresult;
   uint8_t numep;
   int rc;
-  struct libusb_context *ctx = HANDLE_CTX (dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx (dev_handle);
 
   usbi_dbg (ctx, "building table of endpoints.");
 
@@ -2133,7 +2133,7 @@ static int get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface
 
       kresult = (*IOINTERFACE(cInterface))->GetAlternateSetting (IOINTERFACE(cInterface), &alt_setting);
       if (kresult != kIOReturnSuccess) {
-        usbi_err (HANDLE_CTX (dev_handle), "can't get alternate setting for interface");
+        usbi_err (usbi_handle_ctx (dev_handle), "can't get alternate setting for interface");
         return darwin_to_libusb (kresult);
       }
 
@@ -2182,7 +2182,7 @@ static int darwin_claim_interface(struct libusb_device_handle *dev_handle, uint8
   /* current interface */
   struct darwin_interface *cInterface = &priv->interfaces[iface];
 
-  struct libusb_context *ctx = HANDLE_CTX (dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx (dev_handle);
 
   kresult = darwin_get_interface (dpriv->device, iface, &usbInterface);
   if (kresult != kIOReturnSuccess)
@@ -2307,11 +2307,11 @@ static int darwin_release_interface(struct libusb_device_handle *dev_handle, uin
 
   kresult = (*IOINTERFACE(cInterface))->USBInterfaceClose(IOINTERFACE(cInterface));
   if (kresult != kIOReturnSuccess)
-    usbi_warn (HANDLE_CTX (dev_handle), "USBInterfaceClose: %s", darwin_error_str(kresult));
+    usbi_warn (usbi_handle_ctx (dev_handle), "USBInterfaceClose: %s", darwin_error_str(kresult));
 
   ULONG refCount = (*IOINTERFACE(cInterface))->Release(IOINTERFACE(cInterface));
   if (refCount != 0) {
-    usbi_warn (HANDLE_CTX (dev_handle), "Release final refCount: %u", refCount);
+    usbi_warn (usbi_handle_ctx (dev_handle), "Release final refCount: %u", refCount);
   }
 
   IOINTERFACE(cInterface) = NULL;
@@ -2333,7 +2333,7 @@ static int check_alt_setting_and_clear_halt(struct libusb_device_handle *dev_han
   for (int i = 0 ; i < cInterface->num_endpoints ; i++) {
     ret = darwin_clear_halt_locked(dev_handle, cInterface->endpoint_addrs[i]);
     if (LIBUSB_SUCCESS != ret) {
-      usbi_warn(HANDLE_CTX (dev_handle), "error clearing pipe halt for endpoint %d", i);
+      usbi_warn(usbi_handle_ctx (dev_handle), "error clearing pipe halt for endpoint %d", i);
       if (LIBUSB_ERROR_NOT_FOUND == ret) {
         /* may need to re-open the interface */
         return ret;
@@ -2376,12 +2376,12 @@ static int darwin_set_interface_altsetting_locked(struct libusb_device_handle *d
     if (ret) {
       /* this should not happen */
       darwin_release_interface (dev_handle, iface);
-      usbi_err (HANDLE_CTX (dev_handle), "could not build endpoint table");
+      usbi_err (usbi_handle_ctx (dev_handle), "could not build endpoint table");
     }
     return ret;
   }
 
-  usbi_warn (HANDLE_CTX (dev_handle), "SetAlternateInterface: %s", darwin_error_str(kresult));
+  usbi_warn (usbi_handle_ctx (dev_handle), "SetAlternateInterface: %s", darwin_error_str(kresult));
 
   ret = darwin_to_libusb(kresult);
   if (ret != LIBUSB_ERROR_PIPE) {
@@ -2399,7 +2399,7 @@ static int darwin_set_interface_altsetting_locked(struct libusb_device_handle *d
     ret = darwin_claim_interface (dev_handle, iface);
     if (LIBUSB_SUCCESS != ret) {
       darwin_release_interface (dev_handle, iface);
-      usbi_err (HANDLE_CTX (dev_handle), "could not reclaim interface: %s", darwin_error_str(kresult));
+      usbi_err (usbi_handle_ctx (dev_handle), "could not reclaim interface: %s", darwin_error_str(kresult));
     }
     ret = check_alt_setting_and_clear_halt(dev_handle, altsetting, cInterface);
   }
@@ -2426,7 +2426,7 @@ static int darwin_clear_halt_locked(struct libusb_device_handle *dev_handle, uns
 
   /* determine the interface/endpoint to use */
   if (ep_to_pipeRef_locked (dev_handle, endpoint, &pipeRef, NULL, &cInterface) != 0) {
-    usbi_err (HANDLE_CTX (dev_handle), "endpoint not found on any open interface");
+    usbi_err (usbi_handle_ctx (dev_handle), "endpoint not found on any open interface");
 
     return LIBUSB_ERROR_NOT_FOUND;
   }
@@ -2434,7 +2434,7 @@ static int darwin_clear_halt_locked(struct libusb_device_handle *dev_handle, uns
   /* newer versions of darwin support clearing additional bits on the device's endpoint */
   kresult = (*IOINTERFACE(cInterface))->ClearPipeStallBothEnds(IOINTERFACE(cInterface), pipeRef);
   if (kresult != kIOReturnSuccess)
-    usbi_warn (HANDLE_CTX (dev_handle), "ClearPipeStall: %s", darwin_error_str (kresult));
+    usbi_warn (usbi_handle_ctx (dev_handle), "ClearPipeStall: %s", darwin_error_str (kresult));
 
   return darwin_to_libusb (kresult);
 }
@@ -2458,7 +2458,7 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   int open_count = dpriv->open_count;
   int ret;
 
-  struct libusb_context *ctx = HANDLE_CTX (dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx (dev_handle);
 
   /* clear claimed interfaces temporarily */
   dev_handle->claimed_interfaces = 0;
@@ -2559,7 +2559,7 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
   IOReturn kresult;
   UInt8 i;
 
-  struct libusb_context *ctx = HANDLE_CTX (dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx (dev_handle);
 
   /* adopt any replacement left over from a previous re-enumeration that
      returned (e.g. on timeout) before the device came back */
@@ -2782,7 +2782,7 @@ static void darwin_destroy_device(struct libusb_device *dev) EXCLUDES(darwin_cac
 }
 
 static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   IOReturn               ret;
@@ -2795,7 +2795,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
 
   if (ep_to_pipeRef_locked (transfer->dev_handle, transfer->endpoint, &pipeRef, NULL, &cInterface) != 0) {
     usbi_mutex_unlock(&transfer->dev_handle->lock);
-    usbi_err (TRANSFER_CTX (transfer), "endpoint not found on any open interface");
+    usbi_err (usbi_transfer_ctx (transfer), "endpoint not found on any open interface");
 
     return LIBUSB_ERROR_NOT_FOUND;
   }
@@ -2803,7 +2803,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
   ret = darwin_get_pipe_properties(cInterface, pipeRef, &pipe_properties);
   if (kIOReturnSuccess != ret) {
     usbi_mutex_unlock(&transfer->dev_handle->lock);
-    usbi_err (TRANSFER_CTX (transfer), "bulk transfer failed (dir = %s): %s (code = 0x%08x)", IS_XFERIN(transfer) ? "In" : "Out",
+    usbi_err (usbi_transfer_ctx (transfer), "bulk transfer failed (dir = %s): %s (code = 0x%08x)", usbi_is_xferin(transfer) ? "In" : "Out",
               darwin_error_str(ret), ret);
     return darwin_to_libusb (ret);
   }
@@ -2813,7 +2813,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
     transfer->flags &= ~LIBUSB_TRANSFER_ADD_ZERO_PACKET;
   }
 
-  if (IS_XFEROUT(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
+  if (usbi_is_xferout(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
     /* pin the interface plug-in for the zero-length packet write in
        darwin_async_io_callback, which must not take dev_handle->lock to
        look the pipe up: it runs on the event thread, and blocking there
@@ -2839,14 +2839,14 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
 
   /* submit the request */
   if (pipe_properties.transfer_type == kUSBInterrupt) {
-    if (IS_XFERIN(transfer))
+    if (usbi_is_xferin(transfer))
       ret = (*IOINTERFACE(cInterface))->ReadPipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
                                                               (UInt32)transfer->length, darwin_async_io_callback, itransfer);
     else
       ret = (*IOINTERFACE(cInterface))->WritePipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
                                                                (UInt32)transfer->length, darwin_async_io_callback, itransfer);
   } else {
-    if (IS_XFERIN(transfer))
+    if (usbi_is_xferin(transfer))
       ret = (*IOINTERFACE(cInterface))->ReadPipeAsyncTO(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
                                                                 (UInt32)transfer->length, transfer->timeout, transfer->timeout,
                                                                 darwin_async_io_callback, itransfer);
@@ -2862,7 +2862,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
       (*tpriv->zlp_interface)->Release (tpriv->zlp_interface);
       tpriv->zlp_interface = NULL;
     }
-    usbi_err (TRANSFER_CTX (transfer), "bulk transfer failed (dir = %s): %s (code = 0x%08x)", IS_XFERIN(transfer) ? "In" : "Out",
+    usbi_err (usbi_transfer_ctx (transfer), "bulk transfer failed (dir = %s): %s (code = 0x%08x)", usbi_is_xferin(transfer) ? "In" : "Out",
                darwin_error_str(ret), ret);
   }
 
@@ -2871,29 +2871,29 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
 
 #if MAX_INTERFACE_VERSION >= 550
 static int submit_stream_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_interface *cInterface;
   uint8_t pipeRef;
   IOReturn ret;
 
-  if (IS_XFEROUT(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
+  if (usbi_is_xferout(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
     /* the previous code terminated stream transfers with a plain WritePipe
        on the streams-configured pipe, which is not a valid operation for a
        stream endpoint. there is no synchronous streams write to terminate
        with, so the flag is not supported here; warn instead of silently
        dropping the requested terminator. */
-    usbi_warn (TRANSFER_CTX (transfer), "LIBUSB_TRANSFER_ADD_ZERO_PACKET is not supported for bulk stream transfers, ignoring");
+    usbi_warn (usbi_transfer_ctx (transfer), "LIBUSB_TRANSFER_ADD_ZERO_PACKET is not supported for bulk stream transfers, ignoring");
     transfer->flags &= ~LIBUSB_TRANSFER_ADD_ZERO_PACKET;
   }
 
   if (ep_to_pipeRef (transfer->dev_handle, transfer->endpoint, &pipeRef, NULL, &cInterface) != 0) {
-    usbi_err (TRANSFER_CTX (transfer), "endpoint not found on any open interface");
+    usbi_err (usbi_transfer_ctx (transfer), "endpoint not found on any open interface");
 
     return LIBUSB_ERROR_NOT_FOUND;
   }
 
   if (get_interface_interface_version() < 550) {
-    usbi_err (TRANSFER_CTX(transfer), "IOUSBFamily version %d does not support bulk stream transfers",
+    usbi_err (usbi_transfer_ctx(transfer), "IOUSBFamily version %d does not support bulk stream transfers",
               get_interface_interface_version());
     return LIBUSB_ERROR_NOT_SUPPORTED;
   }
@@ -2904,7 +2904,7 @@ static int submit_stream_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
      (see submit_fence in struct usbi_transfer) */
   usbi_atomic_store(&itransfer->submit_fence, 1);
 
-  if (IS_XFERIN(transfer))
+  if (usbi_is_xferin(transfer))
     ret = (*IOINTERFACE_V(cInterface, 550))->ReadStreamsPipeAsyncTO(IOINTERFACE(cInterface), pipeRef, itransfer->stream_id,
                                                                   transfer->buffer, (UInt32)transfer->length, transfer->timeout,
                                                                   transfer->timeout, darwin_async_io_callback, itransfer);
@@ -2914,7 +2914,7 @@ static int submit_stream_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
                                                                    transfer->timeout, darwin_async_io_callback, itransfer);
 
   if (ret)
-    usbi_err (TRANSFER_CTX (transfer), "bulk stream transfer failed (dir = %s): %s (code = 0x%08x)", IS_XFERIN(transfer) ? "In" : "Out",
+    usbi_err (usbi_transfer_ctx (transfer), "bulk stream transfer failed (dir = %s): %s (code = 0x%08x)", usbi_is_xferin(transfer) ? "In" : "Out",
                darwin_error_str(ret), ret);
 
   return darwin_to_libusb (ret);
@@ -2922,7 +2922,7 @@ static int submit_stream_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
 #endif
 
 static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   IOReturn kresult;
@@ -2955,7 +2955,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
 
   /* determine the interface/endpoint to use */
   if (ep_to_pipeRef (transfer->dev_handle, transfer->endpoint, &pipeRef, NULL, &cInterface) != 0) {
-    usbi_err (TRANSFER_CTX (transfer), "endpoint not found on any open interface");
+    usbi_err (usbi_transfer_ctx (transfer), "endpoint not found on any open interface");
 
     return LIBUSB_ERROR_NOT_FOUND;
   }
@@ -2963,7 +2963,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
   /* determine the properties of this endpoint and the speed of the device */
   kresult = darwin_get_pipe_properties(cInterface, pipeRef, &pipe_properties);
   if (kresult != kIOReturnSuccess) {
-    usbi_err (TRANSFER_CTX (transfer), "failed to get pipe properties: %d", kresult);
+    usbi_err (usbi_transfer_ctx (transfer), "failed to get pipe properties: %d", kresult);
     free(tpriv->isoc_framelist);
     tpriv->isoc_framelist = NULL;
 
@@ -2973,7 +2973,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
   /* Last but not least we need the bus frame number */
   kresult = (*IOINTERFACE(cInterface))->GetBusFrameNumber(IOINTERFACE(cInterface), &frame, &atTime);
   if (kresult != kIOReturnSuccess) {
-    usbi_err (TRANSFER_CTX (transfer), "failed to get bus frame number: %d", kresult);
+    usbi_err (usbi_transfer_ctx (transfer), "failed to get bus frame number: %d", kresult);
     free(tpriv->isoc_framelist);
     tpriv->isoc_framelist = NULL;
 
@@ -2991,7 +2991,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
   usbi_atomic_store(&itransfer->submit_fence, 1);
 
   /* submit the request */
-  if (IS_XFERIN(transfer))
+  if (usbi_is_xferin(transfer))
     kresult = (*IOINTERFACE(cInterface))->ReadIsochPipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer, frame,
                                                                      (UInt32)transfer->num_iso_packets, tpriv->isoc_framelist, darwin_async_io_callback,
                                                                      itransfer);
@@ -3008,7 +3008,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
     cInterface->frames[transfer->endpoint] = frame + (UInt64)transfer->num_iso_packets * (1UL << (pipe_properties.interval - 1)) / 8;
 
   if (kresult != kIOReturnSuccess) {
-    usbi_err (TRANSFER_CTX (transfer), "isochronous transfer failed (dir: %s): %s", IS_XFERIN(transfer) ? "In" : "Out",
+    usbi_err (usbi_transfer_ctx (transfer), "isochronous transfer failed (dir: %s): %s", usbi_is_xferin(transfer) ? "In" : "Out",
                darwin_error_str(kresult));
     free (tpriv->isoc_framelist);
     tpriv->isoc_framelist = NULL;
@@ -3018,7 +3018,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
 }
 
 static int submit_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct libusb_control_setup *setup = (struct libusb_control_setup *) transfer->buffer;
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(transfer->dev_handle->dev);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
@@ -3052,7 +3052,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itr
     uint8_t                 pipeRef;
 
     if (ep_to_pipeRef (transfer->dev_handle, transfer->endpoint, &pipeRef, NULL, &cInterface) != 0) {
-      usbi_err (TRANSFER_CTX (transfer), "endpoint not found on any open interface");
+      usbi_err (usbi_transfer_ctx (transfer), "endpoint not found on any open interface");
 
       return LIBUSB_ERROR_NOT_FOUND;
     }
@@ -3064,13 +3064,13 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itr
     kresult = (*dpriv->device)->DeviceRequestAsyncTO(dpriv->device, &(tpriv->req), darwin_async_io_callback, itransfer);
 
   if (kresult != kIOReturnSuccess)
-    usbi_err (TRANSFER_CTX (transfer), "control request failed: %s", darwin_error_str(kresult));
+    usbi_err (usbi_transfer_ctx (transfer), "control request failed: %s", darwin_error_str(kresult));
 
   return darwin_to_libusb (kresult);
 }
 
 static int darwin_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   /* transfers may be resubmitted; clear the cached zero-length-packet pipe
@@ -3089,21 +3089,21 @@ static int darwin_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
 #if MAX_INTERFACE_VERSION >= 550
     return submit_stream_transfer(itransfer);
 #else
-    usbi_err (TRANSFER_CTX(transfer), "IOUSBFamily version does not support bulk stream transfers");
+    usbi_err (usbi_transfer_ctx(transfer), "IOUSBFamily version does not support bulk stream transfers");
     return LIBUSB_ERROR_NOT_SUPPORTED;
 #endif
   default:
-    usbi_err (TRANSFER_CTX(transfer), "unknown endpoint type %d", transfer->type);
+    usbi_err (usbi_transfer_ctx(transfer), "unknown endpoint type %d", transfer->type);
     return LIBUSB_ERROR_INVALID_PARAM;
   }
 }
 
 static int cancel_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(transfer->dev_handle->dev);
   IOReturn kresult;
 
-  usbi_warn (ITRANSFER_CTX (itransfer), "aborting all transactions control pipe");
+  usbi_warn (usbi_itransfer_ctx (itransfer), "aborting all transactions control pipe");
 
   if (!dpriv->device) {
     return LIBUSB_ERROR_NO_DEVICE;
@@ -3115,13 +3115,13 @@ static int cancel_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itr
 }
 
 static int darwin_abort_transfers (struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(transfer->dev_handle->dev);
   struct darwin_interface *cInterface;
   uint8_t pipeRef, iface;
   IOReturn kresult;
 
-  struct libusb_context *ctx = ITRANSFER_CTX (itransfer);
+  struct libusb_context *ctx = usbi_itransfer_ctx (itransfer);
 
   if (ep_to_pipeRef (transfer->dev_handle, transfer->endpoint, &pipeRef, &iface, &cInterface) != 0) {
     usbi_err (ctx, "endpoint not found on any open interface");
@@ -3157,7 +3157,7 @@ static int darwin_abort_transfers (struct usbi_transfer *itransfer) REQUIRES(itr
 }
 
 static int darwin_cancel_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
   switch (transfer->type) {
   case LIBUSB_TRANSFER_TYPE_CONTROL:
@@ -3167,7 +3167,7 @@ static int darwin_cancel_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
   case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
     return darwin_abort_transfers (itransfer);
   default:
-    usbi_err (TRANSFER_CTX(transfer), "unknown endpoint type %d", transfer->type);
+    usbi_err (usbi_transfer_ctx(transfer), "unknown endpoint type %d", transfer->type);
     return LIBUSB_ERROR_INVALID_PARAM;
   }
 }
@@ -3181,10 +3181,10 @@ static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0)
      struct usbi_transfer. */
   (void)usbi_atomic_load(&itransfer->submit_fence);
 
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
-  usbi_dbg (TRANSFER_CTX(transfer), "an async io operation has completed");
+  usbi_dbg (usbi_transfer_ctx(transfer), "an async io operation has completed");
 
   /* if requested write a zero packet. use the interface plug-in pinned at
      submission: this callback runs on the event thread and must not take
@@ -3195,7 +3195,7 @@ static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0)
      a closed interface just returns an error, which is ignored as before).
      the reference is always dropped here, whatever the completion result. */
   if (tpriv->zlp_interface) {
-    if (kIOReturnSuccess == result && IS_XFEROUT(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
+    if (kIOReturnSuccess == result && usbi_is_xferout(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET)) {
       (*tpriv->zlp_interface)->WritePipe (tpriv->zlp_interface, tpriv->zlp_pipeRef, transfer->buffer, 0);
     }
     (*tpriv->zlp_interface)->Release (tpriv->zlp_interface);
@@ -3213,7 +3213,7 @@ static enum libusb_transfer_status darwin_transfer_status (struct usbi_transfer 
   if (itransfer->timeout_flags & USBI_TRANSFER_TIMED_OUT)
     result = kIOUSBTransactionTimeout;
 
-  struct libusb_context *ctx = ITRANSFER_CTX (itransfer);
+  struct libusb_context *ctx = usbi_itransfer_ctx (itransfer);
 
   switch (result) {
   case kIOReturnUnderrun:
@@ -3238,14 +3238,14 @@ static enum libusb_transfer_status darwin_transfer_status (struct usbi_transfer 
 }
 
 static int darwin_handle_transfer_completion (struct usbi_transfer *itransfer) {
-  struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+  struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
   const unsigned char max_transfer_type = LIBUSB_TRANSFER_TYPE_BULK_STREAM;
 #ifdef ENABLE_LOGGING
   const char *transfer_types[] = {"control", "isoc", "bulk", "interrupt", "bulk-stream", NULL};
 #endif
   bool is_isoc = LIBUSB_TRANSFER_TYPE_ISOCHRONOUS == transfer->type;
-  struct libusb_context *ctx = ITRANSFER_CTX (itransfer);
+  struct libusb_context *ctx = usbi_itransfer_ctx (itransfer);
 
   if (transfer->type > max_transfer_type) {
     usbi_err (ctx, "unknown endpoint type %d", transfer->type);
@@ -3405,7 +3405,7 @@ static int darwin_reload_device (struct libusb_device_handle *dev_handle) EXCLUD
   enum libusb_error err;
 
   usbi_mutex_lock(&darwin_cached_devices_mutex);
-  err = darwin_device_from_service (HANDLE_CTX (dev_handle), dpriv->service, &new_device);
+  err = darwin_device_from_service (usbi_handle_ctx (dev_handle), dpriv->service, &new_device);
   if (err == LIBUSB_SUCCESS) {
     (*dpriv->device)->Release(dpriv->device);
     dpriv->device = new_device;
@@ -3423,7 +3423,7 @@ static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
   int err;
-  struct libusb_context *ctx = HANDLE_CTX (dev_handle);
+  struct libusb_context *ctx = usbi_handle_ctx (dev_handle);
 
   if (get_interface_interface_version() < 700) {
     return LIBUSB_ERROR_NOT_SUPPORTED;
@@ -3500,7 +3500,7 @@ static int darwin_attach_kernel_driver_locked (struct libusb_device_handle *dev_
     return LIBUSB_SUCCESS;
   }
 
-  usbi_dbg (HANDLE_CTX (dev_handle), "reenumerating device for kernel driver attach");
+  usbi_dbg (usbi_handle_ctx (dev_handle), "reenumerating device for kernel driver attach");
 
   /* reset device to attach kernel drivers */
   return darwin_reenumerate_device (dev_handle, false);
@@ -3534,7 +3534,7 @@ static int darwin_capture_claim_interface(struct libusb_device_handle *dev_handl
     ret = darwin_detach_kernel_driver_locked (dev_handle, iface);
     usbi_mutex_unlock(&dpriv->lock);
     if (ret != LIBUSB_SUCCESS) {
-      usbi_info (HANDLE_CTX (dev_handle), "failed to auto-detach the kernel driver for this device, ret=%d", ret);
+      usbi_info (usbi_handle_ctx (dev_handle), "failed to auto-detach the kernel driver for this device, ret=%d", ret);
     }
   }
 
@@ -3554,7 +3554,7 @@ static int darwin_capture_release_interface(struct libusb_device_handle *dev_han
   if (dev_handle->auto_detach_kernel_driver && dpriv->capture_count > 0) {
     ret = darwin_attach_kernel_driver_locked (dev_handle, iface);
     if (LIBUSB_SUCCESS != ret) {
-      usbi_info (HANDLE_CTX (dev_handle), "on attempt to reattach the kernel driver got ret=%d", ret);
+      usbi_info (usbi_handle_ctx (dev_handle), "on attempt to reattach the kernel driver got ret=%d", ret);
     }
     /* ignore the error as the interface was successfully released */
   }

--- a/libusb/os/emscripten_webusb.cpp
+++ b/libusb/os/emscripten_webusb.cpp
@@ -782,7 +782,7 @@ int em_submit_transfer(usbi_transfer* itransfer) REQUIRES(itransfer->lock) {
 				auto endpoint =
 					transfer->endpoint & LIBUSB_ENDPOINT_ADDRESS_MASK;
 
-				if (IS_XFERIN(transfer)) {
+				if (usbi_is_xfer_in(transfer)) {
 					transfer_promise = web_usb_device.call<val>(
 						"transferIn", endpoint, transfer->length);
 				} else {

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -190,7 +190,7 @@ static int dev_has_config0(struct libusb_device *dev)
 
 static int get_usbfs_fd(struct libusb_device *dev, int access_mode, int silent)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	char path[24];
 	int fd;
 
@@ -498,7 +498,7 @@ static int op_get_device_string(struct libusb_device *dev,
 {
 	int fd;
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
-	struct libusb_context* ctx = DEVICE_CTX(dev);
+	struct libusb_context* ctx = usbi_device_ctx(dev);
 	const char * attr;
 
 	switch (string_type) {
@@ -551,7 +551,7 @@ static int op_get_config_string(struct libusb_device *dev,
 		uint8_t config_value, char *buffer, int length)
 {
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
-	struct libusb_context* ctx = DEVICE_CTX(dev);
+	struct libusb_context* ctx = usbi_device_ctx(dev);
 	uint8_t string_index = 0;
 	int r;
 
@@ -597,7 +597,7 @@ static int op_get_interface_string(struct libusb_device *dev,
 		char *buffer, int length)
 {
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
-	struct libusb_context* ctx = DEVICE_CTX(dev);
+	struct libusb_context* ctx = usbi_device_ctx(dev);
 	char intf_dir[256];
 	uint8_t string_index = 0;
 	int active = 0;
@@ -794,7 +794,7 @@ static int sysfs_get_active_config(struct libusb_device *dev, int *config)
 {
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
 
-	return read_sysfs_attr(DEVICE_CTX(dev), priv->sysfs_dir, "bConfigurationValue",
+	return read_sysfs_attr(usbi_device_ctx(dev), priv->sysfs_dir, "bConfigurationValue",
 			UINT8_MAX, config);
 }
 
@@ -895,7 +895,7 @@ static int seek_to_next_config(struct libusb_context *ctx,
 
 static int parse_config_descriptors(struct libusb_device *dev)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
 	struct usbi_device_descriptor *device_desc;
 	uint8_t idx, num_configs;
@@ -1025,7 +1025,7 @@ static int op_get_active_config_descriptor(struct libusb_device *dev,
 	}
 
 	if (active_config == -1) {
-		usbi_err(DEVICE_CTX(dev), "device unconfigured");
+		usbi_err(usbi_device_ctx(dev), "device unconfigured");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -1076,7 +1076,7 @@ static int usbfs_get_active_config(struct libusb_device *dev, int fd)
 			return LIBUSB_ERROR_NO_DEVICE;
 
 		/* we hit this error path frequently with buggy devices :( */
-		usbi_warn(DEVICE_CTX(dev), "get configuration failed, errno=%d", errno);
+		usbi_warn(usbi_device_ctx(dev), "get configuration failed, errno=%d", errno);
 
 		/* assume the current configuration is the first one if we have
 		 * the configuration descriptors, otherwise treat the device
@@ -1124,7 +1124,7 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 	uint8_t devaddr, const char *sysfs_dir, int wrapped_fd)
 {
 	struct linux_device_priv *priv = (struct linux_device_priv *)usbi_get_device_priv(dev);
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	size_t alloc_len;
 	int fd, speed, r;
 	ssize_t nb;
@@ -1244,7 +1244,7 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 
 static int linux_get_parent_info(struct libusb_device *dev, const char *sysfs_dir)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct libusb_device *it;
 	char *parent_sysfs_dir, *tmp, *end;
 	int ret, add_parent = 1;
@@ -1565,13 +1565,13 @@ static int initialize_handle(struct libusb_device_handle *handle, int fd)
 	r = ioctl(fd, IOCTL_USBFS_GET_CAPABILITIES, &hpriv->caps);
 	if (r < 0) {
 		if (errno == ENOTTY)
-			usbi_dbg(HANDLE_CTX(handle), "getcap not available");
+			usbi_dbg(usbi_handle_ctx(handle), "getcap not available");
 		else
-			usbi_err(HANDLE_CTX(handle), "getcap failed, errno=%d", errno);
+			usbi_err(usbi_handle_ctx(handle), "getcap failed, errno=%d", errno);
 		hpriv->caps = USBFS_CAP_BULK_CONTINUATION;
 	}
 
-	return usbi_add_event_source(HANDLE_CTX(handle), hpriv->fd, POLLOUT);
+	return usbi_add_event_source(usbi_handle_ctx(handle), hpriv->fd, POLLOUT);
 }
 
 static int op_wrap_sys_device(struct libusb_context *ctx,
@@ -1635,7 +1635,7 @@ static int op_open(struct libusb_device_handle *handle)
 			 * hasn't processed remove event yet */
 			usbi_mutex_static_lock(&linux_hotplug_lock);
 			if (usbi_atomic_load(&handle->dev->attached)) {
-				usbi_dbg(HANDLE_CTX(handle), "open failed with no device, but device still attached");
+				usbi_dbg(usbi_handle_ctx(handle), "open failed with no device, but device still attached");
 				linux_device_disconnected(handle->dev->bus_number,
 							  handle->dev->device_address);
 			}
@@ -1657,7 +1657,7 @@ static void op_close(struct libusb_device_handle *dev_handle)
 
 	/* fd may have already been removed by POLLERR condition in op_handle_events() */
 	if (!hpriv->fd_removed)
-		usbi_remove_event_source(HANDLE_CTX(dev_handle), hpriv->fd);
+		usbi_remove_event_source(usbi_handle_ctx(dev_handle), hpriv->fd);
 	if (!hpriv->fd_keep)
 		close(hpriv->fd);
 }
@@ -1682,7 +1682,7 @@ static int op_get_configuration(struct libusb_device_handle *handle,
 		return r;
 
 	if (active_config == -1) {
-		usbi_warn(HANDLE_CTX(handle), "device unconfigured");
+		usbi_warn(usbi_handle_ctx(handle), "device unconfigured");
 		active_config = 0;
 	}
 
@@ -1706,7 +1706,7 @@ static int op_set_configuration(struct libusb_device_handle *handle, int config)
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "set configuration failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "set configuration failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -1735,7 +1735,7 @@ static int claim_interface(struct libusb_device_handle *handle, unsigned int ifa
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "claim interface failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "claim interface failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 	return 0;
@@ -1751,7 +1751,7 @@ static int release_interface(struct libusb_device_handle *handle, unsigned int i
 		if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "release interface failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "release interface failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 	return 0;
@@ -1774,7 +1774,7 @@ static int op_set_interface(struct libusb_device_handle *handle, uint8_t interfa
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "set interface failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "set interface failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -1795,7 +1795,7 @@ static int op_clear_halt(struct libusb_device_handle *handle,
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "clear halt failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "clear halt failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -1827,7 +1827,7 @@ static int op_reset_device(struct libusb_device_handle *handle)
 			goto out;
 		}
 
-		usbi_err(HANDLE_CTX(handle), "reset failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "reset failed, errno=%d", errno);
 		ret = LIBUSB_ERROR_OTHER;
 		goto out;
 	}
@@ -1843,7 +1843,7 @@ static int op_reset_device(struct libusb_device_handle *handle)
 		 */
 		r = detach_kernel_driver_and_claim(handle, i);
 		if (r) {
-			usbi_warn(HANDLE_CTX(handle), "failed to re-claim interface %u after reset: %s",
+			usbi_warn(usbi_handle_ctx(handle), "failed to re-claim interface %u after reset: %s",
 				  i, libusb_error_name(r));
 			handle->claimed_interfaces &= ~(1UL << i);
 			ret = LIBUSB_ERROR_NOT_FOUND;
@@ -1885,7 +1885,7 @@ static int do_streams_ioctl(struct libusb_device_handle *handle,
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "streams-ioctl failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "streams-ioctl failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 	return r;
@@ -1912,7 +1912,7 @@ static void *op_dev_mem_alloc(struct libusb_device_handle *handle, size_t len)
 
 	buffer = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, hpriv->fd, 0);
 	if (buffer == MAP_FAILED) {
-		usbi_err(HANDLE_CTX(handle), "alloc dev mem failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "alloc dev mem failed, errno=%d", errno);
 		return NULL;
 	}
 	return buffer;
@@ -1922,7 +1922,7 @@ static int op_dev_mem_free(struct libusb_device_handle *handle, void *buffer,
 	size_t len)
 {
 	if (munmap(buffer, len) != 0) {
-		usbi_err(HANDLE_CTX(handle), "free dev mem failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "free dev mem failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	} else {
 		return LIBUSB_SUCCESS;
@@ -1945,7 +1945,7 @@ static int op_kernel_driver_active(struct libusb_device_handle *handle,
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "get driver failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "get driver failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -1979,7 +1979,7 @@ static int op_detach_kernel_driver(struct libusb_device_handle *handle,
 		else if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "detach failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "detach failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -2009,7 +2009,7 @@ static int op_attach_kernel_driver(struct libusb_device_handle *handle,
 		else if (errno == EBUSY)
 			return LIBUSB_ERROR_BUSY;
 
-		usbi_err(HANDLE_CTX(handle), "attach failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "attach failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	} else if (r == 0) {
 		return LIBUSB_ERROR_NOT_FOUND;
@@ -2041,7 +2041,7 @@ static int detach_kernel_driver_and_claim(struct libusb_device_handle *handle,
 	case ENODEV:
 		return LIBUSB_ERROR_NO_DEVICE;
 	default:
-		usbi_err(HANDLE_CTX(handle), "disconnect-and-claim failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "disconnect-and-claim failed, errno=%d", errno);
 		return LIBUSB_ERROR_OTHER;
 	}
 
@@ -2089,7 +2089,7 @@ static void op_destroy_device(struct libusb_device *dev)
 static int discard_urbs(struct usbi_transfer *itransfer, int first, int last_plus_one)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	struct linux_device_handle_priv *hpriv =
 		(struct linux_device_handle_priv *)usbi_get_device_handle_priv(transfer->dev_handle);
@@ -2106,14 +2106,14 @@ static int discard_urbs(struct usbi_transfer *itransfer, int first, int last_plu
 			continue;
 
 		if (errno == EINVAL) {
-			usbi_dbg(TRANSFER_CTX(transfer), "URB not found --> assuming ready to be reaped");
+			usbi_dbg(usbi_transfer_ctx(transfer), "URB not found --> assuming ready to be reaped");
 			if (i == (last_plus_one - 1))
 				ret = LIBUSB_ERROR_NOT_FOUND;
 		} else if (errno == ENODEV) {
-			usbi_dbg(TRANSFER_CTX(transfer), "Device not found for URB --> assuming ready to be reaped");
+			usbi_dbg(usbi_transfer_ctx(transfer), "Device not found for URB --> assuming ready to be reaped");
 			ret = LIBUSB_ERROR_NO_DEVICE;
 		} else {
-			usbi_warn(TRANSFER_CTX(transfer), "unrecognised discard errno %d", errno);
+			usbi_warn(usbi_transfer_ctx(transfer), "unrecognised discard errno %d", errno);
 			ret = LIBUSB_ERROR_OTHER;
 		}
 	}
@@ -2139,12 +2139,12 @@ static void free_iso_urbs(struct linux_transfer_priv *tpriv)
 static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	struct linux_device_handle_priv *hpriv =
 		(struct linux_device_handle_priv *)usbi_get_device_handle_priv(transfer->dev_handle);
 	struct usbfs_urb *urbs;
-	int is_out = IS_XFEROUT(transfer);
+	int is_out = usbi_is_xferout(transfer);
 	int bulk_buffer_len, use_bulk_continuation;
 	int num_urbs;
 	int last_urb_partial = 0;
@@ -2201,7 +2201,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 		last_urb_partial = 1;
 		num_urbs++;
 	}
-	usbi_dbg(TRANSFER_CTX(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
+	usbi_dbg(usbi_transfer_ctx(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
 	urbs = (struct usbfs_urb *)calloc(num_urbs, sizeof(*urbs));
 	if (!urbs)
 		return LIBUSB_ERROR_NO_MEM;
@@ -2259,14 +2259,14 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 		} else if (errno == ENOMEM) {
 			r = LIBUSB_ERROR_NO_MEM;
 		} else {
-			usbi_err(TRANSFER_CTX(transfer), "submiturb failed, errno=%d", errno);
+			usbi_err(usbi_transfer_ctx(transfer), "submiturb failed, errno=%d", errno);
 			r = LIBUSB_ERROR_IO;
 		}
 
 		/* if the first URB submission fails, we can simply free up and
 		 * return failure immediately. */
 		if (i == 0) {
-			usbi_dbg(TRANSFER_CTX(transfer), "first URB failed, easy peasy");
+			usbi_dbg(usbi_transfer_ctx(transfer), "first URB failed, easy peasy");
 			free(urbs);
 			tpriv->urbs = NULL;
 			return r;
@@ -2300,7 +2300,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 
 		discard_urbs(itransfer, 0, i);
 
-		usbi_dbg(TRANSFER_CTX(transfer), "reporting successful submission but waiting for %d "
+		usbi_dbg(usbi_transfer_ctx(transfer), "reporting successful submission but waiting for %d "
 			 "discards before reporting error", i);
 		return 0;
 	}
@@ -2311,7 +2311,7 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer)
 static int submit_iso_transfer(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	struct linux_device_handle_priv *hpriv =
 		(struct linux_device_handle_priv *)usbi_get_device_handle_priv(transfer->dev_handle);
@@ -2336,7 +2336,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		packet_len = transfer->iso_packet_desc[i].length;
 
 		if (packet_len > max_iso_packet_len) {
-			usbi_warn(TRANSFER_CTX(transfer),
+			usbi_warn(usbi_transfer_ctx(transfer),
 				  "iso packet length of %u bytes exceeds maximum of %u bytes",
 				  packet_len, max_iso_packet_len);
 			return LIBUSB_ERROR_INVALID_PARAM;
@@ -2351,7 +2351,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 	/* usbfs limits the number of iso packets per URB */
 	num_urbs = (num_packets + (MAX_ISO_PACKETS_PER_URB - 1)) / MAX_ISO_PACKETS_PER_URB;
 
-	usbi_dbg(TRANSFER_CTX(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
+	usbi_dbg(usbi_transfer_ctx(transfer), "need %d urbs for new transfer with length %d", num_urbs, transfer->length);
 
 	urbs = (struct usbfs_urb **)calloc(num_urbs, sizeof(*urbs));
 	if (!urbs)
@@ -2409,20 +2409,20 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		if (errno == ENODEV) {
 			r = LIBUSB_ERROR_NO_DEVICE;
 		} else if (errno == EINVAL) {
-			usbi_warn(TRANSFER_CTX(transfer), "submiturb failed, transfer too large");
+			usbi_warn(usbi_transfer_ctx(transfer), "submiturb failed, transfer too large");
 			r = LIBUSB_ERROR_INVALID_PARAM;
 		} else if (errno == EMSGSIZE) {
-			usbi_warn(TRANSFER_CTX(transfer), "submiturb failed, iso packet length too large");
+			usbi_warn(usbi_transfer_ctx(transfer), "submiturb failed, iso packet length too large");
 			r = LIBUSB_ERROR_INVALID_PARAM;
 		} else {
-			usbi_err(TRANSFER_CTX(transfer), "submiturb failed, errno=%d", errno);
+			usbi_err(usbi_transfer_ctx(transfer), "submiturb failed, errno=%d", errno);
 			r = LIBUSB_ERROR_IO;
 		}
 
 		/* if the first URB submission fails, we can simply free up and
 		 * return failure immediately. */
 		if (i == 0) {
-			usbi_dbg(TRANSFER_CTX(transfer), "first URB failed, easy peasy");
+			usbi_dbg(usbi_transfer_ctx(transfer), "first URB failed, easy peasy");
 			free_iso_urbs(tpriv);
 			return r;
 		}
@@ -2447,7 +2447,7 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer)
 		tpriv->num_retired = num_urbs - i;
 		discard_urbs(itransfer, 0, i);
 
-		usbi_dbg(TRANSFER_CTX(transfer), "reporting successful submission but waiting for %d "
+		usbi_dbg(usbi_transfer_ctx(transfer), "reporting successful submission but waiting for %d "
 			 "discards before reporting error", i);
 		return 0;
 	}
@@ -2459,7 +2459,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer)
 {
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_device_handle_priv *hpriv =
 		(struct linux_device_handle_priv *)usbi_get_device_handle_priv(transfer->dev_handle);
 	struct usbfs_urb *urb;
@@ -2488,7 +2488,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer)
 		if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(TRANSFER_CTX(transfer), "submiturb failed, errno=%d", errno);
+		usbi_err(usbi_transfer_ctx(transfer), "submiturb failed, errno=%d", errno);
 		return LIBUSB_ERROR_IO;
 	}
 	return 0;
@@ -2497,7 +2497,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer)
 static int op_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
@@ -2510,7 +2510,7 @@ static int op_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfe
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
 		return submit_iso_transfer(itransfer);
 	default:
-		usbi_err(TRANSFER_CTX(transfer), "unknown transfer type %u", transfer->type);
+		usbi_err(usbi_transfer_ctx(transfer), "unknown transfer type %u", transfer->type);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 }
@@ -2519,7 +2519,7 @@ static int op_cancel_transfer(struct usbi_transfer *itransfer)
 {
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	int r;
 
 	if (!tpriv->urbs)
@@ -2545,7 +2545,7 @@ static int op_cancel_transfer(struct usbi_transfer *itransfer)
 static void op_clear_transfer_priv(struct usbi_transfer *itransfer)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
 	switch (transfer->type) {
@@ -2565,7 +2565,7 @@ static void op_clear_transfer_priv(struct usbi_transfer *itransfer)
 		}
 		break;
 	default:
-		usbi_err(TRANSFER_CTX(transfer), "unknown transfer type %u", transfer->type);
+		usbi_err(usbi_transfer_ctx(transfer), "unknown transfer type %u", transfer->type);
 	}
 }
 
@@ -2573,18 +2573,18 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	struct usbfs_urb *urb)
 {
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	int urb_idx = urb - tpriv->urbs;
 
 	usbi_mutex_lock(&itransfer->lock);
-	usbi_dbg(TRANSFER_CTX(transfer), "handling completion status %d of bulk urb %d/%d", urb->status,
+	usbi_dbg(usbi_transfer_ctx(transfer), "handling completion status %d of bulk urb %d/%d", urb->status,
 		 urb_idx + 1, tpriv->num_urbs);
 
 	tpriv->num_retired++;
 
 	if (tpriv->reap_action != NORMAL) {
 		/* cancelled, submit_fail, or completed early */
-		usbi_dbg(TRANSFER_CTX(transfer), "abnormal reap: urb status %d", urb->status);
+		usbi_dbg(usbi_transfer_ctx(transfer), "abnormal reap: urb status %d", urb->status);
 
 		/* even though we're in the process of cancelling, it's possible that
 		 * we may receive some data in these URBs that we don't want to lose.
@@ -2605,9 +2605,9 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		if (urb->actual_length > 0) {
 			unsigned char *target = transfer->buffer + itransfer->transferred;
 
-			usbi_dbg(TRANSFER_CTX(transfer), "received %d bytes of surplus data", urb->actual_length);
+			usbi_dbg(usbi_transfer_ctx(transfer), "received %d bytes of surplus data", urb->actual_length);
 			if (urb->buffer != target) {
-				usbi_dbg(TRANSFER_CTX(transfer), "moving surplus data from offset %zu to offset %zu",
+				usbi_dbg(usbi_transfer_ctx(transfer), "moving surplus data from offset %zu to offset %zu",
 					 (unsigned char *)urb->buffer - transfer->buffer,
 					 target - transfer->buffer);
 				memmove(target, urb->buffer, urb->actual_length);
@@ -2616,7 +2616,7 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		}
 
 		if (tpriv->num_retired == tpriv->num_urbs) {
-			usbi_dbg(TRANSFER_CTX(transfer), "abnormal reap: last URB handled, reporting");
+			usbi_dbg(usbi_transfer_ctx(transfer), "abnormal reap: last URB handled, reporting");
 			if (tpriv->reap_action != COMPLETED_EARLY &&
 			    tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 				tpriv->reap_status = LIBUSB_TRANSFER_ERROR;
@@ -2640,17 +2640,17 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 		break;
 	case -ENODEV:
 	case -ESHUTDOWN:
-		usbi_dbg(TRANSFER_CTX(transfer), "device removed");
+		usbi_dbg(usbi_transfer_ctx(transfer), "device removed");
 		tpriv->reap_status = LIBUSB_TRANSFER_NO_DEVICE;
 		goto cancel_remaining;
 	case -EPIPE:
-		usbi_dbg(TRANSFER_CTX(transfer), "detected endpoint stall");
+		usbi_dbg(usbi_transfer_ctx(transfer), "detected endpoint stall");
 		if (tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 			tpriv->reap_status = LIBUSB_TRANSFER_STALL;
 		goto cancel_remaining;
 	case -EOVERFLOW:
 		/* overflow can only ever occur in the last urb */
-		usbi_dbg(TRANSFER_CTX(transfer), "overflow, actual_length=%d", urb->actual_length);
+		usbi_dbg(usbi_transfer_ctx(transfer), "overflow, actual_length=%d", urb->actual_length);
 		if (tpriv->reap_status == LIBUSB_TRANSFER_COMPLETED)
 			tpriv->reap_status = LIBUSB_TRANSFER_OVERFLOW;
 		goto completed;
@@ -2659,11 +2659,11 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	case -EILSEQ:
 	case -ECOMM:
 	case -ENOSR:
-		usbi_dbg(TRANSFER_CTX(transfer), "low-level bus error %d", urb->status);
+		usbi_dbg(usbi_transfer_ctx(transfer), "low-level bus error %d", urb->status);
 		tpriv->reap_action = ERROR;
 		goto cancel_remaining;
 	default:
-		usbi_warn(ITRANSFER_CTX(itransfer), "unrecognised urb status %d", urb->status);
+		usbi_warn(usbi_itransfer_ctx(itransfer), "unrecognised urb status %d", urb->status);
 		tpriv->reap_action = ERROR;
 		goto cancel_remaining;
 	}
@@ -2671,10 +2671,10 @@ static int handle_bulk_completion(struct usbi_transfer *itransfer,
 	/* if we've reaped all urbs or we got less data than requested then we're
 	 * done */
 	if (tpriv->num_retired == tpriv->num_urbs) {
-		usbi_dbg(TRANSFER_CTX(transfer), "all URBs in transfer reaped --> complete!");
+		usbi_dbg(usbi_transfer_ctx(transfer), "all URBs in transfer reaped --> complete!");
 		goto completed;
 	} else if (urb->actual_length < urb->buffer_length) {
-		usbi_dbg(TRANSFER_CTX(transfer), "short transfer %d/%d --> complete!",
+		usbi_dbg(usbi_transfer_ctx(transfer), "short transfer %d/%d --> complete!",
 			 urb->actual_length, urb->buffer_length);
 		if (tpriv->reap_action == NORMAL)
 			tpriv->reap_action = COMPLETED_EARLY;
@@ -2710,7 +2710,7 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 	struct usbfs_urb *urb)
 {
 	struct libusb_transfer *transfer =
-		USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		usbi_transfer_to_libusb_transfer(itransfer);
 	struct linux_transfer_priv *tpriv = (struct linux_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	int num_urbs = tpriv->num_urbs;
 	int urb_idx = 0;
@@ -2725,12 +2725,12 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		}
 	}
 	if (urb_idx == 0) {
-		usbi_err(TRANSFER_CTX(transfer), "could not locate urb!");
+		usbi_err(usbi_transfer_ctx(transfer), "could not locate urb!");
 		usbi_mutex_unlock(&itransfer->lock);
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(TRANSFER_CTX(transfer), "handling completion status %d of iso urb %d/%d", urb->status,
+	usbi_dbg(usbi_transfer_ctx(transfer), "handling completion status %d of iso urb %d/%d", urb->status,
 		 urb_idx, num_urbs);
 
 	/* copy isochronous results back in */
@@ -2751,15 +2751,15 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 			break;
 		case -ENODEV:
 		case -ESHUTDOWN:
-			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - device removed", i);
+			usbi_dbg(usbi_transfer_ctx(transfer), "packet %d - device removed", i);
 			lib_desc->status = LIBUSB_TRANSFER_NO_DEVICE;
 			break;
 		case -EPIPE:
-			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - detected endpoint stall", i);
+			usbi_dbg(usbi_transfer_ctx(transfer), "packet %d - detected endpoint stall", i);
 			lib_desc->status = LIBUSB_TRANSFER_STALL;
 			break;
 		case -EOVERFLOW:
-			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - overflow error", i);
+			usbi_dbg(usbi_transfer_ctx(transfer), "packet %d - overflow error", i);
 			lib_desc->status = LIBUSB_TRANSFER_OVERFLOW;
 			break;
 		case -ETIME:
@@ -2768,11 +2768,11 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		case -ECOMM:
 		case -ENOSR:
 		case -EXDEV:
-			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - low-level USB error %d", i, packet_status);
+			usbi_dbg(usbi_transfer_ctx(transfer), "packet %d - low-level USB error %d", i, packet_status);
 			lib_desc->status = LIBUSB_TRANSFER_ERROR;
 			break;
 		default:
-			usbi_warn(TRANSFER_CTX(transfer), "packet %d - unrecognised urb status %d",
+			usbi_warn(usbi_transfer_ctx(transfer), "packet %d - unrecognised urb status %d",
 				  i, packet_status);
 			lib_desc->status = LIBUSB_TRANSFER_ERROR;
 			break;
@@ -2783,10 +2783,10 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 	tpriv->num_retired++;
 
 	if (tpriv->reap_action != NORMAL) { /* cancelled or submit_fail */
-		usbi_dbg(TRANSFER_CTX(transfer), "CANCEL: urb status %d", urb->status);
+		usbi_dbg(usbi_transfer_ctx(transfer), "CANCEL: urb status %d", urb->status);
 
 		if (tpriv->num_retired == num_urbs) {
-			usbi_dbg(TRANSFER_CTX(transfer), "CANCEL: last URB handled, reporting");
+			usbi_dbg(usbi_transfer_ctx(transfer), "CANCEL: last URB handled, reporting");
 			free_iso_urbs(tpriv);
 			if (tpriv->reap_action == CANCELLED) {
 				usbi_mutex_unlock(&itransfer->lock);
@@ -2806,18 +2806,18 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 	case -ECONNRESET:
 		break;
 	case -ESHUTDOWN:
-		usbi_dbg(TRANSFER_CTX(transfer), "device removed");
+		usbi_dbg(usbi_transfer_ctx(transfer), "device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;
 	default:
-		usbi_warn(TRANSFER_CTX(transfer), "unrecognised urb status %d", urb->status);
+		usbi_warn(usbi_transfer_ctx(transfer), "unrecognised urb status %d", urb->status);
 		status = LIBUSB_TRANSFER_ERROR;
 		break;
 	}
 
 	/* if we've reaped all urbs then we're done */
 	if (tpriv->num_retired == num_urbs) {
-		usbi_dbg(TRANSFER_CTX(transfer), "all URBs in transfer reaped --> complete!");
+		usbi_dbg(usbi_transfer_ctx(transfer), "all URBs in transfer reaped --> complete!");
 		free_iso_urbs(tpriv);
 		usbi_mutex_unlock(&itransfer->lock);
 		return usbi_handle_transfer_completion(itransfer, status);
@@ -2835,13 +2835,13 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 	int status;
 
 	usbi_mutex_lock(&itransfer->lock);
-	usbi_dbg(ITRANSFER_CTX(itransfer), "handling completion status %d", urb->status);
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "handling completion status %d", urb->status);
 
 	itransfer->transferred += urb->actual_length;
 
 	if (tpriv->reap_action == CANCELLED) {
 		if (urb->status && urb->status != -ENOENT)
-			usbi_warn(ITRANSFER_CTX(itransfer), "cancel: unrecognised urb status %d",
+			usbi_warn(usbi_itransfer_ctx(itransfer), "cancel: unrecognised urb status %d",
 				  urb->status);
 		free(tpriv->urbs);
 		tpriv->urbs = NULL;
@@ -2858,15 +2858,15 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 		break;
 	case -ENODEV:
 	case -ESHUTDOWN:
-		usbi_dbg(ITRANSFER_CTX(itransfer), "device removed");
+		usbi_dbg(usbi_itransfer_ctx(itransfer), "device removed");
 		status = LIBUSB_TRANSFER_NO_DEVICE;
 		break;
 	case -EPIPE:
-		usbi_dbg(ITRANSFER_CTX(itransfer), "unsupported control request");
+		usbi_dbg(usbi_itransfer_ctx(itransfer), "unsupported control request");
 		status = LIBUSB_TRANSFER_STALL;
 		break;
 	case -EOVERFLOW:
-		usbi_dbg(ITRANSFER_CTX(itransfer), "overflow, actual_length=%d", urb->actual_length);
+		usbi_dbg(usbi_itransfer_ctx(itransfer), "overflow, actual_length=%d", urb->actual_length);
 		status = LIBUSB_TRANSFER_OVERFLOW;
 		break;
 	case -ETIME:
@@ -2874,11 +2874,11 @@ static int handle_control_completion(struct usbi_transfer *itransfer,
 	case -EILSEQ:
 	case -ECOMM:
 	case -ENOSR:
-		usbi_dbg(ITRANSFER_CTX(itransfer), "low-level bus error %d", urb->status);
+		usbi_dbg(usbi_itransfer_ctx(itransfer), "low-level bus error %d", urb->status);
 		status = LIBUSB_TRANSFER_ERROR;
 		break;
 	default:
-		usbi_warn(ITRANSFER_CTX(itransfer), "unrecognised urb status %d", urb->status);
+		usbi_warn(usbi_itransfer_ctx(itransfer), "unrecognised urb status %d", urb->status);
 		status = LIBUSB_TRANSFER_ERROR;
 		break;
 	}
@@ -2904,14 +2904,14 @@ static int reap_for_handle(struct libusb_device_handle *handle)
 		if (errno == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 
-		usbi_err(HANDLE_CTX(handle), "reap failed, errno=%d", errno);
+		usbi_err(usbi_handle_ctx(handle), "reap failed, errno=%d", errno);
 		return LIBUSB_ERROR_IO;
 	}
 
 	itransfer = (struct usbi_transfer *)urb->usercontext;
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
-	usbi_dbg(HANDLE_CTX(handle), "urb type=%u status=%d transferred=%d", urb->type, urb->status, urb->actual_length);
+	usbi_dbg(usbi_handle_ctx(handle), "urb type=%u status=%d transferred=%d", urb->type, urb->status, urb->actual_length);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
@@ -2923,7 +2923,7 @@ static int reap_for_handle(struct libusb_device_handle *handle)
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		return handle_control_completion(itransfer, urb);
 	default:
-		usbi_err(HANDLE_CTX(handle), "unrecognised transfer type %u", transfer->type);
+		usbi_err(usbi_handle_ctx(handle), "unrecognised transfer type %u", transfer->type);
 		return LIBUSB_ERROR_OTHER;
 	}
 }
@@ -2962,7 +2962,7 @@ static int op_handle_events(struct libusb_context *ctx,
 			/* remove the fd from the pollfd set so that it doesn't continuously
 			 * trigger an event, and flag that it has been removed so op_close()
 			 * doesn't try to remove it a second time */
-			usbi_remove_event_source(HANDLE_CTX(handle), hpriv->fd);
+			usbi_remove_event_source(usbi_handle_ctx(handle), hpriv->fd);
 			hpriv->fd_removed = 1;
 
 			/* device will still be marked as attached if hotplug monitor thread

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -210,7 +210,7 @@ netbsd_open(struct libusb_device_handle *handle)
 	for (i = 0; i < USB_MAX_ENDPOINTS; i++)
 		hpriv->endpoints[i] = -1;
 
-	usbi_dbg(HANDLE_CTX(handle), "open %s: fd %d", dpriv->devnode, dpriv->fd);
+	usbi_dbg(usbi_handle_ctx(handle), "open %s: fd %d", dpriv->devnode, dpriv->fd);
 
 	return LIBUSB_SUCCESS;
 }
@@ -220,7 +220,7 @@ netbsd_close(struct libusb_device_handle *handle)
 {
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 
-	usbi_dbg(HANDLE_CTX(handle), "close: fd %d", dpriv->fd);
+	usbi_dbg(usbi_handle_ctx(handle), "close: fd %d", dpriv->fd);
 
 	close(dpriv->fd);
 	dpriv->fd = -1;
@@ -234,7 +234,7 @@ netbsd_get_active_config_descriptor(struct libusb_device *dev,
 
 	len = MIN(len, (size_t)UGETW(dpriv->cdesc->wTotalLength));
 
-	usbi_dbg(DEVICE_CTX(dev), "len %zu", len);
+	usbi_dbg(usbi_device_ctx(dev), "len %zu", len);
 
 	memcpy(buf, dpriv->cdesc, len);
 
@@ -249,7 +249,7 @@ netbsd_get_config_descriptor(struct libusb_device *dev, uint8_t idx,
 	struct usb_full_desc ufd;
 	int fd, err;
 
-	usbi_dbg(DEVICE_CTX(dev), "index %u, len %zu", idx, len);
+	usbi_dbg(usbi_device_ctx(dev), "index %u, len %zu", idx, len);
 
 	/* A config descriptor may be requested before opening the device */
 	if (dpriv->fd >= 0) {
@@ -283,12 +283,12 @@ netbsd_get_configuration(struct libusb_device_handle *handle, uint8_t *config)
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 	int tmp;
 
-	usbi_dbg(HANDLE_CTX(handle), " ");
+	usbi_dbg(usbi_handle_ctx(handle), " ");
 
 	if (ioctl(dpriv->fd, USB_GET_CONFIG, &tmp) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg(HANDLE_CTX(handle), "configuration %d", tmp);
+	usbi_dbg(usbi_handle_ctx(handle), "configuration %d", tmp);
 	*config = (uint8_t)tmp;
 
 	return LIBUSB_SUCCESS;
@@ -299,7 +299,7 @@ netbsd_set_configuration(struct libusb_device_handle *handle, int config)
 {
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 
-	usbi_dbg(HANDLE_CTX(handle), "configuration %d", config);
+	usbi_dbg(usbi_handle_ctx(handle), "configuration %d", config);
 
 	if (ioctl(dpriv->fd, USB_SET_CONFIG, &config) < 0)
 		return _errno_to_libusb(errno);
@@ -343,7 +343,7 @@ netbsd_set_interface_altsetting(struct libusb_device_handle *handle, uint8_t ifa
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 	struct usb_alt_interface intf;
 
-	usbi_dbg(HANDLE_CTX(handle), "iface %u, setting %u", iface, altsetting);
+	usbi_dbg(usbi_handle_ctx(handle), "iface %u, setting %u", iface, altsetting);
 
 	memset(&intf, 0, sizeof(intf));
 
@@ -362,7 +362,7 @@ netbsd_clear_halt(struct libusb_device_handle *handle, unsigned char endpoint)
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 	struct usb_ctl_request req;
 
-	usbi_dbg(HANDLE_CTX(handle), " ");
+	usbi_dbg(usbi_handle_ctx(handle), " ");
 
 	req.ucr_request.bmRequestType = UT_WRITE_ENDPOINT;
 	req.ucr_request.bRequest = UR_CLEAR_FEATURE;
@@ -381,7 +381,7 @@ netbsd_destroy_device(struct libusb_device *dev)
 {
 	struct device_priv *dpriv = usbi_get_device_priv(dev);
 
-	usbi_dbg(DEVICE_CTX(dev), " ");
+	usbi_dbg(usbi_device_ctx(dev), " ");
 
 	free(dpriv->cdesc);
 }
@@ -392,16 +392,16 @@ netbsd_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock
 	struct libusb_transfer *transfer;
 	int err = 0;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
+	usbi_dbg(usbi_itransfer_ctx(itransfer), " ");
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		err = _sync_control_transfer(itransfer);
 		break;
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
-		if (IS_XFEROUT(transfer)) {
+		if (usbi_is_xferout(transfer)) {
 			/* Isochronous write is not supported */
 			err = LIBUSB_ERROR_NOT_SUPPORTED;
 			break;
@@ -410,7 +410,7 @@ netbsd_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock
 		break;
 	case LIBUSB_TRANSFER_TYPE_BULK:
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
-		if (IS_XFEROUT(transfer) &&
+		if (usbi_is_xferout(transfer) &&
 		    transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET) {
 			err = LIBUSB_ERROR_NOT_SUPPORTED;
 			break;
@@ -435,7 +435,7 @@ netbsd_cancel_transfer(struct usbi_transfer *itransfer)
 {
 	UNUSED(itransfer);
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
+	usbi_dbg(usbi_itransfer_ctx(itransfer), " ");
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }
@@ -477,14 +477,14 @@ _cache_active_config_descriptor(struct libusb_device *dev, int fd)
 	void *buf;
 	int len;
 
-	usbi_dbg(DEVICE_CTX(dev), "fd %d", fd);
+	usbi_dbg(usbi_device_ctx(dev), "fd %d", fd);
 
 	ucd.ucd_config_index = USB_CURRENT_CONFIG_INDEX;
 
 	if (ioctl(fd, USB_GET_CONFIG_DESC, &ucd) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg(DEVICE_CTX(dev), "active bLength %d", ucd.ucd_desc.bLength);
+	usbi_dbg(usbi_device_ctx(dev), "active bLength %d", ucd.ucd_desc.bLength);
 
 	len = UGETW(ucd.ucd_desc.wTotalLength);
 	buf = malloc((size_t)len);
@@ -495,7 +495,7 @@ _cache_active_config_descriptor(struct libusb_device *dev, int fd)
 	ufd.ufd_size = len;
 	ufd.ufd_data = buf;
 
-	usbi_dbg(DEVICE_CTX(dev), "index %d, len %d", ufd.ufd_config_index, len);
+	usbi_dbg(usbi_device_ctx(dev), "index %d, len %d", ufd.ufd_config_index, len);
 
 	if (ioctl(fd, USB_GET_FULL_DESC, &ufd) < 0) {
 		free(buf);
@@ -517,11 +517,11 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 	struct device_priv *dpriv;
 	struct usb_ctl_request req;
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 	setup = (struct libusb_control_setup *)transfer->buffer;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
 	    setup->bmRequestType, setup->bRequest,
 	    libusb_le16_to_cpu(setup->wValue),
 	    libusb_le16_to_cpu(setup->wIndex),
@@ -546,7 +546,7 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 
 	itransfer->transferred = req.ucr_actlen;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "transferred %d", itransfer->transferred);
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "transferred %d", itransfer->transferred);
 
 	return 0;
 }
@@ -564,9 +564,9 @@ _access_endpoint(struct libusb_transfer *transfer)
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 
 	endpt = UE_GET_ADDR(transfer->endpoint);
-	mode = IS_XFERIN(transfer) ? O_RDONLY : O_WRONLY;
+	mode = usbi_is_xferin(transfer) ? O_RDONLY : O_WRONLY;
 
-	usbi_dbg(TRANSFER_CTX(transfer), "endpoint %d mode %d", endpt, mode);
+	usbi_dbg(usbi_transfer_ctx(transfer), "endpoint %d mode %d", endpt, mode);
 
 	if (hpriv->endpoints[endpt] < 0) {
 		/* Pick the right node given the control one */
@@ -591,7 +591,7 @@ _sync_gen_transfer(struct usbi_transfer *itransfer)
 	struct libusb_transfer *transfer;
 	int fd, nr = 1;
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	/*
 	 * Bulk, Interrupt or Isochronous transfer depends on the
@@ -603,7 +603,7 @@ _sync_gen_transfer(struct usbi_transfer *itransfer)
 	if (ioctl(fd, USB_SET_TIMEOUT, &transfer->timeout) < 0)
 		return _errno_to_libusb(errno);
 
-	if (IS_XFERIN(transfer)) {
+	if (usbi_is_xferin(transfer)) {
 		if ((transfer->flags & LIBUSB_TRANSFER_SHORT_NOT_OK) == 0)
 			if (ioctl(fd, USB_SET_SHORT_XFER, &nr) < 0)
 				return _errno_to_libusb(errno);

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -243,7 +243,7 @@ obsd_open(struct libusb_device_handle *handle)
 			return _errno_to_libusb(errno);
 		dpriv->fd = fd;
 
-		usbi_dbg(HANDLE_CTX(handle), "open %s: fd %d", devnode, dpriv->fd);
+		usbi_dbg(usbi_handle_ctx(handle), "open %s: fd %d", devnode, dpriv->fd);
 	}
 
 	return LIBUSB_SUCCESS;
@@ -255,7 +255,7 @@ obsd_close(struct libusb_device_handle *handle)
 	struct device_priv *dpriv = usbi_get_device_priv(handle->dev);
 
 	if (dpriv->devname) {
-		usbi_dbg(HANDLE_CTX(handle), "close: fd %d", dpriv->fd);
+		usbi_dbg(usbi_handle_ctx(handle), "close: fd %d", dpriv->fd);
 
 		close(dpriv->fd);
 		dpriv->fd = -1;
@@ -270,7 +270,7 @@ obsd_get_active_config_descriptor(struct libusb_device *dev,
 
 	len = MIN(len, (size_t)UGETW(dpriv->cdesc->wTotalLength));
 
-	usbi_dbg(DEVICE_CTX(dev), "len %zu", len);
+	usbi_dbg(usbi_device_ctx(dev), "len %zu", len);
 
 	memcpy(buf, dpriv->cdesc, len);
 
@@ -293,7 +293,7 @@ obsd_get_config_descriptor(struct libusb_device *dev, uint8_t idx,
 	udf.udf_size = len;
 	udf.udf_data = buf;
 
-	usbi_dbg(DEVICE_CTX(dev), "index %d, len %zu", udf.udf_config_index, len);
+	usbi_dbg(usbi_device_ctx(dev), "index %d, len %zu", udf.udf_config_index, len);
 
 	if (ioctl(fd, USB_DEVICE_GET_FDESC, &udf) < 0) {
 		err = errno;
@@ -312,7 +312,7 @@ obsd_get_configuration(struct libusb_device_handle *handle, uint8_t *config)
 
 	*config = dpriv->cdesc->bConfigurationValue;
 
-	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %u", *config);
+	usbi_dbg(usbi_handle_ctx(handle), "bConfigurationValue %u", *config);
 
 	return LIBUSB_SUCCESS;
 }
@@ -325,7 +325,7 @@ obsd_set_configuration(struct libusb_device_handle *handle, int config)
 	if (dpriv->devname == NULL)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
-	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %d", config);
+	usbi_dbg(usbi_handle_ctx(handle), "bConfigurationValue %d", config);
 
 	if (ioctl(dpriv->fd, USB_SET_CONFIG, &config) < 0)
 		return _errno_to_libusb(errno);
@@ -372,7 +372,7 @@ obsd_set_interface_altsetting(struct libusb_device_handle *handle, uint8_t iface
 	if (dpriv->devname == NULL)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
-	usbi_dbg(HANDLE_CTX(handle), "iface %u, setting %u", iface, altsetting);
+	usbi_dbg(usbi_handle_ctx(handle), "iface %u, setting %u", iface, altsetting);
 
 	memset(&intf, 0, sizeof(intf));
 
@@ -394,7 +394,7 @@ obsd_clear_halt(struct libusb_device_handle *handle, unsigned char endpoint)
 	if ((fd = _bus_open(handle->dev->bus_number)) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg(HANDLE_CTX(handle), " ");
+	usbi_dbg(usbi_handle_ctx(handle), " ");
 
 	req.ucr_addr = handle->dev->device_address;
 	req.ucr_request.bmRequestType = UT_WRITE_ENDPOINT;
@@ -418,7 +418,7 @@ obsd_destroy_device(struct libusb_device *dev)
 {
 	struct device_priv *dpriv = usbi_get_device_priv(dev);
 
-	usbi_dbg(DEVICE_CTX(dev), " ");
+	usbi_dbg(usbi_device_ctx(dev), " ");
 
 	free(dpriv->cdesc);
 	free(dpriv->devname);
@@ -430,16 +430,16 @@ obsd_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 	struct libusb_transfer *transfer;
 	int err = 0;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
+	usbi_dbg(usbi_itransfer_ctx(itransfer), " ");
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		err = _sync_control_transfer(itransfer);
 		break;
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
-		if (IS_XFEROUT(transfer)) {
+		if (usbi_is_xferout(transfer)) {
 			/* Isochronous write is not supported */
 			err = LIBUSB_ERROR_NOT_SUPPORTED;
 			break;
@@ -448,7 +448,7 @@ obsd_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 		break;
 	case LIBUSB_TRANSFER_TYPE_BULK:
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
-		if (IS_XFEROUT(transfer) &&
+		if (usbi_is_xferout(transfer) &&
 		    transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET) {
 			err = LIBUSB_ERROR_NOT_SUPPORTED;
 			break;
@@ -473,7 +473,7 @@ obsd_cancel_transfer(struct usbi_transfer *itransfer)
 {
 	UNUSED(itransfer);
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), " ");
+	usbi_dbg(usbi_itransfer_ctx(itransfer), " ");
 
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }
@@ -517,7 +517,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 	if ((fd = _bus_open(dev->bus_number)) < 0)
 		return _errno_to_libusb(errno);
 
-	usbi_dbg(DEVICE_CTX(dev), "fd %d, addr %d", fd, dev->device_address);
+	usbi_dbg(usbi_device_ctx(dev), "fd %d, addr %d", fd, dev->device_address);
 
 	udc.udc_bus = dev->bus_number;
 	udc.udc_addr = dev->device_address;
@@ -528,7 +528,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 		return _errno_to_libusb(errno);
 	}
 
-	usbi_dbg(DEVICE_CTX(dev), "active bLength %d", udc.udc_desc.bLength);
+	usbi_dbg(usbi_device_ctx(dev), "active bLength %d", udc.udc_desc.bLength);
 
 	len = UGETW(udc.udc_desc.wTotalLength);
 	buf = malloc((size_t)len);
@@ -541,7 +541,7 @@ _cache_active_config_descriptor(struct libusb_device *dev)
 	udf.udf_size = len;
 	udf.udf_data = buf;
 
-	usbi_dbg(DEVICE_CTX(dev), "index %d, len %d", udf.udf_config_index, len);
+	usbi_dbg(usbi_device_ctx(dev), "index %d, len %d", udf.udf_config_index, len);
 
 	if (ioctl(fd, USB_DEVICE_GET_FDESC, &udf) < 0) {
 		err = errno;
@@ -566,11 +566,11 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 	struct device_priv *dpriv;
 	struct usb_ctl_request req;
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 	setup = (struct libusb_control_setup *)transfer->buffer;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "type 0x%x request 0x%x value 0x%x index %d length %d timeout %d",
 	    setup->bmRequestType, setup->bRequest,
 	    libusb_le16_to_cpu(setup->wValue),
 	    libusb_le16_to_cpu(setup->wIndex),
@@ -615,7 +615,7 @@ _sync_control_transfer(struct usbi_transfer *itransfer)
 
 	itransfer->transferred = req.ucr_actlen;
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "transferred %d", itransfer->transferred);
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "transferred %d", itransfer->transferred);
 
 	return 0;
 }
@@ -633,9 +633,9 @@ _access_endpoint(struct libusb_transfer *transfer)
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 
 	endpt = UE_GET_ADDR(transfer->endpoint);
-	mode = IS_XFERIN(transfer) ? O_RDONLY : O_WRONLY;
+	mode = usbi_is_xferin(transfer) ? O_RDONLY : O_WRONLY;
 
-	usbi_dbg(TRANSFER_CTX(transfer), "endpoint %d mode %d", endpt, mode);
+	usbi_dbg(usbi_transfer_ctx(transfer), "endpoint %d mode %d", endpt, mode);
 
 	if (hpriv->endpoints[endpt] < 0) {
 		/* Pick the right endpoint node */
@@ -660,7 +660,7 @@ _sync_gen_transfer(struct usbi_transfer *itransfer)
 	struct device_priv *dpriv;
 	int fd, nr = 1;
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	dpriv = usbi_get_device_priv(transfer->dev_handle->dev);
 
 	if (dpriv->devname == NULL)
@@ -676,7 +676,7 @@ _sync_gen_transfer(struct usbi_transfer *itransfer)
 	if (ioctl(fd, USB_SET_TIMEOUT, &transfer->timeout) < 0)
 		return _errno_to_libusb(errno);
 
-	if (IS_XFERIN(transfer)) {
+	if (usbi_is_xferin(transfer)) {
 		if ((transfer->flags & LIBUSB_TRANSFER_SHORT_NOT_OK) == 0)
 			if (ioctl(fd, USB_SET_SHORT_XFER, &nr) < 0)
 				return _errno_to_libusb(errno);

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -170,17 +170,17 @@ sunos_usb_ioctl(struct libusb_device *dev, int cmd)
 		return (-1);
 	}
 	end++;
-	usbi_dbg(DEVICE_CTX(dev), "unitaddr: %s", end);
+	usbi_dbg(usbi_device_ctx(dev), "unitaddr: %s", end);
 
 	nvlist_alloc(&nvlist, NV_UNIQUE_NAME_TYPE, KM_NOSLEEP);
 	nvlist_add_int32(nvlist, "port", dev->port_number);
 	/* find the hub path */
 	snprintf(path_arg, sizeof(path_arg), "/devices%s:hubd", hubpath);
-	usbi_dbg(DEVICE_CTX(dev), "ioctl hub path: %s", path_arg);
+	usbi_dbg(usbi_device_ctx(dev), "ioctl hub path: %s", path_arg);
 
 	fd = open(path_arg, O_RDONLY);
 	if (fd < 0) {
-		usbi_err(DEVICE_CTX(dev), "open failed: errno %d (%s)", errno, strerror(errno));
+		usbi_err(usbi_device_ctx(dev), "open failed: errno %d (%s)", errno, strerror(errno));
 		nvlist_free(nvlist);
 		free(hubpath);
 		return (-1);
@@ -196,21 +196,21 @@ sunos_usb_ioctl(struct libusb_device *dev, int cmd)
 	iocdata.c_nodename = (char *)"hub";
 	iocdata.c_unitaddr = end;
 	iocdata.cpyout_buf = &devctl_ap_state;
-	usbi_dbg(DEVICE_CTX(dev), "%p, %" PRIuPTR, iocdata.nvl_user, iocdata.nvl_usersz);
+	usbi_dbg(usbi_device_ctx(dev), "%p, %" PRIuPTR, iocdata.nvl_user, iocdata.nvl_usersz);
 
 	errno = 0;
 	if (ioctl(fd, DEVCTL_AP_GETSTATE, &iocdata) == -1) {
-		usbi_err(DEVICE_CTX(dev), "ioctl failed: fd %d, cmd %x, errno %d (%s)",
+		usbi_err(usbi_device_ctx(dev), "ioctl failed: fd %d, cmd %x, errno %d (%s)",
 			 fd, DEVCTL_AP_GETSTATE, errno, strerror(errno));
 	} else {
-		usbi_dbg(DEVICE_CTX(dev), "dev rstate: %d", devctl_ap_state.ap_rstate);
-		usbi_dbg(DEVICE_CTX(dev), "dev ostate: %d", devctl_ap_state.ap_ostate);
+		usbi_dbg(usbi_device_ctx(dev), "dev rstate: %d", devctl_ap_state.ap_rstate);
+		usbi_dbg(usbi_device_ctx(dev), "dev ostate: %d", devctl_ap_state.ap_ostate);
 	}
 
 	errno = 0;
 	iocdata.cmd = cmd;
 	if (ioctl(fd, (int)cmd, &iocdata) != 0) {
-		usbi_err(DEVICE_CTX(dev), "ioctl failed: fd %d, cmd %x, errno %d (%s)",
+		usbi_err(usbi_device_ctx(dev), "ioctl failed: fd %d, cmd %x, errno %d (%s)",
 			 fd, cmd, errno, strerror(errno));
 		sleep(2);
 	}
@@ -230,7 +230,7 @@ sunos_kernel_driver_active(struct libusb_device_handle *dev_handle, uint8_t inte
 
 	UNUSED(interface);
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "%s", dpriv->ugenpath);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "%s", dpriv->ugenpath);
 
 	return (dpriv->ugenpath == NULL);
 }
@@ -351,7 +351,7 @@ static int
 sunos_detach_kernel_driver(struct libusb_device_handle *dev_handle,
 	uint8_t interface_number)
 {
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 	string_list_t *list;
 	char path_arg[PATH_MAX];
 	sunos_dev_priv_t *dpriv;
@@ -361,7 +361,7 @@ sunos_detach_kernel_driver(struct libusb_device_handle *dev_handle,
 
 	dpriv = usbi_get_device_priv(dev_handle->dev);
 	snprintf(path_arg, sizeof(path_arg), "\'\"%s\"\'", dpriv->phypath);
-	usbi_dbg(HANDLE_CTX(dev_handle), "%s", path_arg);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "%s", path_arg);
 
 	list = sunos_new_string_list();
 	if (list == NULL)
@@ -389,7 +389,7 @@ sunos_detach_kernel_driver(struct libusb_device_handle *dev_handle,
 	r |= sunos_usb_ioctl(dev_handle->dev, DEVCTL_AP_DISCONNECT);
 	r |= sunos_usb_ioctl(dev_handle->dev, DEVCTL_AP_CONFIGURE);
 	if (r)
-		usbi_warn(HANDLE_CTX(dev_handle), "one or more ioctls failed");
+		usbi_warn(usbi_handle_ctx(dev_handle), "one or more ioctls failed");
 
 	snprintf(path_arg, sizeof(path_arg), "^usb/%x.%x",
 	    dev_handle->dev->device_descriptor.idVendor,
@@ -397,7 +397,7 @@ sunos_detach_kernel_driver(struct libusb_device_handle *dev_handle,
 	sunos_physpath_to_devlink(dpriv->phypath, path_arg, &dpriv->ugenpath);
 
 	if (access(dpriv->ugenpath, F_OK) == -1) {
-		usbi_err(HANDLE_CTX(dev_handle), "fail to detach kernel driver");
+		usbi_err(usbi_handle_ctx(dev_handle), "fail to detach kernel driver");
 		return (LIBUSB_ERROR_IO);
 	}
 
@@ -408,7 +408,7 @@ static int
 sunos_attach_kernel_driver(struct libusb_device_handle *dev_handle,
 	uint8_t interface_number)
 {
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 	string_list_t *list;
 	char path_arg[PATH_MAX];
 	sunos_dev_priv_t *dpriv;
@@ -421,7 +421,7 @@ sunos_attach_kernel_driver(struct libusb_device_handle *dev_handle,
 
 	dpriv = usbi_get_device_priv(dev_handle->dev);
 	snprintf(path_arg, sizeof(path_arg), "\'\"%s\"\'", dpriv->phypath);
-	usbi_dbg(HANDLE_CTX(dev_handle), "%s", path_arg);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "%s", path_arg);
 
 	list = sunos_new_string_list();
 	if (list == NULL)
@@ -450,7 +450,7 @@ sunos_attach_kernel_driver(struct libusb_device_handle *dev_handle,
 	r |= sunos_usb_ioctl(dev_handle->dev, DEVCTL_AP_DISCONNECT);
 	r |= sunos_usb_ioctl(dev_handle->dev, DEVCTL_AP_CONFIGURE);
 	if (r)
-		usbi_warn(HANDLE_CTX(dev_handle), "one or more ioctls failed");
+		usbi_warn(usbi_handle_ctx(dev_handle), "one or more ioctls failed");
 
 	return 0;
 }
@@ -477,7 +477,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
 	    "usb-raw-cfg-descriptors", &rdata);
 	if (proplen <= 0) {
-		usbi_dbg(DEVICE_CTX(dev), "can't find raw config descriptors");
+		usbi_dbg(usbi_device_ctx(dev), "can't find raw config descriptors");
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -504,7 +504,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 		snprintf(match_str, sizeof(match_str), "^usb/%x.%x",
 		    dev->device_descriptor.idVendor,
 		    dev->device_descriptor.idProduct);
-		usbi_dbg(DEVICE_CTX(dev), "match is %s", match_str);
+		usbi_dbg(usbi_device_ctx(dev), "match is %s", match_str);
 		sunos_physpath_to_devlink(dpriv->phypath, match_str,  &dpriv->ugenpath);
 		di_devfs_path_free(phypath);
 
@@ -517,7 +517,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 	/* address */
 	n = di_prop_lookup_ints(DDI_DEV_T_ANY, node, "assigned-address", &addr);
 	if (n != 1 || *addr == 0) {
-		usbi_dbg(DEVICE_CTX(dev), "can't get address");
+		usbi_dbg(usbi_device_ctx(dev), "can't get address");
 	} else {
 		dev->device_address = *addr;
 	}
@@ -533,7 +533,7 @@ sunos_fill_in_dev_info(di_node_t node, struct libusb_device *dev)
 		dev->speed = LIBUSB_SPEED_SUPER;
 	}
 
-	usbi_dbg(DEVICE_CTX(dev), "vid=%x pid=%x, path=%s, bus_nmber=0x%x, port_number=%d, speed=%d",
+	usbi_dbg(usbi_device_ctx(dev), "vid=%x pid=%x, path=%s, bus_nmber=0x%x, port_number=%d, speed=%d",
 	    dev->device_descriptor.idVendor, dev->device_descriptor.idProduct,
 	    dpriv->phypath, dev->bus_number, dev->port_number, dev->speed);
 
@@ -841,20 +841,20 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 	uint8_t	ep_index;
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg(HANDLE_CTX(hdl), "open ep 0x%02x", ep_addr);
+	usbi_dbg(usbi_handle_ctx(hdl), "open ep 0x%02x", ep_addr);
 	hpriv = usbi_get_device_handle_priv(hdl);
 	ep_index = sunos_usb_ep_index(ep_addr);
 	/* ep already opened */
 	if ((hpriv->eps[ep_index].datafd > 0) &&
 	    (hpriv->eps[ep_index].statfd > 0)) {
-		usbi_dbg(HANDLE_CTX(hdl), "ep 0x%02x already opened, return success",
+		usbi_dbg(usbi_handle_ctx(hdl), "ep 0x%02x already opened, return success",
 			ep_addr);
 
 		return (0);
 	}
 
 	if (sunos_find_interface(hdl, ep_addr, &ifc) < 0) {
-		usbi_dbg(HANDLE_CTX(hdl), "can't find interface for endpoint 0x%02x",
+		usbi_dbg(usbi_handle_ctx(hdl), "can't find interface for endpoint 0x%02x",
 		    ep_addr);
 
 		return (EACCES);
@@ -880,14 +880,14 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 	    (ep_addr & LIBUSB_ENDPOINT_DIR_MASK) ? "in" : "out",
 	    ep_addr & LIBUSB_ENDPOINT_ADDRESS_MASK);
 	if (e < 0 || e >= (int)sizeof (filename)) {
-		usbi_dbg(HANDLE_CTX(hdl),
+		usbi_dbg(usbi_handle_ctx(hdl),
 		    "path buffer overflow for endpoint 0x%02x", ep_addr);
 		return (EINVAL);
 	}
 
 	e = snprintf(statfilename, sizeof (statfilename), "%sstat", filename);
 	if (e < 0 || e >= (int)sizeof (statfilename)) {
-		usbi_dbg(HANDLE_CTX(hdl),
+		usbi_dbg(usbi_handle_ctx(hdl),
 		    "path buffer overflow for endpoint 0x%02x stat", ep_addr);
 		return (EINVAL);
 	}
@@ -912,7 +912,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 	}
 	/* Open the xfer endpoint first */
 	if ((fd = open(filename, mode)) == -1) {
-		usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", filename, errno,
+		usbi_dbg(usbi_handle_ctx(hdl), "can't open %s: errno %d (%s)", filename, errno,
 		    strerror(errno));
 
 		return (errno);
@@ -933,7 +933,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 		/* Open the status endpoint with RDWR */
 		if ((fdstat = open(statfilename, O_RDWR)) == -1) {
-			usbi_dbg(HANDLE_CTX(hdl), "can't open %s RDWR: errno %d (%s)",
+			usbi_dbg(usbi_handle_ctx(hdl), "can't open %s RDWR: errno %d (%s)",
 				statfilename, errno, strerror(errno));
 
 			return (errno);
@@ -941,7 +941,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 			count = write(fdstat, &control, sizeof(control));
 			if (count != 1) {
 				/* this should have worked */
-				usbi_dbg(HANDLE_CTX(hdl), "can't write to %s: errno %d (%s)",
+				usbi_dbg(usbi_handle_ctx(hdl), "can't write to %s: errno %d (%s)",
 					statfilename, errno, strerror(errno));
 				(void) close(fdstat);
 
@@ -950,7 +950,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 		}
 	} else {
 		if ((fdstat = open(statfilename, O_RDONLY)) == -1) {
-			usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", statfilename, errno,
+			usbi_dbg(usbi_handle_ctx(hdl), "can't open %s: errno %d (%s)", statfilename, errno,
 				strerror(errno));
 
 			return (errno);
@@ -959,7 +959,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 	/* Re-open the xfer endpoint */
 	if ((fd = open(filename, mode)) == -1) {
-		usbi_dbg(HANDLE_CTX(hdl), "can't open %s: errno %d (%s)", filename, errno,
+		usbi_dbg(usbi_handle_ctx(hdl), "can't open %s: errno %d (%s)", filename, errno,
 			strerror(errno));
 		(void) close(fdstat);
 
@@ -968,7 +968,7 @@ sunos_check_device_and_status_open(struct libusb_device_handle *hdl,
 
 	hpriv->eps[ep_index].datafd = fd;
 	hpriv->eps[ep_index].statfd = fdstat;
-	usbi_dbg(HANDLE_CTX(hdl), "ep=0x%02x datafd=%d, statfd=%d", ep_addr, fd, fdstat);
+	usbi_dbg(usbi_handle_ctx(hdl), "ep=0x%02x datafd=%d, statfd=%d", ep_addr, fd, fdstat);
 
 	return (0);
 }
@@ -997,7 +997,7 @@ sunos_open(struct libusb_device_handle *handle)
 	}
 
 	if ((ret = sunos_usb_open_ep0(hpriv, dpriv)) != LIBUSB_SUCCESS) {
-		usbi_dbg(HANDLE_CTX(handle), "fail: %d", ret);
+		usbi_dbg(usbi_handle_ctx(handle), "fail: %d", ret);
 		return (ret);
 	}
 
@@ -1009,7 +1009,7 @@ sunos_close(struct libusb_device_handle *handle)
 {
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg(HANDLE_CTX(handle), " ");
+	usbi_dbg(usbi_handle_ctx(handle), " ");
 
 	hpriv = usbi_get_device_handle_priv(handle);
 
@@ -1032,14 +1032,14 @@ sunos_get_active_config_descriptor(struct libusb_device *dev,
 	 * has ever been changed through setCfg.
 	 */
 	if ((node = di_init(dpriv->phypath, DINFOCPYALL)) == DI_NODE_NIL) {
-		usbi_dbg(DEVICE_CTX(dev), "di_int() failed: errno %d (%s)", errno,
+		usbi_dbg(usbi_device_ctx(dev), "di_int() failed: errno %d (%s)", errno,
 			strerror(errno));
 		return (LIBUSB_ERROR_IO);
 	}
 	proplen = di_prop_lookup_bytes(DDI_DEV_T_ANY, node,
 	    "usb-raw-cfg-descriptors", &rdata);
 	if (proplen <= 0) {
-		usbi_dbg(DEVICE_CTX(dev), "can't find raw config descriptors");
+		usbi_dbg(usbi_device_ctx(dev), "can't find raw config descriptors");
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -1056,7 +1056,7 @@ sunos_get_active_config_descriptor(struct libusb_device *dev,
 	cfg = (struct libusb_config_descriptor *)dpriv->raw_cfgdescr;
 	len = MIN(len, libusb_le16_to_cpu(cfg->wTotalLength));
 	memcpy(buf, dpriv->raw_cfgdescr, len);
-	usbi_dbg(DEVICE_CTX(dev), "path:%s len %zu", dpriv->phypath, len);
+	usbi_dbg(usbi_device_ctx(dev), "path:%s len %zu", dpriv->phypath, len);
 
 	return (len);
 }
@@ -1077,7 +1077,7 @@ sunos_get_configuration(struct libusb_device_handle *handle, uint8_t *config)
 
 	*config = dpriv->cfgvalue;
 
-	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %u", *config);
+	usbi_dbg(usbi_handle_ctx(handle), "bConfigurationValue %u", *config);
 
 	return (LIBUSB_SUCCESS);
 }
@@ -1088,7 +1088,7 @@ sunos_set_configuration(struct libusb_device_handle *handle, int config)
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(handle->dev);
 	sunos_dev_handle_priv_t *hpriv;
 
-	usbi_dbg(HANDLE_CTX(handle), "bConfigurationValue %d", config);
+	usbi_dbg(usbi_handle_ctx(handle), "bConfigurationValue %d", config);
 	hpriv = usbi_get_device_handle_priv(handle);
 
 	if (dpriv->ugenpath == NULL)
@@ -1108,7 +1108,7 @@ sunos_claim_interface(struct libusb_device_handle *handle, uint8_t iface)
 {
 	UNUSED(handle);
 
-	usbi_dbg(HANDLE_CTX(handle), "iface %u", iface);
+	usbi_dbg(usbi_handle_ctx(handle), "iface %u", iface);
 
 	return (LIBUSB_SUCCESS);
 }
@@ -1118,7 +1118,7 @@ sunos_release_interface(struct libusb_device_handle *handle, uint8_t iface)
 {
 	sunos_dev_handle_priv_t *hpriv = usbi_get_device_handle_priv(handle);
 
-	usbi_dbg(HANDLE_CTX(handle), "iface %u", iface);
+	usbi_dbg(usbi_handle_ctx(handle), "iface %u", iface);
 
 	/* XXX: can we release it? */
 	hpriv->altsetting[iface] = 0;
@@ -1133,7 +1133,7 @@ sunos_set_interface_altsetting(struct libusb_device_handle *handle, uint8_t ifac
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(handle->dev);
 	sunos_dev_handle_priv_t *hpriv = usbi_get_device_handle_priv(handle);
 
-	usbi_dbg(HANDLE_CTX(handle), "iface %u, setting %u", iface, altsetting);
+	usbi_dbg(usbi_handle_ctx(handle), "iface %u, setting %u", iface, altsetting);
 
 	if (dpriv->ugenpath == NULL)
 		return (LIBUSB_ERROR_NOT_FOUND);
@@ -1185,20 +1185,20 @@ sunos_async_callback(union sigval arg)
 
 		ret = aio_error(aiocb);
 		if (ret != 0) {
-			xfer->status = sunos_usb_get_status(TRANSFER_CTX(xfer), hpriv->eps[ep].statfd);
+			xfer->status = sunos_usb_get_status(usbi_transfer_ctx(xfer), hpriv->eps[ep].statfd);
 		} else {
 			xfer->actual_length =
-			    LIBUSB_TRANSFER_TO_USBI_TRANSFER(xfer)->transferred =
+			    usbi_libusb_transfer_to_usbi_transfer(xfer)->transferred =
 			    aio_return(aiocb);
 		}
 
 		usb_dump_data(xfer->buffer, xfer->actual_length);
 
-		usbi_dbg(TRANSFER_CTX(xfer), "ret=%d, len=%d, actual_len=%d", ret, xfer->length,
+		usbi_dbg(usbi_transfer_ctx(xfer), "ret=%d, len=%d, actual_len=%d", ret, xfer->length,
 		    xfer->actual_length);
 
 		/* async notification */
-		usbi_signal_transfer_completion(LIBUSB_TRANSFER_TO_USBI_TRANSFER(xfer));
+		usbi_signal_transfer_completion(usbi_libusb_transfer_to_usbi_transfer(xfer));
 	}
 }
 
@@ -1211,9 +1211,9 @@ sunos_do_async_io(struct libusb_transfer *transfer)
 	uint8_t ep;
 	struct sunos_transfer_priv *tpriv;
 
-	usbi_dbg(TRANSFER_CTX(transfer), " ");
+	usbi_dbg(usbi_transfer_ctx(transfer), " ");
 
-	tpriv = usbi_get_transfer_priv(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
+	tpriv = usbi_get_transfer_priv(usbi_libusb_transfer_to_usbi_transfer(transfer));
 	hpriv = usbi_get_device_handle_priv(transfer->dev_handle);
 	ep = sunos_usb_ep_index(transfer->endpoint);
 
@@ -1302,26 +1302,26 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
 	wLength = transfer->length - LIBUSB_CONTROL_SETUP_SIZE;
 
 	if (hpriv->eps[0].datafd == -1) {
-		usbi_dbg(TRANSFER_CTX(transfer), "ep0 not opened");
+		usbi_dbg(usbi_transfer_ctx(transfer), "ep0 not opened");
 
 		return (LIBUSB_ERROR_NOT_FOUND);
 	}
 
 	if ((data[0] & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN) {
-		usbi_dbg(TRANSFER_CTX(transfer), "IN request");
-		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd,
+		usbi_dbg(usbi_transfer_ctx(transfer), "IN request");
+		ret = usb_do_io(usbi_transfer_ctx(transfer), hpriv->eps[0].datafd,
 		    hpriv->eps[0].statfd, data, LIBUSB_CONTROL_SETUP_SIZE,
 		    WRITE, &status);
 	} else {
-		usbi_dbg(TRANSFER_CTX(transfer), "OUT request");
-		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd, hpriv->eps[0].statfd,
+		usbi_dbg(usbi_transfer_ctx(transfer), "OUT request");
+		ret = usb_do_io(usbi_transfer_ctx(transfer), hpriv->eps[0].datafd, hpriv->eps[0].statfd,
 		    transfer->buffer, transfer->length, WRITE,
 		    (int *)&transfer->status);
 	}
 
 	setup_ret = ret;
 	if (ret < (ssize_t)LIBUSB_CONTROL_SETUP_SIZE) {
-		usbi_dbg(TRANSFER_CTX(transfer), "error sending control msg: %zd", ret);
+		usbi_dbg(usbi_transfer_ctx(transfer), "error sending control msg: %zd", ret);
 
 		return (LIBUSB_ERROR_IO);
 	}
@@ -1331,27 +1331,27 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
 	/* Read the remaining bytes for IN request */
 	if ((wLength) && ((data[0] & LIBUSB_ENDPOINT_DIR_MASK) ==
 	    LIBUSB_ENDPOINT_IN)) {
-		usbi_dbg(TRANSFER_CTX(transfer), "DATA: %d", transfer->length - (int)setup_ret);
-		ret = usb_do_io(TRANSFER_CTX(transfer), hpriv->eps[0].datafd,
+		usbi_dbg(usbi_transfer_ctx(transfer), "DATA: %d", transfer->length - (int)setup_ret);
+		ret = usb_do_io(usbi_transfer_ctx(transfer), hpriv->eps[0].datafd,
 			hpriv->eps[0].statfd,
 			transfer->buffer + LIBUSB_CONTROL_SETUP_SIZE,
 			wLength, READ, (int *)&transfer->status);
 	}
 
 	if (ret >= 0) {
-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->transferred = ret;
+		usbi_libusb_transfer_to_usbi_transfer(transfer)->transferred = ret;
 	}
-	usbi_dbg(TRANSFER_CTX(transfer), "Done: ctrl data bytes %zd", ret);
+	usbi_dbg(usbi_transfer_ctx(transfer), "Done: ctrl data bytes %zd", ret);
 
 	/**
 	 * Sync transfer handling.
  	 * We should release transfer lock here and later get it back
 	 * as usbi_handle_transfer_completion() takes its own transfer lock.
 	 */
-	usbi_mutex_unlock(&LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->lock);
-	ret = usbi_handle_transfer_completion(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer),
+	usbi_mutex_unlock(&usbi_libusb_transfer_to_usbi_transfer(transfer)->lock);
+	ret = usbi_handle_transfer_completion(usbi_libusb_transfer_to_usbi_transfer(transfer),
 	    transfer->status);
-	usbi_mutex_lock(&LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->lock);
+	usbi_mutex_lock(&usbi_libusb_transfer_to_usbi_transfer(transfer)->lock);
 
 	return (ret);
 }
@@ -1361,13 +1361,13 @@ sunos_clear_halt(struct libusb_device_handle *handle, unsigned char endpoint)
 {
 	int ret;
 
-	usbi_dbg(HANDLE_CTX(handle), "endpoint=0x%02x", endpoint);
+	usbi_dbg(usbi_handle_ctx(handle), "endpoint=0x%02x", endpoint);
 
 	ret = libusb_control_transfer(handle, LIBUSB_ENDPOINT_OUT |
 	    LIBUSB_RECIPIENT_ENDPOINT | LIBUSB_REQUEST_TYPE_STANDARD,
 	    LIBUSB_REQUEST_CLEAR_FEATURE, 0, endpoint, NULL, 0, 1000);
 
-	usbi_dbg(HANDLE_CTX(handle), "ret=%d", ret);
+	usbi_dbg(usbi_handle_ctx(handle), "ret=%d", ret);
 
 	return (ret);
 }
@@ -1377,7 +1377,7 @@ sunos_destroy_device(struct libusb_device *dev)
 {
 	sunos_dev_priv_t *dpriv = usbi_get_device_priv(dev);
 
-	usbi_dbg(DEVICE_CTX(dev), "destroy everything");
+	usbi_dbg(usbi_device_ctx(dev), "destroy everything");
 	free(dpriv->raw_cfgdescr);
 	free(dpriv->ugenpath);
 	free(dpriv->phypath);
@@ -1390,7 +1390,7 @@ sunos_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 	struct	libusb_device_handle *hdl;
 	int	err = 0;
 
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	hdl = transfer->dev_handle;
 
 	err = sunos_check_device_and_status_open(hdl,
@@ -1402,7 +1402,7 @@ sunos_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		/* sync transfer */
-		usbi_dbg(ITRANSFER_CTX(itransfer), "CTRL transfer: %d", transfer->length);
+		usbi_dbg(usbi_itransfer_ctx(itransfer), "CTRL transfer: %d", transfer->length);
 		err = solaris_submit_ctrl_on_default(transfer);
 		break;
 
@@ -1410,9 +1410,9 @@ sunos_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 		/* fallthru */
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
 		if (transfer->type == LIBUSB_TRANSFER_TYPE_BULK)
-			usbi_dbg(ITRANSFER_CTX(itransfer), "BULK transfer: %d", transfer->length);
+			usbi_dbg(usbi_itransfer_ctx(itransfer), "BULK transfer: %d", transfer->length);
 		else
-			usbi_dbg(ITRANSFER_CTX(itransfer), "INTR transfer: %d", transfer->length);
+			usbi_dbg(usbi_itransfer_ctx(itransfer), "INTR transfer: %d", transfer->length);
 		err = sunos_do_async_io(transfer);
 		break;
 
@@ -1422,9 +1422,9 @@ sunos_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 		/* fallthru */
 	case LIBUSB_TRANSFER_TYPE_BULK_STREAM:
 		if (transfer->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS)
-			usbi_dbg(ITRANSFER_CTX(itransfer), "ISOC transfer: %d", transfer->length);
+			usbi_dbg(usbi_itransfer_ctx(itransfer), "ISOC transfer: %d", transfer->length);
 		else
-			usbi_dbg(ITRANSFER_CTX(itransfer), "BULK STREAM transfer: %d", transfer->length);
+			usbi_dbg(usbi_itransfer_ctx(itransfer), "BULK STREAM transfer: %d", transfer->length);
 		err = LIBUSB_ERROR_NOT_SUPPORTED;
 		break;
 	}
@@ -1444,13 +1444,13 @@ sunos_cancel_transfer(struct usbi_transfer *itransfer)
 
 	tpriv = usbi_get_transfer_priv(itransfer);
 	aiocb = &tpriv->aiocb;
-	transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	hpriv = usbi_get_device_handle_priv(transfer->dev_handle);
 	ep = sunos_usb_ep_index(transfer->endpoint);
 
 	ret = aio_cancel(hpriv->eps[ep].datafd, aiocb);
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "aio->fd=%d fd=%d ret = %d, %s", aiocb->aio_fildes,
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "aio->fd=%d fd=%d ret = %d, %s", aiocb->aio_fildes,
 	    hpriv->eps[ep].datafd, ret, (ret == AIO_CANCELED)?
 	    strerror(0):strerror(errno));
 

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -301,18 +301,18 @@ enum libusb_transfer_status usbd_status_to_libusb_transfer_status(USBD_STATUS st
  */
 void windows_force_sync_completion(struct usbi_transfer *itransfer, ULONG size)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(TRANSFER_CTX(transfer));
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_transfer_ctx(transfer));
 	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv *)usbi_get_transfer_priv(itransfer);
 	OVERLAPPED *overlapped = &transfer_priv->overlapped;
 
-	usbi_dbg(TRANSFER_CTX(transfer), "transfer %p, length %lu", transfer, ULONG_CAST(size));
+	usbi_dbg(usbi_transfer_ctx(transfer), "transfer %p, length %lu", transfer, ULONG_CAST(size));
 
 	overlapped->Internal = (ULONG_PTR)STATUS_SUCCESS;
 	overlapped->InternalHigh = (ULONG_PTR)size;
 
 	if (!PostQueuedCompletionStatus(priv->completion_port, (DWORD)size, (ULONG_PTR)transfer->dev_handle, overlapped))
-		usbi_err(TRANSFER_CTX(transfer), "failed to post I/O completion: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "failed to post I/O completion: %s", windows_error_str(0));
 }
 
 /* Windows version detection */
@@ -517,9 +517,9 @@ static unsigned __stdcall windows_iocp_thread(void *arg)
 			continue;
 		}
 
-		itransfer = TRANSFER_PRIV_TO_USBI_TRANSFER(transfer_priv);
+		itransfer = usbi_transfer_priv_to_usbi_transfer(transfer_priv);
 #ifdef ENABLE_LOGGING
-		struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+		struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 		usbi_dbg(ctx, "transfer %p completed, length %lu",
 			 transfer, ULONG_CAST(num_bytes));
 #endif
@@ -711,7 +711,7 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 static int windows_get_device_string(libusb_device *dev,
 	enum libusb_device_string_type string_type, char *data, int length)
 {
-	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	if (NULL != priv->backend->get_device_string) {
 		return priv->backend->get_device_string(dev, string_type, data, length);
 	}
@@ -721,7 +721,7 @@ static int windows_get_device_string(libusb_device *dev,
 static int windows_get_config_string(libusb_device *dev,
 	uint8_t config_value, char *data, int length)
 {
-	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	if (NULL != priv->backend->get_config_string) {
 		return priv->backend->get_config_string(dev, config_value, data, length);
 	}
@@ -732,7 +732,7 @@ static int windows_get_interface_string(libusb_device *dev,
 	uint8_t config_value, uint8_t interface_number, uint8_t alt_setting,
 	char *data, int length)
 {
-	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv* priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	if (NULL != priv->backend->get_interface_string) {
 		return priv->backend->get_interface_string(dev, config_value,
 			interface_number, alt_setting, data, length);
@@ -742,7 +742,7 @@ static int windows_get_interface_string(libusb_device *dev,
 
 static int windows_open(struct libusb_device_handle *dev_handle)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	struct windows_device_handle_priv *handle_priv = (struct windows_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
 
 	list_init(&handle_priv->active_transfers);
@@ -751,40 +751,40 @@ static int windows_open(struct libusb_device_handle *dev_handle)
 
 static void windows_close(struct libusb_device_handle *dev_handle)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	priv->backend->close(dev_handle);
 }
 
 static int windows_get_active_config_descriptor(struct libusb_device *dev,
 	void *buffer, size_t len)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	return priv->backend->get_active_config_descriptor(dev, buffer, len);
 }
 
 static int windows_get_config_descriptor(struct libusb_device *dev,
 	uint8_t config_index, void *buffer, size_t len)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	return priv->backend->get_config_descriptor(dev, config_index, buffer, len);
 }
 
 static int windows_get_config_descriptor_by_value(struct libusb_device *dev,
 	uint8_t bConfigurationValue, void **buffer)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	return priv->backend->get_config_descriptor_by_value(dev, bConfigurationValue, buffer);
 }
 
 static int windows_get_configuration(struct libusb_device_handle *dev_handle, uint8_t *config)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->get_configuration(dev_handle, config);
 }
 
 static int windows_set_configuration(struct libusb_device_handle *dev_handle, int config)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	if (config == -1)
 		config = 0;
 	return priv->backend->set_configuration(dev_handle, (uint8_t)config);
@@ -792,45 +792,45 @@ static int windows_set_configuration(struct libusb_device_handle *dev_handle, in
 
 static int windows_claim_interface(struct libusb_device_handle *dev_handle, uint8_t interface_number)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->claim_interface(dev_handle, interface_number);
 }
 
 static int windows_release_interface(struct libusb_device_handle *dev_handle, uint8_t interface_number)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->release_interface(dev_handle, interface_number);
 }
 
 static int windows_set_interface_altsetting(struct libusb_device_handle *dev_handle,
 	uint8_t interface_number, uint8_t altsetting)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->set_interface_altsetting(dev_handle, interface_number, altsetting);
 }
 
 static int windows_clear_halt(struct libusb_device_handle *dev_handle, unsigned char endpoint)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->clear_halt(dev_handle, endpoint);
 }
 
 static int windows_reset_device(struct libusb_device_handle *dev_handle)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	return priv->backend->reset_device(dev_handle);
 }
 
 static void windows_destroy_device(struct libusb_device *dev)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(DEVICE_CTX(dev));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_device_ctx(dev));
 	priv->backend->destroy_device(dev);
 }
 
 static int windows_endpoint_supports_raw_io(libusb_device_handle* dev_handle,
 	uint8_t endpoint)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	if (priv->backend->endpoint_supports_raw_io)
 		return priv->backend->endpoint_supports_raw_io(dev_handle, endpoint);
 	return LIBUSB_ERROR_NOT_SUPPORTED;
@@ -839,7 +839,7 @@ static int windows_endpoint_supports_raw_io(libusb_device_handle* dev_handle,
 static int windows_endpoint_set_raw_io(libusb_device_handle* dev_handle,
 	uint8_t endpoint, int enable)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 
 	if (priv->backend->endpoint_supports_raw_io == NULL
 		|| priv->backend->endpoint_supports_raw_io(dev_handle, endpoint) != 1
@@ -852,7 +852,7 @@ static int windows_endpoint_set_raw_io(libusb_device_handle* dev_handle,
 static int windows_get_max_raw_io_transfer_size(struct libusb_device_handle *dev_handle,
 	uint8_t endpoint)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(HANDLE_CTX(dev_handle));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_handle_ctx(dev_handle));
 	if (priv->backend->get_max_raw_io_transfer_size)
 		return priv->backend->get_max_raw_io_transfer_size(dev_handle, endpoint);
 	return LIBUSB_ERROR_NOT_SUPPORTED;
@@ -860,9 +860,9 @@ static int windows_get_max_raw_io_transfer_size(struct libusb_device_handle *dev
 
 static int windows_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itransfer->lock)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct libusb_device_handle *dev_handle = transfer->dev_handle;
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(ctx);
 	struct windows_device_handle_priv *handle_priv = (struct windows_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
 	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv *)usbi_get_transfer_priv(itransfer);
@@ -915,7 +915,7 @@ static int windows_submit_transfer(struct usbi_transfer *itransfer) REQUIRES(itr
 
 static int windows_cancel_transfer(struct usbi_transfer *itransfer)
 {
-	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(ITRANSFER_CTX(itransfer));
+	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(usbi_itransfer_ctx(itransfer));
 	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
 	// Try CancelIoEx() on the transfer
@@ -929,13 +929,13 @@ static int windows_cancel_transfer(struct usbi_transfer *itransfer)
 	if (priv->backend->cancel_transfer)
 		return priv->backend->cancel_transfer(itransfer);
 
-	usbi_warn(ITRANSFER_CTX(itransfer), "cancellation not supported for this transfer's driver");
+	usbi_warn(usbi_itransfer_ctx(itransfer), "cancellation not supported for this transfer's driver");
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }
 
 static int windows_handle_transfer_completion(struct usbi_transfer *itransfer) EXCLUDES(itransfer->lock)
 {
-	struct libusb_context *ctx = ITRANSFER_CTX(itransfer);
+	struct libusb_context *ctx = usbi_itransfer_ctx(itransfer);
 	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(ctx);
 	const struct windows_backend *backend = priv->backend;
 	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv *)usbi_get_transfer_priv(itransfer);
@@ -957,7 +957,7 @@ static int windows_handle_transfer_completion(struct usbi_transfer *itransfer) E
 		result = GetLastError();
 
 #ifdef ENABLE_LOGGING
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	usbi_dbg(ctx, "handling transfer %p completion with errcode %lu, length %lu",
 		 transfer, ULONG_CAST(result), ULONG_CAST(bytes_transferred));
 #endif

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -407,7 +407,7 @@ static int usbdk_get_active_config_descriptor(struct libusb_device *dev, void *b
 static int usbdk_open(struct libusb_device_handle *dev_handle)
 {
 	struct libusb_device *dev = dev_handle->dev;
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(ctx);
 	struct usbdk_device_priv *device_priv = (struct usbdk_device_priv *)usbi_get_device_priv(dev);
 
@@ -436,7 +436,7 @@ static void usbdk_close(struct libusb_device_handle *dev_handle)
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(dev_handle->dev);
 
 	if (!usbdk_helper.StopRedirect(priv->redirector_handle))
-		usbi_err(HANDLE_CTX(dev_handle), "Redirector shutdown failed");
+		usbi_err(usbi_handle_ctx(dev_handle), "Redirector shutdown failed");
 
 	priv->system_handle = NULL;
 	priv->redirector_handle = NULL;
@@ -470,7 +470,7 @@ static int usbdk_set_interface_altsetting(struct libusb_device_handle *dev_handl
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(dev_handle->dev);
 
 	if (!usbdk_helper.SetAltsetting(priv->redirector_handle, iface, altsetting)) {
-		usbi_err(HANDLE_CTX(dev_handle), "SetAltsetting failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "SetAltsetting failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
 
@@ -489,7 +489,7 @@ static int usbdk_clear_halt(struct libusb_device_handle *dev_handle, unsigned ch
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(dev_handle->dev);
 
 	if (!usbdk_helper.ResetPipe(priv->redirector_handle, endpoint)) {
-		usbi_err(HANDLE_CTX(dev_handle), "ResetPipe failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "ResetPipe failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
 
@@ -501,7 +501,7 @@ static int usbdk_reset_device(struct libusb_device_handle *dev_handle)
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(dev_handle->dev);
 
 	if (!usbdk_helper.ResetDevice(priv->redirector_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "ResetDevice failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "ResetDevice failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
 
@@ -519,7 +519,7 @@ static void usbdk_destroy_device(struct libusb_device *dev)
 static void usbdk_clear_transfer_priv(struct usbi_transfer *itransfer)
 {
 	struct usbdk_transfer_priv *transfer_priv = get_usbdk_transfer_priv(itransfer);
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	if (transfer->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS) {
 		safe_free(transfer_priv->IsochronousPacketsArray);
@@ -529,7 +529,7 @@ static void usbdk_clear_transfer_priv(struct usbi_transfer *itransfer)
 
 static int usbdk_do_control_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	struct usbdk_transfer_priv *transfer_priv = get_usbdk_transfer_priv(itransfer);
 	OVERLAPPED *overlapped = get_transfer_priv_overlapped(itransfer);
@@ -553,7 +553,7 @@ static int usbdk_do_control_transfer(struct usbi_transfer *itransfer)
 	case TransferSuccessAsync:
 		break;
 	case TransferFailure:
-		usbi_err(TRANSFER_CTX(transfer), "ControlTransfer failed: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "ControlTransfer failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_IO;
 	}
 
@@ -562,7 +562,7 @@ static int usbdk_do_control_transfer(struct usbi_transfer *itransfer)
 
 static int usbdk_do_bulk_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	struct usbdk_transfer_priv *transfer_priv = get_usbdk_transfer_priv(itransfer);
 	OVERLAPPED *overlapped = get_transfer_priv_overlapped(itransfer);
@@ -583,7 +583,7 @@ static int usbdk_do_bulk_transfer(struct usbi_transfer *itransfer)
 
 	set_transfer_priv_handle(itransfer, priv->system_handle);
 
-	if (IS_XFERIN(transfer))
+	if (usbi_is_xferin(transfer))
 		transferRes = usbdk_helper.ReadPipe(priv->redirector_handle, &transfer_priv->request, overlapped);
 	else
 		transferRes = usbdk_helper.WritePipe(priv->redirector_handle, &transfer_priv->request, overlapped);
@@ -595,7 +595,7 @@ static int usbdk_do_bulk_transfer(struct usbi_transfer *itransfer)
 	case TransferSuccessAsync:
 		break;
 	case TransferFailure:
-		usbi_err(TRANSFER_CTX(transfer), "ReadPipe/WritePipe failed: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "ReadPipe/WritePipe failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_IO;
 	}
 
@@ -604,7 +604,7 @@ static int usbdk_do_bulk_transfer(struct usbi_transfer *itransfer)
 
 static int usbdk_do_iso_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct usbdk_device_priv *priv = (struct usbdk_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	struct usbdk_transfer_priv *transfer_priv = get_usbdk_transfer_priv(itransfer);
 	OVERLAPPED *overlapped = get_transfer_priv_overlapped(itransfer);
@@ -619,14 +619,14 @@ static int usbdk_do_iso_transfer(struct usbi_transfer *itransfer)
 	transfer_priv->IsochronousPacketsArray = (PULONG64)malloc(transfer->num_iso_packets * sizeof(ULONG64));
 	transfer_priv->request.IsochronousPacketsArray = (PVOID64)transfer_priv->IsochronousPacketsArray;
 	if (!transfer_priv->IsochronousPacketsArray) {
-		usbi_err(TRANSFER_CTX(transfer), "Allocation of IsochronousPacketsArray failed");
+		usbi_err(usbi_transfer_ctx(transfer), "Allocation of IsochronousPacketsArray failed");
 		return LIBUSB_ERROR_NO_MEM;
 	}
 
 	transfer_priv->IsochronousResultsArray = (PUSB_DK_ISO_TRANSFER_RESULT)malloc(transfer->num_iso_packets * sizeof(USB_DK_ISO_TRANSFER_RESULT));
 	transfer_priv->request.Result.IsochronousResultsArray = (PVOID64)transfer_priv->IsochronousResultsArray;
 	if (!transfer_priv->IsochronousResultsArray) {
-		usbi_err(TRANSFER_CTX(transfer), "Allocation of isochronousResultsArray failed");
+		usbi_err(usbi_transfer_ctx(transfer), "Allocation of isochronousResultsArray failed");
 		return LIBUSB_ERROR_NO_MEM;
 	}
 
@@ -635,7 +635,7 @@ static int usbdk_do_iso_transfer(struct usbi_transfer *itransfer)
 
 	set_transfer_priv_handle(itransfer, priv->system_handle);
 
-	if (IS_XFERIN(transfer))
+	if (usbi_is_xferin(transfer))
 		transferRes = usbdk_helper.ReadPipe(priv->redirector_handle, &transfer_priv->request, overlapped);
 	else
 		transferRes = usbdk_helper.WritePipe(priv->redirector_handle, &transfer_priv->request, overlapped);
@@ -655,14 +655,14 @@ static int usbdk_do_iso_transfer(struct usbi_transfer *itransfer)
 
 static int usbdk_submit_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 		return usbdk_do_control_transfer(itransfer);
 	case LIBUSB_TRANSFER_TYPE_BULK:
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
-		if (IS_XFEROUT(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET))
+		if (usbi_is_xferout(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET))
 			return LIBUSB_ERROR_NOT_SUPPORTED; //TODO: Check whether we can support this in UsbDk
 		return usbdk_do_bulk_transfer(itransfer);
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
@@ -670,14 +670,14 @@ static int usbdk_submit_transfer(struct usbi_transfer *itransfer)
 	default:
 		// Should not get here since windows_submit_transfer() validates
 		// the transfer->type field
-		usbi_err(TRANSFER_CTX(transfer), "unsupported endpoint type %d", transfer->type);
+		usbi_err(usbi_transfer_ctx(transfer), "unsupported endpoint type %d", transfer->type);
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 }
 
 static enum libusb_transfer_status usbdk_copy_transfer_data(struct usbi_transfer *itransfer, DWORD length)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct usbdk_transfer_priv *transfer_priv = get_usbdk_transfer_priv(itransfer);
 
 	UNUSED(length);

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -512,7 +512,7 @@ static const struct libusb_interface_descriptor *get_interface_descriptor_by_num
 		}
 	}
 
-	usbi_err(HANDLE_CTX(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
+	usbi_err(usbi_handle_ctx(dev_handle), "interface %d with altsetting %d not found for device", iface, (int)altsetting);
 	return NULL;
 }
 
@@ -521,7 +521,7 @@ static const struct libusb_interface_descriptor *get_interface_descriptor_by_num
  */
 static HANDLE windows_open(struct libusb_device_handle *dev_handle, const char *path, DWORD access)
 {
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 	struct windows_context_priv *priv = (struct windows_context_priv *)usbi_get_context_priv(ctx);
 	HANDLE handle;
 
@@ -550,7 +550,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 
 	r = libusb_get_active_config_descriptor(dev_handle->dev, &conf_desc);
 	if (r != LIBUSB_SUCCESS) {
-		usbi_warn(HANDLE_CTX(dev_handle), "could not read config descriptor: error %d", r);
+		usbi_warn(usbi_handle_ctx(dev_handle), "could not read config descriptor: error %d", r);
 		return r;
 	}
 
@@ -563,7 +563,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 	safe_free(priv->usb_interface[iface].endpoint);
 
 	if (if_desc->bNumEndpoints == 0) {
-		usbi_dbg(HANDLE_CTX(dev_handle), "no endpoints found for interface %u", iface);
+		usbi_dbg(usbi_handle_ctx(dev_handle), "no endpoints found for interface %u", iface);
 	} else {
 		priv->usb_interface[iface].endpoint = (uint8_t *)malloc(if_desc->bNumEndpoints);
 		if (priv->usb_interface[iface].endpoint == NULL) {
@@ -573,7 +573,7 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 		priv->usb_interface[iface].nb_endpoints = if_desc->bNumEndpoints;
 		for (i = 0; i < if_desc->bNumEndpoints; i++) {
 			priv->usb_interface[iface].endpoint[i] = if_desc->endpoint[i].bEndpointAddress;
-			usbi_dbg(HANDLE_CTX(dev_handle), "(re)assigned endpoint %02X to interface %u", priv->usb_interface[iface].endpoint[i], iface);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "(re)assigned endpoint %02X to interface %u", priv->usb_interface[iface].endpoint[i], iface);
 		}
 	}
 
@@ -657,9 +657,9 @@ static int auto_claim(struct libusb_transfer *transfer, int *interface_number, i
 
 			claim_status = libusb_claim_interface(transfer->dev_handle, current_interface);
 			if (claim_status == LIBUSB_SUCCESS) {
-				usbi_dbg(TRANSFER_CTX(transfer), "auto-claimed interface %d for control request", current_interface);
+				usbi_dbg(usbi_transfer_ctx(transfer), "auto-claimed interface %d for control request", current_interface);
 				if (handle_priv->autoclaim_count[current_interface] != 0)
-					usbi_err(TRANSFER_CTX(transfer), "program assertion failed - autoclaim_count was nonzero");
+					usbi_err(usbi_transfer_ctx(transfer), "program assertion failed - autoclaim_count was nonzero");
 				handle_priv->autoclaim_count[current_interface]++;
 				break;
 			}
@@ -672,7 +672,7 @@ static int auto_claim(struct libusb_transfer *transfer, int *interface_number, i
 		}
 		if (current_interface == USB_MAXINTERFACES) {
 			r = claim_status;
-			usbi_err(TRANSFER_CTX(transfer), "could not auto-claim any interface: %s",
+			usbi_err(usbi_transfer_ctx(transfer), "could not auto-claim any interface: %s",
 				libusb_error_name(r));
 		}
 	} else {
@@ -690,7 +690,7 @@ static int auto_claim(struct libusb_transfer *transfer, int *interface_number, i
 static void auto_release(struct usbi_transfer *itransfer)
 {
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	libusb_device_handle *dev_handle = transfer->dev_handle;
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
 	int r;
@@ -701,9 +701,9 @@ static void auto_release(struct usbi_transfer *itransfer)
 		if (handle_priv->autoclaim_count[transfer_priv->interface_number] == 0) {
 			r = libusb_release_interface(dev_handle, transfer_priv->interface_number);
 			if (r == LIBUSB_SUCCESS)
-				usbi_dbg(ITRANSFER_CTX(itransfer), "auto-released interface %d", transfer_priv->interface_number);
+				usbi_dbg(usbi_itransfer_ctx(itransfer), "auto-released interface %d", transfer_priv->interface_number);
 			else
-				usbi_dbg(ITRANSFER_CTX(itransfer), "failed to auto-release interface %d (%s)",
+				usbi_dbg(usbi_itransfer_ctx(itransfer), "failed to auto-release interface %d (%s)",
 					transfer_priv->interface_number, libusb_error_name((enum libusb_error)r));
 		}
 	}
@@ -1029,7 +1029,7 @@ static void winusb_exit(struct libusb_context *ctx)
  */
 static int cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handle)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 	DWORD size, ret_size;
 	uint8_t i, num_configurations;
@@ -1209,7 +1209,7 @@ static int alloc_root_hub_config_desc(struct libusb_device *dev, ULONG num_ports
 
 static int init_root_hub(struct libusb_device *dev)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_context *ctx = usbi_device_ctx(dev);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 	USB_NODE_CONNECTION_INFORMATION_EX conn_info;
 	USB_NODE_CONNECTION_INFORMATION_EX_V2 conn_info_v2;
@@ -1414,7 +1414,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 	}
 
 	if (parent_dev != NULL) { // Not a HCD root hub
-		ctx = DEVICE_CTX(dev);
+		ctx = usbi_device_ctx(dev);
 		parent_priv = (struct winusb_device_priv *)usbi_get_device_priv(parent_dev);
 		if (parent_priv->apib->id != USB_API_HUB) {
 			usbi_warn(ctx, "parent for device '%s' is not a hub", priv->dev_id);
@@ -2696,7 +2696,7 @@ static int winusb_fetch_string_descriptor(libusb_device *dev,
 	uint8_t string_descriptor_idx, char *data, int length)
 {
 	struct winusb_device_priv* priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
-	struct libusb_context* ctx = DEVICE_CTX(dev);
+	struct libusb_context* ctx = usbi_device_ctx(dev);
 	DWORD size;
 	DWORD ret_size;
 	struct string_descriptor_req_s sd;
@@ -3010,7 +3010,7 @@ static void winusb_destroy_device(struct libusb_device *dev)
 static void winusb_clear_transfer_priv(struct usbi_transfer *itransfer)
 {
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int sub_api = priv->sub_api;
 
@@ -3021,7 +3021,7 @@ static void winusb_clear_transfer_priv(struct usbi_transfer *itransfer)
 			if (WinUSBX[sub_api].UnregisterIsochBuffer(transfer_priv->isoch_buffer_handle)) {
 				transfer_priv->isoch_buffer_handle = NULL;
 			} else {
-				usbi_warn(TRANSFER_CTX(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
+				usbi_warn(usbi_transfer_ctx(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
 			}
 		}
 	}
@@ -3034,7 +3034,7 @@ static void winusb_clear_transfer_priv(struct usbi_transfer *itransfer)
 
 static int winusb_submit_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int (*transfer_fn)(int, struct usbi_transfer *);
 
@@ -3052,12 +3052,12 @@ static int winusb_submit_transfer(struct usbi_transfer *itransfer)
 	default:
 		// Should not get here since windows_submit_transfer() validates
 		// the transfer->type field
-		usbi_err(TRANSFER_CTX(transfer), "unknown endpoint type %d", transfer->type);
+		usbi_err(usbi_transfer_ctx(transfer), "unknown endpoint type %d", transfer->type);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
 	if (transfer_fn == NULL) {
-		usbi_warn(TRANSFER_CTX(transfer),
+		usbi_warn(usbi_transfer_ctx(transfer),
 			"unsupported transfer type %d (unrecognized device driver)",
 			transfer->type);
 		return LIBUSB_ERROR_NOT_SUPPORTED;
@@ -3068,7 +3068,7 @@ static int winusb_submit_transfer(struct usbi_transfer *itransfer)
 
 static int winusb_cancel_transfer(struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 
 	CHECK_SUPPORTED_API(priv->apib, cancel_transfer);
@@ -3078,11 +3078,11 @@ static int winusb_cancel_transfer(struct usbi_transfer *itransfer)
 
 static enum libusb_transfer_status winusb_copy_transfer_data(struct usbi_transfer *itransfer, DWORD length)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 
 	if (priv->apib->copy_transfer_data == NULL) {
-		usbi_err(TRANSFER_CTX(transfer), "program assertion failed - no function to copy transfer data");
+		usbi_err(usbi_transfer_ctx(transfer), "program assertion failed - no function to copy transfer data");
 		return LIBUSB_TRANSFER_ERROR;
 	}
 
@@ -3095,7 +3095,7 @@ static int winusb_endpoint_supports_raw_io(struct libusb_device_handle* dev_hand
 
 	if (priv->apib->endpoint_supports_raw_io == NULL)
 	{
-		usbi_dbg(HANDLE_CTX(dev_handle), "device driver does not support RAW_IO query -> unsupported.");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "device driver does not support RAW_IO query -> unsupported.");
 		return 0;
 	}
 
@@ -3108,7 +3108,7 @@ static int winusb_endpoint_set_raw_io(struct libusb_device_handle* dev_handle, u
 
 	if (priv->apib->endpoint_set_raw_io == NULL)
 	{
-		usbi_err(HANDLE_CTX(dev_handle), "device driver does not support setting RAW_IO.");
+		usbi_err(usbi_handle_ctx(dev_handle), "device driver does not support setting RAW_IO.");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 
@@ -3123,7 +3123,7 @@ static int winusb_get_max_raw_io_transfer_size(
 
 	if (priv->apib->get_max_raw_io_transfer_size == NULL)
 	{
-		usbi_err(HANDLE_CTX(dev_handle), "device driver does not support RAW_IO max size query.");
+		usbi_err(usbi_handle_ctx(dev_handle), "device driver does not support RAW_IO max size query.");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 
@@ -3471,7 +3471,7 @@ static int winusbx_open(int sub_api, struct libusb_device_handle *dev_handle)
 				&& (priv->usb_interface[i].apib->id == USB_API_WINUSBX)) {
 			file_handle = windows_open(dev_handle, priv->usb_interface[i].path, GENERIC_READ | GENERIC_WRITE);
 			if (file_handle == INVALID_HANDLE_VALUE) {
-				usbi_err(HANDLE_CTX(dev_handle), "could not open device %s (interface %d): %s", priv->usb_interface[i].path, i, windows_error_str(0));
+				usbi_err(usbi_handle_ctx(dev_handle), "could not open device %s (interface %d): %s", priv->usb_interface[i].path, i, windows_error_str(0));
 				switch (GetLastError()) {
 				case ERROR_FILE_NOT_FOUND: // The device was disconnected
 					return LIBUSB_ERROR_NO_DEVICE;
@@ -3576,7 +3576,7 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		endpoint_address = (i == -1) ? 0 : priv->usb_interface[iface].endpoint[i];
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			PIPE_TRANSFER_TIMEOUT, sizeof(ULONG), &timeout))
-			usbi_dbg(HANDLE_CTX(dev_handle), "failed to set PIPE_TRANSFER_TIMEOUT for control endpoint %02X", endpoint_address);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "failed to set PIPE_TRANSFER_TIMEOUT for control endpoint %02X", endpoint_address);
 
 		if ((i == -1) || (sub_api == SUB_API_LIBUSB0))
 			continue; // Other policies don't apply to control endpoint or libusb0
@@ -3585,27 +3585,27 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 		handle_priv->interface_handle[iface].zlp[endpoint_address] = WINUSB_ZLP_UNSET;
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			SHORT_PACKET_TERMINATE, sizeof(UCHAR), &policy))
-			usbi_dbg(HANDLE_CTX(dev_handle), "failed to disable SHORT_PACKET_TERMINATE for endpoint %02X", endpoint_address);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "failed to disable SHORT_PACKET_TERMINATE for endpoint %02X", endpoint_address);
 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			IGNORE_SHORT_PACKETS, sizeof(UCHAR), &policy))
-			usbi_dbg(HANDLE_CTX(dev_handle), "failed to disable IGNORE_SHORT_PACKETS for endpoint %02X", endpoint_address);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "failed to disable IGNORE_SHORT_PACKETS for endpoint %02X", endpoint_address);
 
 		policy = true;
 		/* ALLOW_PARTIAL_READS must be enabled due to likely libusbK bug. See:
 		   https://sourceforge.net/mailarchive/message.php?msg_id=29736015 */
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			ALLOW_PARTIAL_READS, sizeof(UCHAR), &policy))
-			usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable ALLOW_PARTIAL_READS for endpoint %02X", endpoint_address);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "failed to enable ALLOW_PARTIAL_READS for endpoint %02X", endpoint_address);
 
 		if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 			AUTO_CLEAR_STALL, sizeof(UCHAR), &policy))
-			usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "failed to enable AUTO_CLEAR_STALL for endpoint %02X", endpoint_address);
 
 		if (sub_api == SUB_API_LIBUSBK) {
 			if (!WinUSBX[sub_api].SetPipePolicy(winusb_handle, endpoint_address,
 				ISO_ALWAYS_START_ASAP, sizeof(UCHAR), &policy))
-				usbi_dbg(HANDLE_CTX(dev_handle), "failed to enable ISO_ALWAYS_START_ASAP for endpoint %02X", endpoint_address);
+				usbi_dbg(usbi_handle_ctx(dev_handle), "failed to enable ISO_ALWAYS_START_ASAP for endpoint %02X", endpoint_address);
 		}
 	}
 
@@ -3614,7 +3614,7 @@ static int winusbx_configure_endpoints(int sub_api, struct libusb_device_handle 
 
 static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev_handle, uint8_t iface)
 {
-	struct libusb_context *ctx = HANDLE_CTX(dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(dev_handle);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev_handle->dev);
 	bool is_using_usbccgp = (priv->apib->id == USB_API_COMPOSITE);
@@ -3784,7 +3784,7 @@ static int get_valid_interface(struct libusb_device_handle *dev_handle, int api_
 	int i;
 
 	if ((api_id < USB_API_WINUSBX) || (api_id > USB_API_HID)) {
-		usbi_dbg(HANDLE_CTX(dev_handle), "unsupported API ID");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "unsupported API ID");
 		return -1;
 	}
 
@@ -3810,7 +3810,7 @@ static int check_valid_interface(struct libusb_device_handle *dev_handle, unsign
 		return -1;
 
 	if ((api_id < USB_API_WINUSBX) || (api_id > USB_API_HID)) {
-		usbi_dbg(HANDLE_CTX(dev_handle), "unsupported API ID");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "unsupported API ID");
 		return -1;
 	}
 
@@ -3858,7 +3858,7 @@ out:
 
 static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
@@ -3888,7 +3888,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 			return r;
 	}
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "will use interface %d", current_interface);
 
 	transfer_priv->interface_number = (uint8_t)current_interface;
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
@@ -3900,14 +3900,14 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 			&& (LIBUSB_REQ_TYPE(setup->RequestType) == LIBUSB_REQUEST_TYPE_STANDARD)
 			&& (setup->Request == LIBUSB_REQUEST_SET_CONFIGURATION)) {
 		if (setup->Value != priv->active_config) {
-			usbi_warn(TRANSFER_CTX(transfer), "cannot set configuration other than the default one");
+			usbi_warn(usbi_transfer_ctx(transfer), "cannot set configuration other than the default one");
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 		windows_force_sync_completion(itransfer, 0);
 	} else {
 		if (!WinUSBX[sub_api].ControlTransfer(winusb_handle, *setup, transfer->buffer + LIBUSB_CONTROL_SETUP_SIZE, size, &transferred, overlapped)) {
 			if (GetLastError() != ERROR_IO_PENDING) {
-				usbi_warn(TRANSFER_CTX(transfer), "ControlTransfer failed: %s", windows_error_str(0));
+				usbi_warn(usbi_transfer_ctx(transfer), "ControlTransfer failed: %s", windows_error_str(0));
 				return LIBUSB_ERROR_IO;
 			}
 		} else {
@@ -3928,12 +3928,12 @@ static int winusbx_set_interface_altsetting(int sub_api, struct libusb_device_ha
 
 	winusb_handle = handle_priv->interface_handle[iface].api_handle;
 	if (!HANDLE_VALID(winusb_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "interface must be claimed first");
+		usbi_err(usbi_handle_ctx(dev_handle), "interface must be claimed first");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
 	if (!WinUSBX[sub_api].SetCurrentAlternateSetting(winusb_handle, altsetting)) {
-		usbi_err(HANDLE_CTX(dev_handle), "SetCurrentAlternateSetting failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "SetCurrentAlternateSetting failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_IO;
 	}
 
@@ -3949,7 +3949,7 @@ static void WINAPI winusbx_native_iso_transfer_continue_stream_callback(struct l
 	// did not succeed.
 
 	struct winusb_transfer_priv *transfer_priv =
-		get_winusb_transfer_priv(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
+		get_winusb_transfer_priv(usbi_libusb_transfer_to_usbi_transfer(transfer));
 	bool fallback = (transfer->status != LIBUSB_TRANSFER_COMPLETED);
 	int idx;
 
@@ -3974,7 +3974,7 @@ static void WINAPI winusbx_native_iso_transfer_continue_stream_callback(struct l
 }
 static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
@@ -3987,11 +3987,11 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 
 	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
 	if (current_interface < 0) {
-		usbi_err(TRANSFER_CTX(transfer), "unable to match endpoint to an open interface - cancelling transfer");
+		usbi_err(usbi_transfer_ctx(transfer), "unable to match endpoint to an open interface - cancelling transfer");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(usbi_transfer_ctx(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	transfer_priv->interface_number = (uint8_t)current_interface;
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
@@ -4005,7 +4005,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		PKISO_CONTEXT iso_context;
 
 		if (WinUSBX[sub_api].IsoReadPipe == NULL) {
-			usbi_warn(TRANSFER_CTX(transfer), "libusbK DLL does not support isoch transfers");
+			usbi_warn(usbi_transfer_ctx(transfer), "libusbK DLL does not support isoch transfers");
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 
@@ -4025,16 +4025,16 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 			offset += transfer->iso_packet_desc[i].length;
 		}
 
-		if (IS_XFERIN(transfer)) {
-			usbi_dbg(TRANSFER_CTX(transfer), "reading %d iso packets", transfer->num_iso_packets);
+		if (usbi_is_xferin(transfer)) {
+			usbi_dbg(usbi_transfer_ctx(transfer), "reading %d iso packets", transfer->num_iso_packets);
 			ret = WinUSBX[sub_api].IsoReadPipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, overlapped, iso_context);
 		} else {
-			usbi_dbg(TRANSFER_CTX(transfer), "writing %d iso packets", transfer->num_iso_packets);
+			usbi_dbg(usbi_transfer_ctx(transfer), "writing %d iso packets", transfer->num_iso_packets);
 			ret = WinUSBX[sub_api].IsoWritePipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, overlapped, iso_context);
 		}
 
 		if (!ret && GetLastError() != ERROR_IO_PENDING) {
-			usbi_err(TRANSFER_CTX(transfer), "IsoReadPipe/IsoWritePipe failed: %s", windows_error_str(0));
+			usbi_err(usbi_transfer_ctx(transfer), "IsoReadPipe/IsoWritePipe failed: %s", windows_error_str(0));
 			return LIBUSB_ERROR_IO;
 		}
 
@@ -4048,12 +4048,12 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 
 		// Depending on the version of Microsoft WinUSB, isochronous transfers may not be supported.
 		if (WinUSBX[sub_api].ReadIsochPipeAsap == NULL) {
-			usbi_warn(TRANSFER_CTX(transfer), "WinUSB DLL does not support isoch transfers");
+			usbi_warn(usbi_transfer_ctx(transfer), "WinUSB DLL does not support isoch transfers");
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 
 		if (sizeof(struct libusb_iso_packet_descriptor) != sizeof(USBD_ISO_PACKET_DESCRIPTOR)) {
-			usbi_err(TRANSFER_CTX(transfer), "size of WinUsb and libusb isoch packet descriptors don't match");
+			usbi_err(usbi_transfer_ctx(transfer), "size of WinUsb and libusb isoch packet descriptors don't match");
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 
@@ -4073,7 +4073,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 			for (idx = 0; idx < nb_endpoints; ++idx) {
 				ret = WinUSBX[sub_api].QueryPipeEx(winusb_handle, altsetting, (UCHAR)idx, &pipe_info_ex);
 				if (!ret) {
-					usbi_err(TRANSFER_CTX(transfer), "couldn't query interface settings for USB pipe with index %d. Error: %s", idx, windows_error_str(0));
+					usbi_err(usbi_transfer_ctx(transfer), "couldn't query interface settings for USB pipe with index %d. Error: %s", idx, windows_error_str(0));
 					return LIBUSB_ERROR_NOT_FOUND;
 				}
 
@@ -4083,12 +4083,12 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 
 			// Make sure we found the index.
 			if (idx == nb_endpoints) {
-				usbi_err(TRANSFER_CTX(transfer), "couldn't find isoch endpoint 0x%02x", transfer->endpoint);
+				usbi_err(usbi_transfer_ctx(transfer), "couldn't find isoch endpoint 0x%02x", transfer->endpoint);
 				return LIBUSB_ERROR_NOT_FOUND;
 			}
 		}
 
-		if (IS_XFERIN(transfer)) {
+		if (usbi_is_xferin(transfer)) {
 			int interval = pipe_info_ex.Interval;
 
 			// For high-speed and SuperSpeed device, the interval is 2**(bInterval-1).
@@ -4104,7 +4104,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 				iso_transfer_size_multiple = pipe_info_ex.MaximumBytesPerInterval / interval;
 
 			if (transfer->length % iso_transfer_size_multiple != 0) {
-				usbi_err(TRANSFER_CTX(transfer), "length of isoch buffer must be a multiple of the MaximumBytesPerInterval * 8 / Interval");
+				usbi_err(usbi_transfer_ctx(transfer), "length of isoch buffer must be a multiple of the MaximumBytesPerInterval * 8 / Interval");
 				return LIBUSB_ERROR_INVALID_PARAM;
 			}
 		} else {
@@ -4114,7 +4114,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 			for (idx = 0; idx < transfer->num_iso_packets; ++idx) {
 				if ((size_should_be_zero && transfer->iso_packet_desc[idx].length != 0) ||
 					(transfer->iso_packet_desc[idx].length != pipe_info_ex.MaximumBytesPerInterval && idx + 1 < transfer->num_iso_packets && transfer->iso_packet_desc[idx + 1].length > 0)) {
-					usbi_err(TRANSFER_CTX(transfer), "isoch packets for OUT transfer with WinUSB must be contiguous in memory");
+					usbi_err(usbi_transfer_ctx(transfer), "isoch packets for OUT transfer with WinUSB must be contiguous in memory");
 					return LIBUSB_ERROR_INVALID_PARAM;
 				}
 
@@ -4127,7 +4127,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 			if (WinUSBX[sub_api].UnregisterIsochBuffer(transfer_priv->isoch_buffer_handle)) {
 				transfer_priv->isoch_buffer_handle = NULL;
 			} else {
-				usbi_err(TRANSFER_CTX(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
+				usbi_err(usbi_transfer_ctx(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
 				return LIBUSB_ERROR_OTHER;
 			}
 		}
@@ -4135,7 +4135,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		// Register the isoch buffer to the operating system.
 		ret = WinUSBX[sub_api].RegisterIsochBuffer(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, &buffer_handle);
 		if (!ret) {
-			usbi_err(TRANSFER_CTX(transfer), "failed to register WinUSB isoch buffer: %s", windows_error_str(0));
+			usbi_err(usbi_transfer_ctx(transfer), "failed to register WinUSB isoch buffer: %s", windows_error_str(0));
 			return LIBUSB_ERROR_NO_MEM;
 		}
 
@@ -4152,15 +4152,15 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		}
 
 		// Initiate the transfers.
-		if (IS_XFERIN(transfer))
+		if (usbi_is_xferin(transfer))
 			ret = WinUSBX[sub_api].ReadIsochPipeAsap(buffer_handle, 0, transfer->length, !transfer_priv->iso_break_stream, transfer->num_iso_packets, (PUSBD_ISO_PACKET_DESCRIPTOR)transfer->iso_packet_desc, overlapped);
 		else
 			ret = WinUSBX[sub_api].WriteIsochPipeAsap(buffer_handle, 0, out_transfer_length, !transfer_priv->iso_break_stream, overlapped);
 
 		if (!ret && GetLastError() != ERROR_IO_PENDING) {
-			usbi_err(TRANSFER_CTX(transfer), "ReadIsochPipeAsap/WriteIsochPipeAsap failed: %s", windows_error_str(0));
+			usbi_err(usbi_transfer_ctx(transfer), "ReadIsochPipeAsap/WriteIsochPipeAsap failed: %s", windows_error_str(0));
 			if (!WinUSBX[sub_api].UnregisterIsochBuffer(buffer_handle))
-				usbi_warn(TRANSFER_CTX(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
+				usbi_warn(usbi_transfer_ctx(transfer), "failed to unregister WinUSB isoch buffer: %s", windows_error_str(0));
 			return LIBUSB_ERROR_IO;
 		}
 
@@ -4178,7 +4178,7 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 
 static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
@@ -4191,21 +4191,21 @@ static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itran
 
 	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
 	if (current_interface < 0) {
-		usbi_err(TRANSFER_CTX(transfer), "unable to match endpoint to an open interface - cancelling transfer");
+		usbi_err(usbi_transfer_ctx(transfer), "unable to match endpoint to an open interface - cancelling transfer");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(usbi_transfer_ctx(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	transfer_priv->interface_number = (uint8_t)current_interface;
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, handle_priv->interface_handle[current_interface].dev_handle);
 	overlapped = get_transfer_priv_overlapped(itransfer);
 
-	if (IS_XFERIN(transfer)) {
+	if (usbi_is_xferin(transfer)) {
 		// Note: We don't need to handle transfers to pipes with RAW_IO enabled differently,
 		// as ReadPipe() already fails if the length argument doesn't satisfy the RAW_IO requirements.
-		usbi_dbg(TRANSFER_CTX(transfer), "reading %d bytes", transfer->length);
+		usbi_dbg(usbi_transfer_ctx(transfer), "reading %d bytes", transfer->length);
 		ret = WinUSBX[sub_api].ReadPipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, NULL, overlapped);
 	} else {
 		// Set SHORT_PACKET_TERMINATE if ZLP requested.
@@ -4216,21 +4216,21 @@ static int winusbx_submit_bulk_transfer(int sub_api, struct usbi_transfer *itran
 			if (policy &&
 				!WinUSBX[sub_api].SetPipePolicy(winusb_handle, transfer->endpoint,
 				SHORT_PACKET_TERMINATE, sizeof(UCHAR), &policy)) {
-				usbi_err(TRANSFER_CTX(transfer), "failed to set SHORT_PACKET_TERMINATE for endpoint %02X", transfer->endpoint);
+				usbi_err(usbi_transfer_ctx(transfer), "failed to set SHORT_PACKET_TERMINATE for endpoint %02X", transfer->endpoint);
 				return LIBUSB_ERROR_NOT_SUPPORTED;
 			}
 			*current_zlp = (uint8_t)(policy ? WINUSB_ZLP_ON : WINUSB_ZLP_OFF);
 		} else if (policy != (*current_zlp == WINUSB_ZLP_ON)) {
-			usbi_err(TRANSFER_CTX(transfer), "cannot change ZERO_PACKET for endpoint %02X on Windows", transfer->endpoint);
+			usbi_err(usbi_transfer_ctx(transfer), "cannot change ZERO_PACKET for endpoint %02X on Windows", transfer->endpoint);
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 
-		usbi_dbg(TRANSFER_CTX(transfer), "writing %d bytes", transfer->length);
+		usbi_dbg(usbi_transfer_ctx(transfer), "writing %d bytes", transfer->length);
 		ret = WinUSBX[sub_api].WritePipe(winusb_handle, transfer->endpoint, transfer->buffer, transfer->length, NULL, overlapped);
 	}
 
 	if (!ret && GetLastError() != ERROR_IO_PENDING) {
-		usbi_err(TRANSFER_CTX(transfer), "ReadPipe/WritePipe failed: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "ReadPipe/WritePipe failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_IO;
 	}
 
@@ -4248,15 +4248,15 @@ static int winusbx_clear_halt(int sub_api, struct libusb_device_handle *dev_hand
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface - cannot clear");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface - cannot clear");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
 	winusb_handle = handle_priv->interface_handle[current_interface].api_handle;
 
 	if (!WinUSBX[sub_api].ResetPipe(winusb_handle, endpoint)) {
-		usbi_err(HANDLE_CTX(dev_handle), "ResetPipe failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "ResetPipe failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
 
@@ -4265,7 +4265,7 @@ static int winusbx_clear_halt(int sub_api, struct libusb_device_handle *dev_hand
 
 static int winusbx_cancel_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
@@ -4274,11 +4274,11 @@ static int winusbx_cancel_transfer(int sub_api, struct usbi_transfer *itransfer)
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
-	usbi_dbg(TRANSFER_CTX(transfer), "will use interface %d", current_interface);
+	usbi_dbg(usbi_transfer_ctx(transfer), "will use interface %d", current_interface);
 
 	handle = handle_priv->interface_handle[current_interface].api_handle;
 	if (!WinUSBX[sub_api].AbortPipe(handle, transfer->endpoint)) {
-		usbi_err(TRANSFER_CTX(transfer), "AbortPipe failed: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "AbortPipe failed: %s", windows_error_str(0));
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
 
@@ -4313,19 +4313,19 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 		winusb_handle = handle_priv->interface_handle[i].api_handle;
 		if (HANDLE_VALID(winusb_handle)) {
 			for (j = 0; j < priv->usb_interface[i].nb_endpoints; j++) {
-				usbi_dbg(HANDLE_CTX(dev_handle), "resetting ep %02X", priv->usb_interface[i].endpoint[j]);
+				usbi_dbg(usbi_handle_ctx(dev_handle), "resetting ep %02X", priv->usb_interface[i].endpoint[j]);
 				if (!WinUSBX[sub_api].AbortPipe(winusb_handle, priv->usb_interface[i].endpoint[j]))
-					usbi_err(HANDLE_CTX(dev_handle), "AbortPipe (pipe address %02X) failed: %s",
+					usbi_err(usbi_handle_ctx(dev_handle), "AbortPipe (pipe address %02X) failed: %s",
 						priv->usb_interface[i].endpoint[j], windows_error_str(0));
 
 				// FlushPipe seems to fail on OUT pipes
-				if (IS_EPIN(priv->usb_interface[i].endpoint[j])
+				if (usbi_is_epin(priv->usb_interface[i].endpoint[j])
 						&& (!WinUSBX[sub_api].FlushPipe(winusb_handle, priv->usb_interface[i].endpoint[j])))
-					usbi_err(HANDLE_CTX(dev_handle), "FlushPipe (pipe address %02X) failed: %s",
+					usbi_err(usbi_handle_ctx(dev_handle), "FlushPipe (pipe address %02X) failed: %s",
 						priv->usb_interface[i].endpoint[j], windows_error_str(0));
 
 				if (!WinUSBX[sub_api].ResetPipe(winusb_handle, priv->usb_interface[i].endpoint[j]))
-					usbi_err(HANDLE_CTX(dev_handle), "ResetPipe (pipe address %02X) failed: %s",
+					usbi_err(usbi_handle_ctx(dev_handle), "ResetPipe (pipe address %02X) failed: %s",
 						priv->usb_interface[i].endpoint[j], windows_error_str(0));
 			}
 		}
@@ -4344,7 +4344,7 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 
 static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struct usbi_transfer *itransfer, DWORD length)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	int i;
 
@@ -4361,7 +4361,7 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 			// iso only supported on libusbk-based backends for now
 			PKISO_CONTEXT iso_context = (PKISO_CONTEXT)transfer_priv->iso_context;
 			for (i = 0; i < transfer->num_iso_packets; i++) {
-				if (IS_XFERIN(transfer)) {
+				if (usbi_is_xferin(transfer)) {
 					transfer->iso_packet_desc[i].actual_length = iso_context->IsoPackets[i].actual_length;
 				} else {
 					// On Windows the usbd Length field is not used for OUT transfers.
@@ -4371,7 +4371,7 @@ static enum libusb_transfer_status winusbx_copy_transfer_data(int sub_api, struc
 				transfer->iso_packet_desc[i].status = usbd_status_to_libusb_transfer_status(iso_context->IsoPackets[i].status);
 			}
 		} else if (sub_api == SUB_API_WINUSB) {
-			if (IS_XFERIN(transfer)) {
+			if (usbi_is_xferin(transfer)) {
 				/* Convert isochronous packet descriptor between Windows and libusb representation.
 				 * Both representation are guaranteed to have the same length in bytes.*/
 				PUSBD_ISO_PACKET_DESCRIPTOR usbd_iso_packet_desc = (PUSBD_ISO_PACKET_DESCRIPTOR)transfer->iso_packet_desc;
@@ -4411,7 +4411,7 @@ static int winusbx_endpoint_supports_raw_io(int sub_api, struct libusb_device_ha
 	int interface;
 	HANDLE winusb_handle;
 
-	ctx = HANDLE_CTX(dev_handle);
+	ctx = usbi_handle_ctx(dev_handle);
 
 	if (!ctx) {
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -4446,7 +4446,7 @@ static int winusbx_endpoint_supports_raw_io(int sub_api, struct libusb_device_ha
 	winusb_handle = handle_priv->interface_handle[interface].api_handle;
 
 	if (!HANDLE_VALID(winusb_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "WinUSB handle not valid for interface %d, cannot query RAW_IO support", interface);
+		usbi_err(usbi_handle_ctx(dev_handle), "WinUSB handle not valid for interface %d, cannot query RAW_IO support", interface);
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -4465,7 +4465,7 @@ int winusbx_endpoint_set_raw_io(int sub_api, libusb_device_handle* dev_handle, u
 	int interface;
 	HANDLE winusb_handle;
 
-	ctx = HANDLE_CTX(dev_handle);
+	ctx = usbi_handle_ctx(dev_handle);
 
 	if (!ctx) {
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -4500,7 +4500,7 @@ int winusbx_endpoint_set_raw_io(int sub_api, libusb_device_handle* dev_handle, u
 	winusb_handle = handle_priv->interface_handle[interface].api_handle;
 
 	if (!HANDLE_VALID(winusb_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "WinUSB handle not valid for interface %d, cannot set RAW_IO", interface);
+		usbi_err(usbi_handle_ctx(dev_handle), "WinUSB handle not valid for interface %d, cannot set RAW_IO", interface);
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -4537,7 +4537,7 @@ static int winusbx_get_max_raw_io_transfer_size(int sub_api, struct libusb_devic
 	HANDLE winusb_handle;
 	ULONG max_transfer_size = 0;
 
-	ctx = HANDLE_CTX(dev_handle);
+	ctx = usbi_handle_ctx(dev_handle);
 
 	if (!ctx) {
 		return LIBUSB_ERROR_INVALID_PARAM;
@@ -4567,7 +4567,7 @@ static int winusbx_get_max_raw_io_transfer_size(int sub_api, struct libusb_devic
 	winusb_handle = handle_priv->interface_handle[interface].api_handle;
 
 	if (!HANDLE_VALID(winusb_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "WinUSB handle not valid for interface %d, cannot get maximum transfer size for RAW_IO", interface);
+		usbi_err(usbi_handle_ctx(dev_handle), "WinUSB handle not valid for interface %d, cannot get maximum transfer size for RAW_IO", interface);
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -4855,34 +4855,34 @@ static int _hid_get_descriptor(struct libusb_device *dev, HANDLE hid_handle, int
 
 	switch (type) {
 	case LIBUSB_DT_DEVICE:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_DEVICE");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_DEVICE");
 		return _hid_get_device_descriptor(dev, priv->hid, data, size);
 	case LIBUSB_DT_CONFIG:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_CONFIG");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_CONFIG");
 		if (!_index)
 			return _hid_get_config_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_STRING:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_STRING");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_STRING");
 		return _hid_get_string_descriptor(priv->hid, _index, data, size, hid_handle);
 	case LIBUSB_DT_HID:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_HID");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_HID");
 		if (!_index)
 			return _hid_get_hid_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_REPORT:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_REPORT");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_REPORT");
 		if (!_index)
 			return _hid_get_report_descriptor(priv->hid, data, size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	case LIBUSB_DT_PHYSICAL:
-		usbi_dbg(DEVICE_CTX(dev), "LIBUSB_DT_PHYSICAL");
+		usbi_dbg(usbi_device_ctx(dev), "LIBUSB_DT_PHYSICAL");
 		if (HidD_GetPhysicalDescriptor(hid_handle, data, (ULONG)*size))
 			return LIBUSB_COMPLETED;
 		return LIBUSB_ERROR_OTHER;
 	}
 
-	usbi_warn(DEVICE_CTX(dev), "unsupported");
+	usbi_warn(usbi_device_ctx(dev), "unsupported");
 	return LIBUSB_ERROR_NOT_SUPPORTED;
 }
 
@@ -4893,10 +4893,10 @@ static int _hid_get_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 	uint8_t *buf;
 
 	if (tp->hid_buffer != NULL)
-		usbi_err(DEVICE_CTX(dev), "program assertion failed - hid_buffer is not NULL");
+		usbi_err(usbi_device_ctx(dev), "program assertion failed - hid_buffer is not NULL");
 
 	if ((size == 0) || (size > MAX_HID_REPORT_SIZE)) {
-		usbi_warn(DEVICE_CTX(dev), "invalid size (%"PRIuPTR")", (uintptr_t)size);
+		usbi_warn(usbi_device_ctx(dev), "invalid size (%"PRIuPTR")", (uintptr_t)size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
@@ -4908,7 +4908,7 @@ static int _hid_get_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		ioctl_code = IOCTL_HID_GET_FEATURE;
 		break;
 	default:
-		usbi_warn(DEVICE_CTX(dev), "unknown HID report type %d", report_type);
+		usbi_warn(usbi_device_ctx(dev), "unknown HID report type %d", report_type);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
@@ -4918,13 +4918,13 @@ static int _hid_get_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		return LIBUSB_ERROR_NO_MEM;
 
 	buf[0] = (uint8_t)id; // Must be set always
-	usbi_dbg(DEVICE_CTX(dev), "report ID: 0x%02X", buf[0]);
+	usbi_dbg(usbi_device_ctx(dev), "report ID: 0x%02X", buf[0]);
 
 	// NB: The size returned by DeviceIoControl doesn't include report IDs when not in use (0)
 	if (!DeviceIoControl(hid_handle, ioctl_code, buf, expected_size + 1,
 		buf, expected_size + 1, NULL, overlapped)) {
 		if (GetLastError() != ERROR_IO_PENDING) {
-			usbi_err(DEVICE_CTX(dev), "failed to read HID Report: %s", windows_error_str(0));
+			usbi_err(usbi_device_ctx(dev), "failed to read HID Report: %s", windows_error_str(0));
 			free(buf);
 			return LIBUSB_ERROR_IO;
 		}
@@ -4947,10 +4947,10 @@ static int _hid_set_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 	uint8_t *buf;
 
 	if (tp->hid_buffer != NULL)
-		usbi_err(DEVICE_CTX(dev), "program assertion failed - hid_buffer is not NULL");
+		usbi_err(usbi_device_ctx(dev), "program assertion failed - hid_buffer is not NULL");
 
 	if ((size == 0) || (size > max_report_size)) {
-		usbi_warn(DEVICE_CTX(dev), "invalid size (%"PRIuPTR")", (uintptr_t)size);
+		usbi_warn(usbi_device_ctx(dev), "invalid size (%"PRIuPTR")", (uintptr_t)size);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
@@ -4962,11 +4962,11 @@ static int _hid_set_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		ioctl_code = IOCTL_HID_SET_FEATURE;
 		break;
 	default:
-		usbi_warn(DEVICE_CTX(dev), "unknown HID report type %d", report_type);
+		usbi_warn(usbi_device_ctx(dev), "unknown HID report type %d", report_type);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 
-	usbi_dbg(DEVICE_CTX(dev), "report ID: 0x%02X", id);
+	usbi_dbg(usbi_device_ctx(dev), "report ID: 0x%02X", id);
 	// When report IDs are not used (i.e. when id == 0), we must add
 	// a null report ID. Otherwise, we just use original data buffer
 	if (id == 0)
@@ -4984,14 +4984,14 @@ static int _hid_set_report(struct libusb_device *dev, HANDLE hid_handle, int id,
 		// data, we'll get issues when freeing hid_buffer
 		memcpy(buf, data, size);
 		if (buf[0] != id)
-			usbi_warn(DEVICE_CTX(dev), "mismatched report ID (data is %02X, parameter is %02X)", buf[0], id);
+			usbi_warn(usbi_device_ctx(dev), "mismatched report ID (data is %02X, parameter is %02X)", buf[0], id);
 	}
 
 	// NB: The size returned by DeviceIoControl doesn't include report IDs when not in use (0)
 	if (!DeviceIoControl(hid_handle, ioctl_code, buf, write_size,
 		buf, write_size, NULL, overlapped)) {
 		if (GetLastError() != ERROR_IO_PENDING) {
-			usbi_err(DEVICE_CTX(dev), "failed to write HID Output Report: %s", windows_error_str(0));
+			usbi_err(usbi_device_ctx(dev), "failed to write HID Output Report: %s", windows_error_str(0));
 			free(buf);
 			return LIBUSB_ERROR_IO;
 		}
@@ -5078,7 +5078,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 	CHECK_HID_AVAILABLE;
 
 	if (priv->hid == NULL) {
-		usbi_err(HANDLE_CTX(dev_handle), "program assertion failed - private HID structure is uninitialized");
+		usbi_err(usbi_handle_ctx(dev_handle), "program assertion failed - private HID structure is uninitialized");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -5094,10 +5094,10 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 			 * HidD_GetFeature (if the device supports Feature reports)."
 			 */
 			if (hid_handle == INVALID_HANDLE_VALUE) {
-				usbi_warn(HANDLE_CTX(dev_handle), "could not open HID device in R/W mode (keyboard or mouse?) - trying without");
+				usbi_warn(usbi_handle_ctx(dev_handle), "could not open HID device in R/W mode (keyboard or mouse?) - trying without");
 				hid_handle = windows_open(dev_handle, priv->usb_interface[i].path, 0);
 				if (hid_handle == INVALID_HANDLE_VALUE) {
-					usbi_err(HANDLE_CTX(dev_handle), "could not open device %s (interface %d): %s", priv->path, i, windows_error_str(0));
+					usbi_err(usbi_handle_ctx(dev_handle), "could not open device %s (interface %d): %s", priv->path, i, windows_error_str(0));
 					switch (GetLastError()) {
 					case ERROR_FILE_NOT_FOUND: // The device was disconnected
 						return LIBUSB_ERROR_NO_DEVICE;
@@ -5116,7 +5116,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 	hid_attributes.Size = sizeof(hid_attributes);
 	do {
 		if (!HidD_GetAttributes(hid_handle, &hid_attributes)) {
-			usbi_err(HANDLE_CTX(dev_handle), "could not gain access to HID top collection (HidD_GetAttributes)");
+			usbi_err(usbi_handle_ctx(dev_handle), "could not gain access to HID top collection (HidD_GetAttributes)");
 			break;
 		}
 
@@ -5125,15 +5125,15 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 
 		// Set the maximum available input buffer size
 		for (i = 32; HidD_SetNumInputBuffers(hid_handle, i); i *= 2);
-		usbi_dbg(HANDLE_CTX(dev_handle), "set maximum input buffer size to %d", i / 2);
+		usbi_dbg(usbi_handle_ctx(dev_handle), "set maximum input buffer size to %d", i / 2);
 
 		// Get the maximum input and output report size
 		if (!HidD_GetPreparsedData(hid_handle, &preparsed_data) || !preparsed_data) {
-			usbi_err(HANDLE_CTX(dev_handle), "could not read HID preparsed data (HidD_GetPreparsedData)");
+			usbi_err(usbi_handle_ctx(dev_handle), "could not read HID preparsed data (HidD_GetPreparsedData)");
 			break;
 		}
 		if (HidP_GetCaps(preparsed_data, &capabilities) != HIDP_STATUS_SUCCESS) {
-			usbi_err(HANDLE_CTX(dev_handle), "could not parse HID capabilities (HidP_GetCaps)");
+			usbi_err(usbi_handle_ctx(dev_handle), "could not parse HID capabilities (HidP_GetCaps)");
 			break;
 		}
 
@@ -5142,7 +5142,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 		size[1] = capabilities.NumberOutputValueCaps;
 		size[2] = capabilities.NumberFeatureValueCaps;
 		for (j = HidP_Input; j <= HidP_Feature; j++) {
-			usbi_dbg(HANDLE_CTX(dev_handle), "%lu HID %s report value(s) found", ULONG_CAST(size[j]), type[j]);
+			usbi_dbg(usbi_handle_ctx(dev_handle), "%lu HID %s report value(s) found", ULONG_CAST(size[j]), type[j]);
 			priv->hid->uses_report_ids[j] = false;
 			if (size[j] > 0) {
 				value_caps = (HIDP_VALUE_CAPS *)calloc(size[j], sizeof(HIDP_VALUE_CAPS));
@@ -5152,7 +5152,7 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 					nb_ids[0] = 0;
 					nb_ids[1] = 0;
 					for (i = 0; i < (int)size[j]; i++) {
-						usbi_dbg(HANDLE_CTX(dev_handle), "  Report ID: 0x%02X", value_caps[i].ReportID);
+						usbi_dbg(usbi_handle_ctx(dev_handle), "  Report ID: 0x%02X", value_caps[i].ReportID);
 						if (value_caps[i].ReportID != 0)
 							nb_ids[1]++;
 						else
@@ -5160,12 +5160,12 @@ static int hid_open(int sub_api, struct libusb_device_handle *dev_handle)
 					}
 					if (nb_ids[1] != 0) {
 						if (nb_ids[0] != 0)
-							usbi_warn(HANDLE_CTX(dev_handle), "program assertion failed - zero and nonzero report IDs used for %s",
+							usbi_warn(usbi_handle_ctx(dev_handle), "program assertion failed - zero and nonzero report IDs used for %s",
 								type[j]);
 						priv->hid->uses_report_ids[j] = true;
 					}
 				} else {
-					usbi_warn(HANDLE_CTX(dev_handle), "  could not process %s report IDs", type[j]);
+					usbi_warn(usbi_handle_ctx(dev_handle), "  could not process %s report IDs", type[j]);
 				}
 				free(value_caps);
 			}
@@ -5248,7 +5248,7 @@ static int hid_claim_interface(int sub_api, struct libusb_device_handle *dev_han
 
 	handle_priv->interface_handle[iface].dev_handle = INTERFACE_CLAIMED;
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "claimed interface %u", iface);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "claimed interface %u", iface);
 	handle_priv->active_interface = iface;
 
 	return LIBUSB_SUCCESS;
@@ -5281,7 +5281,7 @@ static int hid_set_interface_altsetting(int sub_api, struct libusb_device_handle
 	CHECK_HID_AVAILABLE;
 
 	if (altsetting != 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "set interface altsetting not supported for altsetting >0");
+		usbi_err(usbi_handle_ctx(dev_handle), "set interface altsetting not supported for altsetting >0");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 
@@ -5290,7 +5290,7 @@ static int hid_set_interface_altsetting(int sub_api, struct libusb_device_handle
 
 static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct libusb_device_handle *dev_handle = transfer->dev_handle;
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(dev_handle);
@@ -5320,7 +5320,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 			return r;
 	}
 
-	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);
+	usbi_dbg(usbi_itransfer_ctx(itransfer), "will use interface %d", current_interface);
 
 	transfer_priv->interface_number = (uint8_t)current_interface;
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
@@ -5346,7 +5346,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 			if (setup->Value == priv->active_config) {
 				r = LIBUSB_COMPLETED;
 			} else {
-				usbi_warn(TRANSFER_CTX(transfer), "cannot set configuration other than the default one");
+				usbi_warn(usbi_transfer_ctx(transfer), "cannot set configuration other than the default one");
 				r = LIBUSB_ERROR_NOT_SUPPORTED;
 			}
 			break;
@@ -5361,7 +5361,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 				r = LIBUSB_COMPLETED;
 			break;
 		default:
-			usbi_warn(TRANSFER_CTX(transfer), "unsupported HID control request");
+			usbi_warn(usbi_transfer_ctx(transfer), "unsupported HID control request");
 			return LIBUSB_ERROR_NOT_SUPPORTED;
 		}
 		break;
@@ -5371,7 +5371,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 			size, overlapped);
 		break;
 	default:
-		usbi_warn(TRANSFER_CTX(transfer), "unsupported HID control request");
+		usbi_warn(usbi_transfer_ctx(transfer), "unsupported HID control request");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 
@@ -5389,7 +5389,7 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 
 static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
@@ -5402,7 +5402,7 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 	UNUSED(sub_api);
 	CHECK_HID_AVAILABLE;
 
-	if (IS_XFEROUT(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET))
+	if (usbi_is_xferout(transfer) && (transfer->flags & LIBUSB_TRANSFER_ADD_ZERO_PACKET))
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
 	transfer_priv->hid_dest = NULL;
@@ -5410,17 +5410,17 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 
 	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
 	if (current_interface < 0) {
-		usbi_err(TRANSFER_CTX(transfer), "unable to match endpoint to an open interface - cancelling transfer");
+		usbi_err(usbi_transfer_ctx(transfer), "unable to match endpoint to an open interface - cancelling transfer");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(TRANSFER_CTX(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
+	usbi_dbg(usbi_transfer_ctx(transfer), "matched endpoint %02X with interface %d", transfer->endpoint, current_interface);
 
 	transfer_priv->interface_number = (uint8_t)current_interface;
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
 	set_transfer_priv_handle(itransfer, hid_handle);
 	overlapped = get_transfer_priv_overlapped(itransfer);
-	direction_in = IS_XFERIN(transfer);
+	direction_in = usbi_is_xferin(transfer);
 
 	// If report IDs are not in use, an extra prefix byte must be added
 	if (((direction_in) && (!priv->hid->uses_report_ids[0]))
@@ -5438,7 +5438,7 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 
 	if (direction_in) {
 		transfer_priv->hid_dest = transfer->buffer;
-		usbi_dbg(TRANSFER_CTX(transfer), "reading %d bytes (report ID: 0x00)", length);
+		usbi_dbg(usbi_transfer_ctx(transfer), "reading %d bytes (report ID: 0x00)", length);
 		ret = ReadFile(hid_handle, transfer_priv->hid_buffer, length + 1, NULL, overlapped);
 	} else {
 		if (!priv->hid->uses_report_ids[1])
@@ -5447,12 +5447,12 @@ static int hid_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer
 			// We could actually do without the calloc and memcpy in this case
 			memcpy(transfer_priv->hid_buffer, transfer->buffer, transfer->length);
 
-		usbi_dbg(TRANSFER_CTX(transfer), "writing %d bytes (report ID: 0x%02X)", length, transfer_priv->hid_buffer[0]);
+		usbi_dbg(usbi_transfer_ctx(transfer), "writing %d bytes (report ID: 0x%02X)", length, transfer_priv->hid_buffer[0]);
 		ret = WriteFile(hid_handle, transfer_priv->hid_buffer, length, NULL, overlapped);
 	}
 
 	if (!ret && GetLastError() != ERROR_IO_PENDING) {
-		usbi_err(TRANSFER_CTX(transfer), "HID transfer failed: %s", windows_error_str(0));
+		usbi_err(usbi_transfer_ctx(transfer), "HID transfer failed: %s", windows_error_str(0));
 		safe_free(transfer_priv->hid_buffer);
 		return LIBUSB_ERROR_IO;
 	}
@@ -5491,17 +5491,17 @@ static int hid_clear_halt(int sub_api, struct libusb_device_handle *dev_handle, 
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface - cannot clear");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface - cannot clear");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
-	usbi_dbg(HANDLE_CTX(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
+	usbi_dbg(usbi_handle_ctx(dev_handle), "matched endpoint %02X with interface %d", endpoint, current_interface);
 	hid_handle = handle_priv->interface_handle[current_interface].api_handle;
 
 	// No endpoint selection with Microsoft's implementation, so we try to flush the
 	// whole interface. Should be OK for most case scenarios
 	if (!HidD_FlushQueue(hid_handle)) {
-		usbi_err(HANDLE_CTX(dev_handle), "Flushing of HID queue failed: %s", windows_error_str(0));
+		usbi_err(usbi_handle_ctx(dev_handle), "Flushing of HID queue failed: %s", windows_error_str(0));
 		// Device was probably disconnected
 		return LIBUSB_ERROR_NO_DEVICE;
 	}
@@ -5512,7 +5512,7 @@ static int hid_clear_halt(int sub_api, struct libusb_device_handle *dev_handle, 
 // This extra function is only needed for HID
 static enum libusb_transfer_status hid_copy_transfer_data(int sub_api, struct usbi_transfer *itransfer, DWORD length)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	enum libusb_transfer_status r = LIBUSB_TRANSFER_COMPLETED;
 
@@ -5524,7 +5524,7 @@ static enum libusb_transfer_status hid_copy_transfer_data(int sub_api, struct us
 			if (length > 0) {
 				// First, check for overflow
 				if ((size_t)length > transfer_priv->hid_expected_size) {
-					usbi_err(TRANSFER_CTX(transfer), "OVERFLOW!");
+					usbi_err(usbi_transfer_ctx(transfer), "OVERFLOW!");
 					length = (DWORD)transfer_priv->hid_expected_size;
 					r = LIBUSB_TRANSFER_OVERFLOW;
 				}
@@ -5590,7 +5590,7 @@ static int composite_open(int sub_api, struct libusb_device_handle *dev_handle)
 		// open HID devices with a U2F usage unless running as administrator. We ignore this
 		// failure and proceed without the HID device opened.
 		if (r == LIBUSB_ERROR_ACCESS) {
-			usbi_dbg(HANDLE_CTX(dev_handle), "ignoring access denied error while opening HID interface of composite device");
+			usbi_dbg(usbi_handle_ctx(dev_handle), "ignoring access denied error while opening HID interface of composite device");
 			r = LIBUSB_SUCCESS;
 		}
 	}
@@ -5668,7 +5668,7 @@ static int composite_release_interface(int sub_api, struct libusb_device_handle 
 
 static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	struct libusb_config_descriptor *conf_desc;
 	WINUSB_SETUP_PACKET *setup = (WINUSB_SETUP_PACKET *)transfer->buffer;
@@ -5699,7 +5699,7 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 
 	// Try and target a specific interface if the control setup indicates such
 	if ((iface >= 0) && (iface < USB_MAXINTERFACES)) {
-		usbi_dbg(TRANSFER_CTX(transfer), "attempting control transfer targeted to interface %d", iface);
+		usbi_dbg(usbi_transfer_ctx(transfer), "attempting control transfer targeted to interface %d", iface);
 		if ((priv->usb_interface[iface].path != NULL)
 				&& (priv->usb_interface[iface].apib->submit_control_transfer != NULL)) {
 			r = priv->usb_interface[iface].apib->submit_control_transfer(priv->usb_interface[iface].sub_api, itransfer);
@@ -5715,10 +5715,10 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 			if ((priv->usb_interface[iface].path != NULL)
 					&& (priv->usb_interface[iface].apib->submit_control_transfer != NULL)) {
 				if ((pass == 0) && (priv->usb_interface[iface].restricted_functionality)) {
-					usbi_dbg(TRANSFER_CTX(transfer), "trying to skip restricted interface #%d (HID keyboard or mouse?)", iface);
+					usbi_dbg(usbi_transfer_ctx(transfer), "trying to skip restricted interface #%d (HID keyboard or mouse?)", iface);
 					continue;
 				}
-				usbi_dbg(TRANSFER_CTX(transfer), "using interface %d", iface);
+				usbi_dbg(usbi_transfer_ctx(transfer), "using interface %d", iface);
 				r = priv->usb_interface[iface].apib->submit_control_transfer(priv->usb_interface[iface].sub_api, itransfer);
 				// If not supported on this API, it may be supported on another, so don't give up yet!!
 				if (r == LIBUSB_ERROR_NOT_SUPPORTED)
@@ -5728,13 +5728,13 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 		}
 	}
 
-	usbi_err(TRANSFER_CTX(transfer), "no libusb supported interfaces to complete request");
+	usbi_err(usbi_transfer_ctx(transfer), "no libusb supported interfaces to complete request");
 	return LIBUSB_ERROR_NOT_FOUND;
 }
 
 static int composite_submit_bulk_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int current_interface;
@@ -5743,7 +5743,7 @@ static int composite_submit_bulk_transfer(int sub_api, struct usbi_transfer *itr
 
 	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
 	if (current_interface < 0) {
-		usbi_err(TRANSFER_CTX(transfer), "unable to match endpoint to an open interface - cancelling transfer");
+		usbi_err(usbi_transfer_ctx(transfer), "unable to match endpoint to an open interface - cancelling transfer");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -5755,7 +5755,7 @@ static int composite_submit_bulk_transfer(int sub_api, struct usbi_transfer *itr
 
 static int composite_submit_iso_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_device_handle_priv *handle_priv = get_winusb_device_handle_priv(transfer->dev_handle);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int current_interface;
@@ -5764,7 +5764,7 @@ static int composite_submit_iso_transfer(int sub_api, struct usbi_transfer *itra
 
 	current_interface = interface_by_endpoint(priv, handle_priv, transfer->endpoint);
 	if (current_interface < 0) {
-		usbi_err(TRANSFER_CTX(transfer), "unable to match endpoint to an open interface - cancelling transfer");
+		usbi_err(usbi_transfer_ctx(transfer), "unable to match endpoint to an open interface - cancelling transfer");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -5784,7 +5784,7 @@ static int composite_clear_halt(int sub_api, struct libusb_device_handle *dev_ha
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface - cannot clear");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface - cannot clear");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -5796,7 +5796,7 @@ static int composite_clear_halt(int sub_api, struct libusb_device_handle *dev_ha
 
 static int composite_cancel_transfer(int sub_api, struct usbi_transfer *itransfer)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int current_interface = transfer_priv->interface_number;
@@ -5804,7 +5804,7 @@ static int composite_cancel_transfer(int sub_api, struct usbi_transfer *itransfe
 	UNUSED(sub_api);
 
 	if ((current_interface < 0) || (current_interface >= USB_MAXINTERFACES)) {
-		usbi_err(TRANSFER_CTX(transfer), "program assertion failed - invalid interface_number");
+		usbi_err(usbi_transfer_ctx(transfer), "program assertion failed - invalid interface_number");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
@@ -5844,14 +5844,14 @@ static int composite_reset_device(int sub_api, struct libusb_device_handle *dev_
 
 static enum libusb_transfer_status composite_copy_transfer_data(int sub_api, struct usbi_transfer *itransfer, DWORD length)
 {
-	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
+	struct libusb_transfer *transfer = usbi_transfer_to_libusb_transfer(itransfer);
 	struct winusb_transfer_priv *transfer_priv = get_winusb_transfer_priv(itransfer);
 	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(transfer->dev_handle->dev);
 	int current_interface = transfer_priv->interface_number;
 
 	UNUSED(sub_api);
 	if (priv->usb_interface[current_interface].apib->copy_transfer_data == NULL) {
-		usbi_err(TRANSFER_CTX(transfer), "program assertion failed - no function to copy transfer data");
+		usbi_err(usbi_transfer_ctx(transfer), "program assertion failed - no function to copy transfer data");
 		return LIBUSB_TRANSFER_ERROR;
 	}
 
@@ -5870,13 +5870,13 @@ static int composite_endpoint_supports_raw_io(int sub_api, struct libusb_device_
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface, cannot query RAW_IO support");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface, cannot query RAW_IO support");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
 	if (priv->usb_interface[current_interface].apib->endpoint_supports_raw_io == NULL)
 	{
-		usbi_dbg(HANDLE_CTX(dev_handle), "device driver doesn't support RAW_IO support query");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "device driver doesn't support RAW_IO support query");
 		return 0;
 	}
 
@@ -5895,13 +5895,13 @@ static int composite_endpoint_set_raw_io(int sub_api, libusb_device_handle *dev_
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface, cannot query RAW_IO support");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface, cannot query RAW_IO support");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
 	if (priv->usb_interface[current_interface].apib->endpoint_set_raw_io == NULL)
 	{
-		usbi_dbg(HANDLE_CTX(dev_handle), "device driver doesn't support setting RAW_IO");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "device driver doesn't support setting RAW_IO");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 
@@ -5921,13 +5921,13 @@ static int composite_get_max_raw_io_transfer_size(int sub_api,
 
 	current_interface = interface_by_endpoint(priv, handle_priv, endpoint);
 	if (current_interface < 0) {
-		usbi_err(HANDLE_CTX(dev_handle), "unable to match endpoint to an open interface - cannot get max RAW_IO transfer size");
+		usbi_err(usbi_handle_ctx(dev_handle), "unable to match endpoint to an open interface - cannot get max RAW_IO transfer size");
 		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
 	if (priv->usb_interface[current_interface].apib->get_max_raw_io_transfer_size == NULL)
 	{
-		usbi_dbg(HANDLE_CTX(dev_handle), "device driver doesn't support querying max RAW_IO transfer size");
+		usbi_dbg(usbi_handle_ctx(dev_handle), "device driver doesn't support querying max RAW_IO transfer size");
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 	}
 

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -37,7 +37,7 @@
 
 static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 {
-	usbi_dbg(TRANSFER_CTX(transfer), "actual_length=%d", transfer->actual_length);
+	usbi_dbg(usbi_transfer_ctx(transfer), "actual_length=%d", transfer->actual_length);
 
 	int *completed = (int *)transfer->user_data;
 	*completed = 1;
@@ -51,7 +51,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 static void sync_transfer_wait_for_completion(struct libusb_transfer *transfer)
 {
 	int r, *completed = (int *)transfer->user_data;
-	struct libusb_context *ctx = HANDLE_CTX(transfer->dev_handle);
+	struct libusb_context *ctx = usbi_handle_ctx(transfer->dev_handle);
 
 	while (!*completed) {
 		r = libusb_handle_events_completed(ctx, completed);
@@ -111,7 +111,7 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 	int completed = 0;
 	int r;
 
-	if (usbi_handling_events(HANDLE_CTX(dev_handle)))
+	if (usbi_handling_events(usbi_handle_ctx(dev_handle)))
 		return LIBUSB_ERROR_BUSY;
 
 	transfer = libusb_alloc_transfer(0);
@@ -165,7 +165,7 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 		r = LIBUSB_ERROR_IO;
 		break;
 	default:
-		usbi_warn(HANDLE_CTX(dev_handle),
+		usbi_warn(usbi_handle_ctx(dev_handle),
 			"unrecognised status code %d", transfer->status);
 		r = LIBUSB_ERROR_OTHER;
 	}
@@ -182,7 +182,7 @@ static int do_sync_bulk_transfer(struct libusb_device_handle *dev_handle,
 	int completed = 0;
 	int r;
 
-	if (usbi_handling_events(HANDLE_CTX(dev_handle)))
+	if (usbi_handling_events(usbi_handle_ctx(dev_handle)))
 		return LIBUSB_ERROR_BUSY;
 
 	transfer = libusb_alloc_transfer(0);
@@ -227,7 +227,7 @@ static int do_sync_bulk_transfer(struct libusb_device_handle *dev_handle,
 		r = LIBUSB_ERROR_IO;
 		break;
 	default:
-		usbi_warn(HANDLE_CTX(dev_handle),
+		usbi_warn(usbi_handle_ctx(dev_handle),
 			"unrecognised status code %d", transfer->status);
 		r = LIBUSB_ERROR_OTHER;
 	}


### PR DESCRIPTION
Macros are well-known footguns. Functions provide type safety.