### PR TITLE
DeviceIoControl use async mode

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -34,6 +34,8 @@
 #include "libusbi.h"
 #include "windows_winusb.h"
 
+#define IO_WAIT_TIME 1000
+
 #define HANDLE_VALID(h) (((h) != NULL) && ((h) != INVALID_HANDLE_VALUE))
 
 // The below macro is used in conjunction with safe loops.
@@ -731,10 +733,38 @@ static void winusb_exit(struct libusb_context *ctx)
 	exit_dlls();
 }
 
+static BOOL device_io_control(HANDLE event, HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer, DWORD nInBufferSize, LPVOID lpOutBuffer, DWORD nOutBufferSize, LPDWORD lpBytesReturned)
+{
+	OVERLAPPED overlapped;
+
+	ResetEvent(event);
+	memset(&overlapped, 0, sizeof(overlapped));
+	overlapped.hEvent = event;
+
+	if (!DeviceIoControl(hDevice, dwIoControlCode, lpInBuffer, nInBufferSize, lpOutBuffer, nOutBufferSize, lpBytesReturned, &overlapped)) {
+		DWORD error = GetLastError();
+		if (error != ERROR_IO_PENDING) {
+			CancelIoEx(hDevice, &overlapped);
+			return FALSE;
+		}
+
+		DWORD wret = WaitForSingleObject(event, IO_WAIT_TIME);
+		if (wret != WAIT_OBJECT_0) {
+			CancelIoEx(hDevice, &overlapped);
+			return FALSE;
+		} else {
+			DWORD bytes_written = 0;
+			if (!GetOverlappedResult(hDevice, &overlapped, &bytes_written, TRUE))
+				return FALSE;
+		}
+	}
+	return TRUE;
+}
+
 /*
  * fetch and cache all the config descriptors through I/O
  */
