### PR TITLE
windows hotplug: little preventive fixes and improvements

### DIFF
--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -263,8 +263,6 @@ static LRESULT CALLBACK windows_proc_callback(
 	WPARAM wParam,
 	LPARAM lParam)
 {
-	UNUSED(lParam);
-
 	static HDEVNOTIFY device_notify_handle;
 
 	switch (message)
@@ -317,7 +315,8 @@ static LRESULT CALLBACK windows_proc_callback(
 				const char* device_name = ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name;
 #endif
 
-				windows_refresh_device_list_for_all_ctx(wParam == DBT_DEVICEARRIVAL ? true : false, device_name);
+				if (device_name != NULL)
+					windows_refresh_device_list_for_all_ctx(wParam == DBT_DEVICEARRIVAL ? true : false, device_name);
 
 #ifdef UNICODE
 				free(device_name);

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1158,7 +1158,7 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 
 		if ((conn_info.DeviceDescriptor.bLength != LIBUSB_DT_DEVICE_SIZE)
 			|| (conn_info.DeviceDescriptor.bDescriptorType != LIBUSB_DT_DEVICE)) {
-			usbi_err(ctx, "device '%s' has invalid descriptor!", priv->dev_id);
+			usbi_warn(ctx, "device '%s' has invalid descriptor!", priv->dev_id);
 			CloseHandle(hub_handle);
 			return LIBUSB_ERROR_OTHER;
 		}
@@ -2201,22 +2201,22 @@ static int usbi_utf16le_to_utf8(uint8_t const *src, int src_length, char *dst, i
 
 /*
  * Backend implementation for libusb_get_device_string().
- * 
+ *
  * Windows makes getting the common device strings
  * very difficult.  DEVPKEY_Device_* does not have SerialNumber,
  * and it reports the driver manufacturer, not the device manufacturer.
- * 
+ *
  * We could parse the serial number from the DEVICE_ID string:
  * https://learn.microsoft.com/en-us/windows-hardware/drivers/install/device-instance-ids
  * https://learn.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers
- * 
- * However, using the dev_id for getting the serial number is 
+ *
+ * However, using the dev_id for getting the serial number is
  * definitely not recommended.
  *
  * The following implementation uses an IOCTL
  * to the parent USB hub to perform the USB control request for the
  * string descriptor without opening the USB device.
- * While we would rather not invoke USB IO, we currently lack a 
+ * While we would rather not invoke USB IO, we currently lack a
  * better option.
  */
 static int winusb_get_device_string(libusb_device *dev,

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12008
+#define LIBUSB_NANO 12009


### PR DESCRIPTION
- check for NULL device_name before using it to trig a device list refresh
- fix wrong UNUSED()
- warn instead of err when discovered device as invalid descriptor

I would suggest to have this in the final 1.0.30 release