### PR TITLE
Always set pointer and its size together for -fbounds-safety

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1408,12 +1408,11 @@ static int parse_iad_array(struct libusb_context *ctx,
 		iad_array->iad = iad;
 
 		/* Second pass: Iterate through desc list, fill IAD structures */
-		int remaining = size;
 		i = 0;
 		do {
 			header.bLength = buffer[0];
 			header.bDescriptorType = buffer[1];
-			if (header.bDescriptorType == LIBUSB_DT_INTERFACE_ASSOCIATION && (remaining >= LIBUSB_DT_INTERFACE_ASSOCIATION_SIZE)) {
+			if (header.bDescriptorType == LIBUSB_DT_INTERFACE_ASSOCIATION && (size >= LIBUSB_DT_INTERFACE_ASSOCIATION_SIZE)) {
 				iad[i].bLength = buffer[0];
 				iad[i].bDescriptorType = buffer[1];
 				iad[i].bFirstInterface = buffer[2];
@@ -1425,10 +1424,11 @@ static int parse_iad_array(struct libusb_context *ctx,
 				i++;
 			}
 
-			remaining -= header.bLength;
-			if (remaining < DESC_HEADER_LENGTH) {
+			if (size - header.bLength < DESC_HEADER_LENGTH) {
 				break;
 			}
+
+			size -= header.bLength;
 			buffer += header.bLength;
 		} while (1);
 	}


### PR DESCRIPTION
Eliminated `remaining` variable in favour of just mutating the `size` parameter, which has to be kept in sync with the `buffer` parameter.

Should be no change in behaviour here.