### PR TITLE
Specify SPDX-License-Identifier

### DIFF
--- a/Xcode/common.xcconfig
+++ b/Xcode/common.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/Xcode/debug.xcconfig
+++ b/Xcode/debug.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/Xcode/libusb.xcconfig
+++ b/Xcode/libusb.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/Xcode/libusb_debug.xcconfig
+++ b/Xcode/libusb_debug.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/Xcode/libusb_release.xcconfig
+++ b/Xcode/libusb_release.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/Xcode/release.xcconfig
+++ b/Xcode/release.xcconfig
@@ -3,6 +3,8 @@
 // Copyright © 2012 Pete Batard <pete@akeo.ie>
 // For more information, please visit: <https://libusb.info>
 //
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either

--- a/android/config.h
+++ b/android/config.h
@@ -2,6 +2,8 @@
  * Android build config for libusb
  * Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/android/examples/unrooted_android.c
+++ b/android/examples/unrooted_android.c
@@ -4,6 +4,8 @@
  *
  *  Copyright 2020-2021 Peter Stoiber
  *
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either

--- a/android/examples/unrooted_android.h
+++ b/android/examples/unrooted_android.h
@@ -1,6 +1,8 @@
 /*
  *  Copyright 2021 Peter Stoiber
  *
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -1,6 +1,8 @@
 # Android build config for libusb, examples and tests
 # Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
 #
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,6 +1,8 @@
 # Android application build config for libusb
 # Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
 #
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/android/jni/examples.mk
+++ b/android/jni/examples.mk
@@ -1,6 +1,8 @@
 # Android build config for libusb examples
 # Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
 #
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/android/jni/libusb.mk
+++ b/android/jni/libusb.mk
@@ -1,6 +1,8 @@
 # Android build config for libusb
 # Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
 #
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/android/jni/tests.mk
+++ b/android/jni/tests.mk
@@ -1,6 +1,8 @@
 # Android build config for libusb tests
 # Copyright © 2012-2013 RealVNC Ltd. <toby.gray@realvnc.com>
 #
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/examples/dpfp.c
+++ b/examples/dpfp.c
@@ -4,6 +4,8 @@
  * Copyright © 2016 Nathan Hjelm <hjelmn@mac.com>
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * Basic image capture program only, does not consider the powerup quirks or
  * the fact that image encryption may be enabled. Not expected to work
  * flawlessly all of the time.

--- a/examples/ezusb.c
+++ b/examples/ezusb.c
@@ -5,6 +5,8 @@
  * Copyright © 2012 Pete Batard (pete@akeo.ie)
  * Copyright © 2013 Federico Manzan (f.manzan@gmail.com)
  *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU
  *    General Public License as published by the Free Software

--- a/examples/ezusb.h
+++ b/examples/ezusb.h
@@ -5,6 +5,8 @@
  * Copyright © 2002 David Brownell (dbrownell@users.sourceforge.net)
  * Copyright © 2013 Federico Manzan (f.manzan@gmail.com)
  *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU
  *    General Public License as published by the Free Software

--- a/examples/fxload.c
+++ b/examples/fxload.c
@@ -5,6 +5,8 @@
  * Copyright © 2012 Pete Batard (pete@akeo.ie)
  * Copyright © 2013 Federico Manzan (f.manzan@gmail.com)
  *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU
  *    General Public License as published by the Free Software

--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -3,6 +3,8 @@
  * libusb example program for hotplug API
  * Copyright © 2012-2013 Nathan Hjelm <hjelmn@mac.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/examples/listdevs.c
+++ b/examples/listdevs.c
@@ -2,6 +2,8 @@
  * libusb example program to list devices on the bus
  * Copyright © 2007 Daniel Drake <dsd@gentoo.org>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/examples/sam3u_benchmark.c
+++ b/examples/sam3u_benchmark.c
@@ -2,6 +2,8 @@
  * libusb example program to measure Atmel SAM3U isochronous performance
  * Copyright (C) 2012 Harald Welte <laforge@gnumonks.org>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * Copied with the author's permission under LGPL-2.1 from
  * http://git.gnumonks.org/cgi-bin/gitweb.cgi?p=sam3u-tests.git;a=blob;f=usb-benchmark-project/host/benchmark.c;h=74959f7ee88f1597286cd435f312a8ff52c56b7e
  *

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -2,6 +2,8 @@
 * Test suite program based of libusb-0.1-compat testlibusb
 * Copyright (c) 2013 Nathan Hjelm <hjelmn@mac.ccom>
 *
+* SPDX-License-Identifier: LGPL-2.1-or-later
+*
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
 * License as published by the Free Software Foundation; either

--- a/examples/xusb.c
+++ b/examples/xusb.c
@@ -3,6 +3,8 @@
  * Copyright © 2009-2012 Pete Batard <pete@akeo.ie>
  * Contributions to Mass Storage by Alan Stern.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -5,6 +5,8 @@
  * Copyright © 2007-2008 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2001 Johannes Erdfelt <johannes@erdfelt.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -4,6 +4,8 @@
  * Copyright © 2007 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2001 Johannes Erdfelt <johannes@erdfelt.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -4,6 +4,8 @@
  * Copyright © 2012-2021 Nathan Hjelm <hjelmn@mac.com>
  * Copyright © 2012-2013 Peter Stuge <peter@stuge.se>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -6,6 +6,8 @@
  * Copyright © 2019-2022 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2019-2022 Google LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -5,6 +5,9 @@
  * Copyright © 2012 Pete Batard <pete@akeo.ie>
  * Copyright © 2012-2023 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2014-2020 Chris Dickens <christopher.a.dickens@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * For more information, please visit: https://libusb.info
  *
  * This library is free software; you can redistribute it and/or

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -6,6 +6,8 @@
  * Copyright © 2019-2020 Google LLC. All rights reserved.
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -4,6 +4,8 @@
  * Copyright © 2008-2023 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2019-2023 Google LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -3,6 +3,8 @@
  * Copyright © 2008-2023 Nathan Hjelm <hjelmn@users.sourceforge.net>
  * Copyright © 2019-2023 Google LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/emscripten_webusb.cpp
+++ b/libusb/os/emscripten_webusb.cpp
@@ -2,6 +2,8 @@
  * Copyright © 2021 Google LLC
  * Copyright © 2023 Ingvar Stepanyan <me@rreverser.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/events_posix.c
+++ b/libusb/os/events_posix.c
@@ -3,6 +3,8 @@
  *
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/events_posix.h
+++ b/libusb/os/events_posix.h
@@ -3,6 +3,8 @@
  *
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/events_windows.c
+++ b/libusb/os/events_windows.c
@@ -3,6 +3,8 @@
  *
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/events_windows.h
+++ b/libusb/os/events_windows.h
@@ -3,6 +3,8 @@
  *
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/haiku_usb.h
+++ b/libusb/os/haiku_usb.h
@@ -2,6 +2,8 @@
  * Haiku Backend for libusb
  * Copyright © 2014 Akshay Jaggi <akshay1994.leo@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/haiku_usb_backend.cpp
+++ b/libusb/os/haiku_usb_backend.cpp
@@ -2,6 +2,8 @@
  * Haiku Backend for libusb
  * Copyright © 2014 Akshay Jaggi <akshay1994.leo@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -2,6 +2,8 @@
  * Haiku Backend for libusb
  * Copyright © 2014 Akshay Jaggi <akshay1994.leo@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/linux_netlink.c
+++ b/libusb/os/linux_netlink.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2013 Nathan Hjelm <hjelmn@mac.com>
  * Copyright (c) 2016 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/linux_udev.c
+++ b/libusb/os/linux_udev.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2001 Johannes Erdfelt <johannes@erdfelt.com>
  * Copyright (c) 2012-2013 Nathan Hjelm <hjelmn@mac.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -7,6 +7,8 @@
  * Copyright © 2012-2013 Hans de Goede <hdegoede@redhat.com>
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -3,6 +3,8 @@
  * Copyright © 2007 Daniel Drake <dsd@gentoo.org>
  * Copyright © 2001 Johannes Erdfelt <johannes@erdfelt.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -1,6 +1,8 @@
 /*
  * Copyright © 2011 Martin Pieuchot <mpi@openbsd.org>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/null_usb.c
+++ b/libusb/os/null_usb.c
@@ -1,6 +1,8 @@
 /*
  * Copyright © 2019 Pino Toscano <toscano.pino@tiscali.it>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -1,6 +1,8 @@
 /*
  * Copyright © 2011-2013 Martin Pieuchot <mpi@openbsd.org>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2016, Oracle and/or its affiliates.
  * Copyright 2023 Oxide Computer Company
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/sunos_usb.h
+++ b/libusb/os/sunos_usb.h
@@ -2,6 +2,8 @@
  *
  * Copyright (c) 2016, Oracle and/or its affiliates.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/threads_posix.c
+++ b/libusb/os/threads_posix.c
@@ -4,6 +4,8 @@
  * Copyright © 2011 Vitali Lovich <vlovich@aliph.com>
  * Copyright © 2011 Peter Stuge <peter@stuge.se>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/threads_posix.h
+++ b/libusb/os/threads_posix.h
@@ -3,6 +3,8 @@
  *
  * Copyright © 2010 Peter Stuge <peter@stuge.se>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/threads_windows.c
+++ b/libusb/os/threads_windows.c
@@ -4,6 +4,8 @@
  * Copyright © 2010 Michael Plante <michael.plante@gmail.com>
  * Copyright © 2020 Chris Dickens <christopher.a.dickens@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/threads_windows.h
+++ b/libusb/os/threads_windows.h
@@ -3,6 +3,8 @@
  *
  * Copyright © 2010 Michael Plante <michael.plante@gmail.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_common.c
+++ b/libusb/os/windows_common.c
@@ -7,6 +7,8 @@
  * Hash table functions adapted from glibc, by Ulrich Drepper et al.
  * Major code testing contribution by Xiaofan Chen
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -10,6 +10,8 @@
  * Parts of this code adapted from libusb-win32-v1 by Stephan Meyer
  * Major code testing contribution by Xiaofan Chen
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -2,6 +2,8 @@
  * windows hotplug backend for libusb 1.0
  * Copyright © 2024 Sylvain Fasel <sylvain@sonatique.net>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_hotplug.h
+++ b/libusb/os/windows_hotplug.h
@@ -2,6 +2,8 @@
  * windows hotplug backend for libusb 1.0
  * Copyright © 2024 Sylvain Fasel <sylvain@sonatique.net>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -6,6 +6,8 @@
  * Dmitry Fleytman <dmitry@daynix.com>
  * Pavel Gurvich <pavel@daynix.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_usbdk.h
+++ b/libusb/os/windows_usbdk.h
@@ -6,6 +6,8 @@
 * Dmitry Fleytman <dmitry@daynix.com>
 * Pavel Gurvich <pavel@daynix.com>
 *
+* SPDX-License-Identifier: LGPL-2.1-or-later
+*
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
 * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -8,6 +8,8 @@
  * Hash table functions adapted from glibc, by Ulrich Drepper et al.
  * Major code testing contribution by Xiaofan Chen
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -5,6 +5,8 @@
  * Parts of this code adapted from libusb-win32-v1 by Stephan Meyer
  * Major code testing contribution by Xiaofan Chen
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/strerror.c
+++ b/libusb/strerror.c
@@ -2,6 +2,8 @@
  * libusb strerror code
  * Copyright © 2013 Hans de Goede <hdegoede@redhat.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -5,6 +5,8 @@
  * Copyright © 2019 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2019 Google LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/libusb/version.h
+++ b/libusb/version.h
@@ -1,3 +1,10 @@
+/*
+ * libusb version.h
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+
 /* This file is parsed by m4 and windres and RC.EXE so please keep it simple. */
 #include "version_nano.h"
 #ifndef LIBUSB_MAJOR

