### PR TITLE
Always set pointer and its size together for -fbounds-safety

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1665,6 +1665,7 @@ int API_EXPORTED libusb_get_device_string(libusb_device *dev,
 	}
 	if (NULL == data) {
 		length = 0;
+		data = NULL;
 	} else if (length > 0) {
 		*data = 0;  // return an empty string on errors when possible
 	}


### PR DESCRIPTION
If length is set to 0, also set data to NULL. When length is zero, usbi_utf8_copy doesn't use the pointer anyway, so there's no change in behaviour.