### PR TITLE
Add v145 toolset to build_all.ps1

### DIFF
--- a/msvc/build_all.ps1
+++ b/msvc/build_all.ps1
@@ -1,4 +1,4 @@
-$toolsets = "v120", "v140", "v141", "v142", "v143"
+$toolsets = "v120", "v140", "v141", "v142", "v143", "v145"
 $platforms = "Win32", "x64", "ARM", "ARM64"
 $configurations = "Debug", "Release"
 


### PR DESCRIPTION
This will add VS2026 support.

Somehow this changing is missing from PR #1702.