### PR TITLE
remove unused usbi_transfer.num_iso_packets struct field

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1303,7 +1303,6 @@ struct libusb_transfer * LIBUSB_CALL libusb_alloc_transfer(
 		return NULL;
 
 	struct usbi_transfer *itransfer = (struct usbi_transfer *)(ptr + priv_size);
-	itransfer->num_iso_packets = iso_packets;
 	itransfer->priv = ptr;
 	usbi_mutex_init(&itransfer->lock);
 	struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -596,7 +596,6 @@ struct usbi_transfer {
 	 * always take the flying_transfers_lock first */
 	usbi_mutex_t lock;
 
-	int num_iso_packets;
 	struct list_head list;
 	struct list_head completed_list;
 	struct timespec timeout;


### PR DESCRIPTION
Surprisingly, to me, this field seems totally unused. The motivation to removing it is Issue #890 which notes that this field is duplicated, also existing in the libusb_transfer struct.