--- a/tests/init_context.c
+++ b/tests/init_context.c
@@ -4,6 +4,8 @@
  * Copyright © 2023 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2023 Google, LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/libusb_testlib.h
+++ b/tests/libusb_testlib.h
@@ -2,6 +2,8 @@
  * libusb test library helper functions
  * Copyright © 2012 Toby Gray <toby.gray@realvnc.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/macos.c
+++ b/tests/macos.c
@@ -4,6 +4,8 @@
  * Copyright © 2023 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2023 Google, LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/set_option.c
+++ b/tests/set_option.c
@@ -4,6 +4,8 @@
  * Copyright © 2023 Nathan Hjelm <hjelmn@cs.unm.edu>
  * Copyright © 2023 Google, LLC. All rights reserved.
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -2,6 +2,8 @@
  * libusb stress test program to perform simple stress tests
  * Copyright © 2012 Toby Gray <toby.gray@realvnc.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -2,6 +2,8 @@
  * libusb multi-thread test program
  * Copyright 2022-2023 Tormod Volden
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -2,6 +2,8 @@
  * libusb test library helper functions
  * Copyright © 2012 Toby Gray <toby.gray@realvnc.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tests/umockdev.c
+++ b/tests/umockdev.c
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2022 Benjamin Berg <bberg@redhat.com>
  *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either


### PR DESCRIPTION
This is a standardized way to specify license and copyright in a machine-parseable way

See: https://spdx.dev/about/overview/

It's very helpful for supply chain and bill of materials tracking.

If we are agreed on this, I can do it in all files.