### PR TITLE
windows hotplug: hotplug events fire for hubs

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -242,6 +242,10 @@ struct usbdk_device_priv {
 
 struct winusb_device_priv {
 	bool initialized;
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+	bool seen_during_scan; // set true for each device encountered during windows_get_device_list
+	bool seen_before_scan; // set true for each device encountered before windows_get_device_list
+#endif
 	bool root_hub;
 	uint8_t active_config;
 	uint8_t depth; // distance to HCD
@@ -275,7 +279,7 @@ struct usbdk_device_handle_priv {
 	// Not currently used
 	char dummy;
 };
- 
+
 enum WINUSB_ZLP {
 	WINUSB_ZLP_UNSET = 0,
 	WINUSB_ZLP_OFF = 1,

--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -25,16 +25,25 @@
 
 #include <stdio.h>
 #include <dbt.h>
-#include <usbiodef.h>
 
-/* The Windows Hotplug system is a three steps process.
- * 1. We create a monitor on GUID_DEVINTERFACE_USB_DEVICE via a hidden window.
- * 2. Upon notification of an event, we run the current windows backend to get
- *    the list of all devices.
- * 3. We use PDEV_BROADCAST_DEVICEINTERFACE->dbcc_name for finding device object
- *    in this list and generate LEFT or ARRIVED events libusb client via hotplug callbacks
+/* The Windows Hotplug system is a two steps process.
+ * 1. We create a hidden window and listen for DBT_DEVNODES_CHANGED, which Windows
+ *    broadcasts to all top-level windows whenever the device tree changes (no
+ *    registration required). Multiple rapid events (e.g. a hub with many children)
+ *    are coalesced via a short debounce timer so we only scan once the burst settles.
+ *    A maximum delay ceiling guarantees a scan fires within a bounded time even
+ *    during sustained bursts, preventing unbounded latency.
+ * 2. Upon timer expiry, we snapshot the current device list, run a full re-enumeration
+ *    via the Windows backend, then diff the result: newly found devices that have been
+ *    successfully initialized generate DEVICE_ARRIVED events; devices that were not
+ *    encountered by the re-enumeration (physically removed) generate DEVICE_LEFT events.
  */
 
+#define HOTPLUG_DEBOUNCE_TIMER_ID		1
+#define HOTPLUG_DEBOUNCE_MS				10
+#define HOTPLUG_DEBOUNCE_MAX_DELAY_MS	100
+
+static ULONGLONG first_debounce_tick;
 static HWND windows_event_hwnd;
 static HANDLE windows_event_thread_handle;
 static DWORD WINAPI windows_event_thread_main(LPVOID lpParam);
@@ -110,8 +119,23 @@ void windows_initial_scan_devices(struct libusb_context *ctx)
 	usbi_mutex_static_unlock(&active_contexts_lock);
 }
 
-static void windows_refresh_device_list(struct libusb_context *ctx, const bool device_arrived, const char* device_name)
+static void windows_refresh_device_list(struct libusb_context *ctx)
 {
+	struct libusb_device *dev, *next_dev;
+
+	// Step 1: clear seen_during_scan so the scan can mark which devices are still
+	// physically present, and set seen_before_scan so we can distinguish newly
+	// created devices (which start with seen_before_scan=false via calloc).
+	for_each_device_safe(ctx, dev, next_dev)
+	{
+		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
+		priv->seen_during_scan = false;
+		priv->seen_before_scan = true;
+	}
+
+	// Step 2: re-enumerate — winusb_get_device_list attaches newly-arrived devices
+	// and sets seen_during_scan=true for every device it physically encounters.
+	// seen_before_scan is untouched and will be left in default state (false) for newly created devices, allowing us to identify them in the next step.
 	const int ret = windows_get_device_list(ctx);
 	if (ret != LIBUSB_SUCCESS)
 	{
@@ -119,43 +143,41 @@ static void windows_refresh_device_list(struct libusb_context *ctx, const bool d
 		return;
 	}
 
-	struct libusb_device *dev, *next_dev;
-
+	// Step 3: diff old vs new.
 	for_each_device_safe(ctx, dev, next_dev)
 	{
-		struct winusb_device_priv* priv = usbi_get_device_priv(dev);
+		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 
-		if(priv->path == NULL || _stricmp(priv->path, device_name) != 0)
+		if (!priv->seen_during_scan)
 		{
-			continue;
-		}
-
-		if(device_arrived)
-		{
-			usbi_hotplug_notification(ctx, dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
-		}
-		else
-		{
+			// Not encountered by the scan: device was physically removed.
 			if (priv->initialized)
 			{
-				usbi_disconnect_device(dev);
+				usbi_disconnect_device(dev); // fires DEVICE_LEFT
 			}
 			else
 			{
 				usbi_detach_device(dev);
 			}
 		}
+		else if (!priv->seen_before_scan)
+		{
+			if (priv->initialized)
+			{
+				usbi_hotplug_notification(ctx, dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
+			}
+		}
 	}
 }
 
-static void windows_refresh_device_list_for_all_ctx(const bool device_arrived, const char* device_name)
+static void windows_refresh_device_list_for_all_ctx(void)
 {
 	usbi_mutex_static_lock(&active_contexts_lock);
 
 	struct libusb_context *ctx;
 	for_each_context(ctx)
 	{
-		windows_refresh_device_list(ctx, device_arrived, device_name);
+		windows_refresh_device_list(ctx);
 	}
 
 	usbi_mutex_static_unlock(&active_contexts_lock);
@@ -232,106 +254,53 @@ static DWORD WINAPI windows_event_thread_main(LPVOID lpParam)
 	return 0;
 }
 
-static bool register_device_interface_to_window_handle(
-	IN GUID interface_class_guid,
-	IN HWND hwnd,
-	OUT HDEVNOTIFY* device_notify_handle)
-{
-	DEV_BROADCAST_DEVICEINTERFACE notificationFilter = { 0 };
-	notificationFilter.dbcc_size = sizeof(notificationFilter);
-	notificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-	notificationFilter.dbcc_classguid = interface_class_guid;
-
-	*device_notify_handle = RegisterDeviceNotification(
-		hwnd,
-		&notificationFilter,
-		DEVICE_NOTIFY_WINDOW_HANDLE
-	);
-
-	if (*device_notify_handle == NULL)
-	{
-		log_error("register_device_interface_to_window_handle");
-		return false;
-	}
-
-	return true;
-}
-
 static LRESULT CALLBACK windows_proc_callback(
 	HWND hwnd,
 	UINT message,
 	WPARAM wParam,
 	LPARAM lParam)
 {
-	static HDEVNOTIFY device_notify_handle;
-
 	switch (message)
 	{
-	case WM_CREATE:
-		if (!register_device_interface_to_window_handle(
-			GUID_DEVINTERFACE_USB_DEVICE,
-			hwnd,
-			&device_notify_handle))
-		{
-			return -1;
-		}
-		return 0;
-
 	case WM_DEVICECHANGE:
-		switch (wParam)
+		if (wParam == DBT_DEVNODES_CHANGED)
 		{
-		case DBT_DEVICEARRIVAL:
-		case DBT_DEVICEREMOVECOMPLETE:
-			if (((PDEV_BROADCAST_HDR)lParam)->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+			if (first_debounce_tick == 0)
 			{
-#ifdef UNICODE
-				char* device_name = NULL;
-				const WCHAR* w_dbcc_name = ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name;
-
-				const int len = WideCharToMultiByte(CP_UTF8, 0, w_dbcc_name, -1, NULL, 0, NULL, NULL);
-			    if (len == 0)
-				{
-			        log_error("Conversion length calculation failed for ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name conversion from wchar to char");
-			    }
-				else
-				{
-					device_name = (char *)malloc(len);
-				    if (device_name == NULL)
-					{
-				        log_error("Memory allocation failed for ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name conversion from wchar to char");
-				    }
-					else
-					{
-					    const int result = WideCharToMultiByte(CP_UTF8, 0, w_dbcc_name, -1, device_name, len, NULL, NULL);
-					    if (result == 0)
-						{
-					        log_error("Conversion failed for ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name conversion from wchar to char");
-					        free(device_name);
-							device_name = NULL;
-					    }
-					}
-    			}
-#else
-				const char* device_name = ((PDEV_BROADCAST_DEVICEINTERFACE)lParam)->dbcc_name;
-#endif
-
-				if (device_name != NULL)
-					windows_refresh_device_list_for_all_ctx(wParam == DBT_DEVICEARRIVAL ? true : false, device_name);
-
-#ifdef UNICODE
-				free(device_name);
-#endif
-				return TRUE;
+				// First event in a new burst — record the time and start the debounce timer.
+				first_debounce_tick = GetTickCount64();
+				SetTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID, HOTPLUG_DEBOUNCE_MS, NULL);
 			}
-			break;
+			else if (GetTickCount64() - first_debounce_tick >= HOTPLUG_DEBOUNCE_MAX_DELAY_MS)
+			{
+				// Maximum delay reached — force an immediate scan so devices
+				// are not invisible for the entire duration of a sustained burst.
+				KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
+				first_debounce_tick = 0;
+				windows_refresh_device_list_for_all_ctx();
+			}
+			else
+			{
+				// Still within the max-delay window — reset the debounce timer.
+				SetTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID, HOTPLUG_DEBOUNCE_MS, NULL);
+			}
+			return TRUE;
 		}
-		return BROADCAST_QUERY_DENY;
+		return DefWindowProc(hwnd, message, wParam, lParam);
+
+	case WM_TIMER:
+		if (wParam == HOTPLUG_DEBOUNCE_TIMER_ID)
+		{
+			KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
+			first_debounce_tick = 0;
+			windows_refresh_device_list_for_all_ctx();
+			return 0;
+		}
+		return DefWindowProc(hwnd, message, wParam, lParam);
 
 	case WM_CLOSE:
-		if (!UnregisterDeviceNotification(device_notify_handle))
-		{
-			log_error("UnregisterDeviceNotification");
-		}
+		KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
+		first_debounce_tick = 0;
 		if (!DestroyWindow(hwnd))
 		{
 			log_error("DestroyWindow");

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1886,6 +1886,9 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 					usbi_attach_device(dev);
 #endif
 					priv = winusb_device_priv_init(dev);
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+					priv->seen_during_scan = true;
+#endif
 					priv->dev_id = _strdup(dev_id);
 					priv->class_guid = dev_info_data.ClassGuid;
 					if (priv->dev_id == NULL) {
@@ -1917,6 +1920,9 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						libusb_unref_device(dev);
 						goto alloc_device;
 					}
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+					priv->seen_during_scan = true;
+#endif
 				}
 
 			track_unref:

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12009
+#define LIBUSB_NANO 12010


### PR DESCRIPTION
The goal is to have hotplug events fired for hubs as well, since this
behavior is the de-facto standard under Linux.

Replace the per-device notification approach (RegisterDeviceNotification +
GUID_DEVINTERFACE_USB_DEVICE + DBT_DEVICEARRIVAL/DBT_DEVICEREMOVECOMPLETE)
with DBT_DEVNODES_CHANGED, which Windows broadcasts to all top-level
windows whenever the device tree changes — no registration required.

The reason for this change is that hubs only fire DBT_DEVNODES_CHANGED.
Since this event does not carry a device name, the code now relies on 2
boolean flags to determine device arrival and departure instead of
matching device names names.

Rapid events (e.g. a dock with many ports) are coalesced via a 10 ms
debounce timer with a 100 ms maximum delay ceiling, so we scan at most
once per burst while guaranteeing bounded latency during sustained event
storms.

Once the debounce timer fires, run a full re-enumeration via the Windows
backend, then diff the result using 2 new flags in winusb_device_priv:

seen_during_scan: set for every device the scan physically encounters.
Devices that remain unset after the scan have been physically removed.

seen_before_scan: explicitly set to true for all pre-existing devices
before the scan. Newly created devices start with false (usbi_alloc_device
uses calloc), so after the scan they can be identified as arrivals by the
combination seen_during_scan=true, seen_before_scan=false.

Note: made on top of #1761 