### PR TITLE
Use const in main() signature

### DIFF
--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -99,7 +99,7 @@ static int LIBUSB_CALL hotplug_callback_detach(libusb_context *ctx, libusb_devic
 	return 0;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	libusb_hotplug_callback_handle hp[2];
 	int product_id, vendor_id, class_id;

--- a/examples/listdevs.c
+++ b/examples/listdevs.c
@@ -79,7 +79,7 @@ static int usage(void) {
 	return 1;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	int verbose = 0;
 	libusb_device **devs;

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -271,7 +271,7 @@ static int test_wrapped_device(const char *device_name)
 }
 #endif
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	const char *device_name = NULL;
 	libusb_device **devs;

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -1105,7 +1105,7 @@ static void display_help(const char *progname)
 	printf("If only the vid:pid is provided, xusb attempts to run the most appropriate test\n");
 }
 
-int main(int argc, char** argv)
+int main(int argc, const char* argv[])
 {
 	bool debug_mode = false;
 	const struct libusb_version* version;
@@ -1113,7 +1113,8 @@ int main(int argc, char** argv)
 	size_t i, arglen;
 	unsigned tmp_vid, tmp_pid;
 	uint16_t endian_test = 0xBE00;
-	char *error_lang = NULL, *old_dbg_str = NULL, str[256];
+	const char *error_lang = NULL;
+	char *old_dbg_str = NULL, str[256];
 
 	// Default to generic, expecting VID:PID
 	VID = 0;

--- a/tests/init_context.c
+++ b/tests/init_context.c
@@ -149,7 +149,7 @@ static const libusb_testlib_test tests[] = {
   LIBUSB_NULL_TEST
 };
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
   return libusb_testlib_run_tests(argc, argv, tests);
 }

--- a/tests/libusb_testlib.h
+++ b/tests/libusb_testlib.h
@@ -73,7 +73,7 @@ typedef struct {
  * \param tests A NULL_TEST terminated array of tests
  * \return 0 on success, non-zero on failure
  */
-int libusb_testlib_run_tests(int argc, char *argv[],
+int libusb_testlib_run_tests(int argc, const char *argv[],
 	const libusb_testlib_test *tests);
 
 #endif //LIBUSB_TESTLIB_H

--- a/tests/macos.c
+++ b/tests/macos.c
@@ -126,7 +126,7 @@ static const libusb_testlib_test tests[] = {
   LIBUSB_NULL_TEST
 };
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
   return libusb_testlib_run_tests(argc, argv, tests);
 }

--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -249,7 +249,7 @@ static const libusb_testlib_test tests[] = {
   LIBUSB_NULL_TEST
 };
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
   return libusb_testlib_run_tests(argc, argv, tests);
 }

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -169,7 +169,7 @@ static const libusb_testlib_test tests[] = {
 	LIBUSB_NULL_TEST
 };
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	return libusb_testlib_run_tests(argc, argv, tests);
 }

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -74,7 +74,7 @@ void libusb_testlib_logf(const char *fmt, ...)
 	fflush(stdout);
 }
 
-int libusb_testlib_run_tests(int argc, char *argv[],
+int libusb_testlib_run_tests(int argc, const char *argv[],
 	const libusb_testlib_test *tests)
 {
 	int run_count = 0;
@@ -85,7 +85,7 @@ int libusb_testlib_run_tests(int argc, char *argv[],
 	int skip_count = 0;
 
 	/* Setup default mode of operation */
-	char **test_names = NULL;
+	const char **test_names = NULL;
 	int test_count = 0;
 	bool list_tests = false;
 	bool verbose = false;

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -1121,7 +1121,7 @@ test_hotplug_add_remove(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 }
 
 int
-main(int argc, char **argv)
+main(int argc, char *argv[])
 {
 	g_test_init(&argc, &argv, NULL);
 


### PR DESCRIPTION
This prepares command-line entry points for `-fbounds-safety`, under which `const char *` is treated as a NUL-terminated string.

Most entry points now expose read-only argument strings. `tests/umockdev.c` keeps the standard mutable `argv` form because `g_test_init()` parses and rewrites the argument vector.

A Bounds Safety build was trialed in the existing macOS Xcode job. It was not retained because that job builds only the library target and currently fails in unrelated core code outside this preparation change.

Related to #1659.
Related to #1887.

Assisted-by: codex:gpt-5.6-sol