### PR TITLE
windows: Support loading libusbK.dll from app directory

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2808,7 +2808,7 @@ cleanup_winusb:
 		usbi_info(ctx, "WinUSB DLL is not available");
 	}
 
-	hlibusbK = load_system_library(ctx, "libusbK");
+	hlibusbK = LoadLibraryA("libusbK.dll");
 	if (hlibusbK != NULL) {
 		LibK_GetVersion_t pLibK_GetVersion;
 		LibK_GetProcAddress_t pLibK_GetProcAddress;


### PR DESCRIPTION
This allows app to ship their own version of the libusbK.dll in their package, and use that without having to install it into the Windows sytem directory.