-static void cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handle)
+static void cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handle, HANDLE event)
 {
 	struct libusb_context *ctx = DEVICE_CTX(dev);
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
@@ -776,8 +806,8 @@ static void cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handl
 		// Dummy call to get the required data size. Initial failures are reported as info rather
 		// than error as they can occur for non-penalizing situations, such as with some hubs.
 		// coverity[tainted_data_argument]
-		if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, &cd_buf_short, size,
-			&cd_buf_short, size, &ret_size, NULL)) {
+		if (!device_io_control(event, hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, &cd_buf_short, size,
+			&cd_buf_short, size, &ret_size)) {
 			usbi_info(ctx, "could not access configuration descriptor %u (dummy) for '%s': %s", i, priv->dev_id, windows_error_str(0));
 			continue;
 		}
@@ -802,8 +832,8 @@ static void cache_config_descriptors(struct libusb_device *dev, HANDLE hub_handl
 		cd_buf_actual->SetupPacket.wIndex = 0;
 		cd_buf_actual->SetupPacket.wLength = cd_buf_short.desc.wTotalLength;
 
-		if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, cd_buf_actual, size,
-			cd_buf_actual, size, &ret_size, NULL)) {
+		if (!device_io_control(event, hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, cd_buf_actual, size,
+			cd_buf_actual, size, &ret_size)) {
 			usbi_err(ctx, "could not access configuration descriptor %u (actual) for '%s': %s", i, priv->dev_id, windows_error_str(0));
 			continue;
 		}
@@ -904,7 +934,7 @@ static int alloc_root_hub_config_desc(struct libusb_device *dev, ULONG num_ports
 	return 0;
 }
 
-static int init_root_hub(struct libusb_device *dev)
+static int init_root_hub(struct libusb_device *dev, HANDLE event)
 {
 	struct libusb_context *ctx = DEVICE_CTX(dev);
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
@@ -924,13 +954,13 @@ static int init_root_hub(struct libusb_device *dev)
 	// are forced to query each individual port of the root hub to try and infer the root hub's
 	// speed. Note that we have to query all ports because the presence of a device on that port
 	// changes if/how Windows returns any useful speed information.
-	handle = CreateFileA(priv->path, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+	handle = CreateFileA(priv->path, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
 	if (handle == INVALID_HANDLE_VALUE) {
 		usbi_err(ctx, "could not open root hub %s: %s", priv->path, windows_error_str(0));
 		return LIBUSB_ERROR_ACCESS;
 	}
 
-	if (!DeviceIoControl(handle, IOCTL_USB_GET_NODE_INFORMATION, NULL, 0, &hub_info, sizeof(hub_info), &size, NULL)) {
+	if (!device_io_control(event, handle, IOCTL_USB_GET_NODE_INFORMATION, NULL, 0, &hub_info, sizeof(hub_info), &size)) {
 		usbi_warn(ctx, "could not get root hub info for '%s': %s", priv->dev_id, windows_error_str(0));
 		CloseHandle(handle);
 		return LIBUSB_ERROR_ACCESS;
@@ -948,8 +978,8 @@ static int init_root_hub(struct libusb_device *dev)
 			conn_info_v2.ConnectionIndex = port_number;
 			conn_info_v2.Length = sizeof(conn_info_v2);
 			conn_info_v2.SupportedUsbProtocols.Usb300 = 1;
-			if (!DeviceIoControl(handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX_V2,
-				&conn_info_v2, sizeof(conn_info_v2), &conn_info_v2, sizeof(conn_info_v2), &size, NULL)) {
+			if (!device_io_control(event, handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX_V2,
+				&conn_info_v2, sizeof(conn_info_v2), &conn_info_v2, sizeof(conn_info_v2), &size)) {
 				usbi_warn(ctx, "could not get node connection information (V2) for root hub '%s' port %lu: %s",
 					priv->dev_id, ULONG_CAST(port_number), windows_error_str(0));
 				break;
@@ -988,8 +1018,8 @@ static int init_root_hub(struct libusb_device *dev)
 	// highest speed that the root hub supports will not give us the correct speed.
 	for (port_number = 1; port_number <= num_ports; port_number++) {
 		conn_info.ConnectionIndex = port_number;
-		if (!DeviceIoControl(handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
-			&conn_info, sizeof(conn_info), &size, NULL)) {
+		if (!device_io_control(event, handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
+			&conn_info, sizeof(conn_info), &size)) {
 			usbi_warn(ctx, "could not get node connection information for root hub '%s' port %lu: %s",
 				priv->dev_id, ULONG_CAST(port_number), windows_error_str(0));
 			continue;
@@ -1081,6 +1111,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 	DWORD size;
 	uint8_t bus_number, depth;
 	int r;
+	HANDLE io_event;
 
 	priv = usbi_get_device_priv(dev);
 
@@ -1088,11 +1119,16 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 	if (priv->initialized)
 		return LIBUSB_SUCCESS;
 
+	io_event = CreateEventA(NULL, FALSE, FALSE, NULL);
+	if (!HANDLE_VALID(io_event))
+		return LIBUSB_ERROR_IO;
+
 	if (parent_dev != NULL) { // Not a HCD root hub
 		ctx = DEVICE_CTX(dev);
 		parent_priv = usbi_get_device_priv(parent_dev);
 		if (parent_priv->apib->id != USB_API_HUB) {
 			usbi_warn(ctx, "parent for device '%s' is not a hub", priv->dev_id);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_NOT_FOUND;
 		}
 
@@ -1102,6 +1138,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 			tmp_dev = get_ancestor(ctx, devinst, &devinst);
 			if (tmp_dev != parent_dev) {
 				usbi_err(ctx, "program assertion failed - first ancestor is not parent");
+				CloseHandle(io_event);
 				return LIBUSB_ERROR_NOT_FOUND;
 			}
 			libusb_unref_device(tmp_dev);
@@ -1110,6 +1147,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 				tmp_dev = get_ancestor(ctx, devinst, &devinst);
 				if (tmp_dev == NULL) {
 					usbi_warn(ctx, "ancestor for device '%s' not found at depth %u", priv->dev_id, depth);
+					CloseHandle(io_event);
 					return LIBUSB_ERROR_NO_DEVICE;
 				}
 				if (tmp_dev->bus_number != 0) {
@@ -1125,6 +1163,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 
 		if (bus_number == 0) {
 			usbi_err(ctx, "program assertion failed - bus number not found for '%s'", priv->dev_id);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_NOT_FOUND;
 		}
 
@@ -1133,26 +1172,29 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 		dev->parent_dev = parent_dev;
 		priv->depth = depth;
 
-		hub_handle = CreateFileA(parent_priv->path, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+		hub_handle = CreateFileA(parent_priv->path, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
 		if (hub_handle == INVALID_HANDLE_VALUE) {
 			usbi_warn(ctx, "could not open hub %s: %s", parent_priv->path, windows_error_str(0));
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_ACCESS;
 		}
 
 		conn_info.ConnectionIndex = (ULONG)port_number;
 		// coverity[tainted_data_argument]
 
-		if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
-			&conn_info, sizeof(conn_info), &size, NULL)) {
+		if (!device_io_control(io_event, hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, &conn_info, sizeof(conn_info),
+			&conn_info, sizeof(conn_info), &size)) {
 			usbi_warn(ctx, "could not get node connection information for device '%s': %s",
 				priv->dev_id, windows_error_str(0));
 			CloseHandle(hub_handle);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_NO_DEVICE;
 		}
 
 		if (conn_info.ConnectionStatus == NoDeviceConnected) {
 			usbi_err(ctx, "device '%s' is no longer connected!", priv->dev_id);
 			CloseHandle(hub_handle);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_NO_DEVICE;
 		}
 
@@ -1160,6 +1202,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 			|| (conn_info.DeviceDescriptor.bDescriptorType != LIBUSB_DT_DEVICE)) {
 			usbi_err(ctx, "device '%s' has invalid descriptor!", priv->dev_id);
 			CloseHandle(hub_handle);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_OTHER;
 		}
 
@@ -1173,6 +1216,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 				dev->device_descriptor.bNumConfigurations,
 				priv->dev_id);
 			CloseHandle(hub_handle);
+			CloseHandle(io_event);
 			return LIBUSB_ERROR_OTHER;
 		}
 
@@ -1181,15 +1225,15 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 			dev->device_descriptor.bNumConfigurations, priv->active_config,	priv->dev_id);
 
 		// Cache as many config descriptors as we can
-		cache_config_descriptors(dev, hub_handle);
+		cache_config_descriptors(dev, hub_handle, io_event);
 
 		// In their great wisdom, Microsoft decided to BREAK the USB speed report between Windows 7 and Windows 8
 		if (windows_version >= WINDOWS_8) {
 			conn_info_v2.ConnectionIndex = (ULONG)port_number;
 			conn_info_v2.Length = sizeof(USB_NODE_CONNECTION_INFORMATION_EX_V2);
 			conn_info_v2.SupportedUsbProtocols.Usb300 = 1;
-			if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX_V2,
-				&conn_info_v2, sizeof(conn_info_v2), &conn_info_v2, sizeof(conn_info_v2), &size, NULL)) {
+			if (!device_io_control(io_event, hub_handle, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX_V2,
+				&conn_info_v2, sizeof(conn_info_v2), &conn_info_v2, sizeof(conn_info_v2), &size)) {
 				usbi_warn(ctx, "could not get node connection information (V2) for device '%s': %s",
 					priv->dev_id,  windows_error_str(0));
 			} else if (conn_info_v2.Flags.DeviceIsOperatingAtSuperSpeedPlusOrHigher) {
@@ -1217,16 +1261,21 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 			break;
 		}
 	} else {
-		r = init_root_hub(dev);
-		if (r)
+		r = init_root_hub(dev, io_event);
+		if (r) {
+			CloseHandle(io_event);
 			return r;
+		}
 	}
 
 	r = usbi_sanitize_device(dev);
-	if (r)
+	if (r) {
+		CloseHandle(io_event);
 		return r;
+	}
 
 	priv->initialized = true;
+	CloseHandle(io_event);
 
 	usbi_dbg(ctx, "(bus: %u, addr: %u, depth: %u, port: %u): '%s'",
 		dev->bus_number, dev->device_address, priv->depth, dev->port_number, priv->dev_id);


### PR DESCRIPTION
DeviceIoControl() will hang indefinitely when the Nacon PS4 Compact Controller is connected, so use async mode to safely call it with a timeout.

We're running into this when adding support for libusb to Steam, so this is a critical fix for us.

This PR is based on https://github.com/libusb/libusb/pull/1127, with the requested changes applied and code reformatted to match libusb style.