### PR TITLE
Add many explicit casts for C++ compatibility

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -782,7 +782,7 @@ void usbi_disconnect_device(struct libusb_device *dev)
 /* Perform some final sanity checks on a newly discovered device. If this
  * function fails (negative return code), the device should not be added
  * to the discovered device list. */
-int usbi_sanitize_device(struct libusb_device *dev)
+enum libusb_error usbi_sanitize_device(struct libusb_device *dev)
 {
 	uint8_t num_configurations;
 
@@ -800,7 +800,7 @@ int usbi_sanitize_device(struct libusb_device *dev)
 		usbi_dbg(DEVICE_CTX(dev), "zero configurations, maybe an unauthorized device");
 	}
 
-	return 0;
+	return LIBUSB_SUCCESS;
 }
 
 /* Examine libusb's internal list of known devices, looking for one with
@@ -2633,14 +2633,14 @@ int API_EXPORTED libusb_init_context(libusb_context **ctx, const struct libusb_i
 	list_init(&_ctx->open_devs);
 
 	/* apply default options to all new contexts */
-	for (enum libusb_option option = 0 ; option < LIBUSB_OPTION_MAX ; option++) {
+	for (int option = 0 ; option < (int)LIBUSB_OPTION_MAX ; option++) {
 		if (LIBUSB_OPTION_LOG_LEVEL == option || !default_context_options[option].is_set) {
 			continue;
 		}
 		if (LIBUSB_OPTION_LOG_CB != option) {
-			r = libusb_set_option(_ctx, option);
+			r = libusb_set_option(_ctx, (enum libusb_option)option);
 		} else {
-			r = libusb_set_option(_ctx, option, default_context_options[option].arg.log_cbval);
+			r = libusb_set_option(_ctx, (enum libusb_option)option, default_context_options[option].arg.log_cbval);
 		}
 		if (LIBUSB_SUCCESS != r)
 			goto err_free_ctx;

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -664,7 +664,7 @@ libusb_free_device_list(list, 1);
 static struct discovered_devs *discovered_devs_alloc(void)
 {
 	struct discovered_devs *ret =
-		malloc(sizeof(*ret) + (sizeof(void *) * DISCOVERED_DEVICES_SIZE_STEP));
+		(struct discovered_devs *)malloc(sizeof(*ret) + (sizeof(void *) * DISCOVERED_DEVICES_SIZE_STEP));
 
 	if (ret) {
 		ret->len = 0;
@@ -704,7 +704,7 @@ struct discovered_devs *discovered_devs_append(
 	capacity = discdevs->capacity + DISCOVERED_DEVICES_SIZE_STEP;
 	/* can't use usbi_reallocf here because in failure cases it would
 	 * free the existing discdevs without unreferencing its devices. */
-	new_discdevs = realloc(discdevs,
+	new_discdevs = (struct discovered_devs *)realloc(discdevs,
 		sizeof(*discdevs) + (sizeof(void *) * capacity));
 	if (!new_discdevs) {
 		discovered_devs_free(discdevs);
@@ -725,7 +725,7 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 	unsigned long session_id)
 {
 	size_t priv_size = usbi_backend.device_priv_size;
-	struct libusb_device *dev = calloc(1, PTR_ALIGN(sizeof(*dev)) + priv_size);
+	struct libusb_device *dev = (struct libusb_device *)calloc(1, PTR_ALIGN(sizeof(*dev)) + priv_size);
 
 	if (!dev)
 		return NULL;
@@ -888,7 +888,7 @@ ssize_t API_EXPORTED libusb_get_device_list(libusb_context *ctx,
 
 	/* convert discovered_devs into a list */
 	len = (ssize_t)discdevs->len;
-	ret = calloc((size_t)len + 1, sizeof(struct libusb_device *));
+	ret = (struct libusb_device **)calloc((size_t)len + 1, sizeof(struct libusb_device *));
 	if (!ret) {
 		len = LIBUSB_ERROR_NO_MEM;
 		goto out;
@@ -1425,7 +1425,7 @@ int API_EXPORTED libusb_wrap_sys_device(libusb_context *ctx, intptr_t sys_dev,
 	if (!usbi_backend.wrap_sys_device)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
-	_dev_handle = calloc(1, PTR_ALIGN(sizeof(*_dev_handle)) + priv_size);
+	_dev_handle = (struct libusb_device_handle *)calloc(1, PTR_ALIGN(sizeof(*_dev_handle)) + priv_size);
 	if (!_dev_handle)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1479,7 +1479,7 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 	if (!usbi_atomic_load(&dev->attached))
 		return LIBUSB_ERROR_NO_DEVICE;
 
-	_dev_handle = calloc(1, PTR_ALIGN(sizeof(*_dev_handle)) + priv_size);
+	_dev_handle = (struct libusb_device_handle *)calloc(1, PTR_ALIGN(sizeof(*_dev_handle)) + priv_size);
 	if (!_dev_handle)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -2106,7 +2106,7 @@ unsigned char * LIBUSB_CALL libusb_dev_mem_alloc(libusb_device_handle *dev_handl
 		return NULL;
 
 	if (usbi_backend.dev_mem_alloc)
-		return usbi_backend.dev_mem_alloc(dev_handle, length);
+		return (unsigned char *)usbi_backend.dev_mem_alloc(dev_handle, length);
 	else
 		return NULL;
 }
@@ -2611,7 +2611,7 @@ int API_EXPORTED libusb_init_context(libusb_context **ctx, const struct libusb_i
 	}
 	usbi_mutex_static_unlock(&active_contexts_lock);
 
-	_ctx = calloc(1, PTR_ALIGN(sizeof(*_ctx)) + priv_size);
+	_ctx = (struct libusb_context *)calloc(1, PTR_ALIGN(sizeof(*_ctx)) + priv_size);
 	if (!_ctx) {
 		usbi_mutex_static_unlock(&default_context_lock);
 		return LIBUSB_ERROR_NO_MEM;

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -133,7 +133,7 @@ static int parse_endpoint(struct libusb_context *ctx,
 		return LIBUSB_ERROR_NO_MEM;
 
 	memcpy(extra, begin, (size_t)len);
-	endpoint->extra = extra;
+	endpoint->extra = (const unsigned char *)extra;
 	endpoint->extra_length = (int)len;
 
 	return parsed;
@@ -183,7 +183,7 @@ static int parse_interface(libusb_context *ctx,
 	while (size >= LIBUSB_DT_INTERFACE_SIZE) {
 		struct libusb_interface_descriptor *altsetting;
 
-		altsetting = realloc((void *)usb_interface->altsetting,
+		altsetting = (struct libusb_interface_descriptor *)realloc((void *)usb_interface->altsetting,
 			sizeof(*altsetting) * (size_t)(usb_interface->num_altsetting + 1));
 		if (!altsetting) {
 			r = LIBUSB_ERROR_NO_MEM;
@@ -279,7 +279,7 @@ static int parse_interface(libusb_context *ctx,
 			}
 
 			memcpy(extra, begin, (size_t)len);
-			ifp->extra = extra;
+			ifp->extra = (const unsigned char *)extra;
 			ifp->extra_length = (int)len;
 		}
 
@@ -287,7 +287,7 @@ static int parse_interface(libusb_context *ctx,
 			struct libusb_endpoint_descriptor *endpoint;
 			uint8_t i;
 
-			endpoint = calloc(ifp->bNumEndpoints, sizeof(*endpoint));
+			endpoint = (struct libusb_endpoint_descriptor *)calloc(ifp->bNumEndpoints, sizeof(*endpoint));
 			if (!endpoint) {
 				r = LIBUSB_ERROR_NO_MEM;
 				goto err;
@@ -378,7 +378,7 @@ static int parse_configuration(struct libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	usb_interface = calloc(config->bNumInterfaces, sizeof(*usb_interface));
+	usb_interface = (struct libusb_interface *)calloc(config->bNumInterfaces, sizeof(*usb_interface));
 	if (!usb_interface)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -425,7 +425,7 @@ static int parse_configuration(struct libusb_context *ctx,
 		/*  drivers to later parse */
 		ptrdiff_t len = buffer - begin;
 		if (len > 0) {
-			uint8_t *extra = realloc((void *)config->extra,
+			uint8_t *extra = (uint8_t *)realloc((void *)config->extra,
 						 (size_t)(config->extra_length) + (size_t)len);
 
 			if (!extra) {
@@ -460,7 +460,7 @@ err:
 static int raw_desc_to_config(struct libusb_context *ctx,
 	const uint8_t *buf, int size, struct libusb_config_descriptor **config)
 {
-	struct libusb_config_descriptor *_config = calloc(1, sizeof(*_config));
+	struct libusb_config_descriptor *_config = (struct libusb_config_descriptor *)calloc(1, sizeof(*_config));
 	int r;
 
 	if (!_config)
@@ -567,7 +567,7 @@ int API_EXPORTED libusb_get_active_config_descriptor(libusb_device *dev,
 		return r;
 
 	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
-	buf = malloc(config_len);
+	buf = (uint8_t *)malloc(config_len);
 	if (!buf)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -612,7 +612,7 @@ int API_EXPORTED libusb_get_config_descriptor(libusb_device *dev,
 		return r;
 
 	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
-	buf = malloc(config_len);
+	buf = (uint8_t *)malloc(config_len);
 	if (!buf)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -655,7 +655,7 @@ int API_EXPORTED libusb_get_config_descriptor_by_value(libusb_device *dev,
 		if (r < 0)
 			return r;
 
-		return raw_desc_to_config(DEVICE_CTX(dev), buf, r, config);
+		return raw_desc_to_config(DEVICE_CTX(dev), (uint8_t *)buf, r, config);
 	}
 
 	usbi_dbg(DEVICE_CTX(dev), "value %u", bConfigurationValue);
@@ -736,7 +736,7 @@ int API_EXPORTED libusb_get_ss_endpoint_companion_descriptor(
 			return LIBUSB_ERROR_IO;
 		}
 
-		*ep_comp = malloc(sizeof(**ep_comp));
+		*ep_comp = (struct libusb_ss_endpoint_companion_descriptor *)malloc(sizeof(**ep_comp));
 		if (!*ep_comp)
 			return LIBUSB_ERROR_NO_MEM;
 		(*ep_comp)->bLength = buffer[0];
@@ -792,7 +792,7 @@ static int parse_bos(struct libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	_bos = calloc(1, sizeof(*_bos) + (bos_desc->bNumDeviceCaps * sizeof(void *)));
+	_bos = (struct libusb_bos_descriptor *)calloc(1, sizeof(*_bos) + (bos_desc->bNumDeviceCaps * sizeof(void *)));
 	if (!_bos)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -826,7 +826,7 @@ static int parse_bos(struct libusb_context *ctx,
 			break;
 		}
 
-		_bos->dev_capability[i] = malloc(header->bLength);
+		_bos->dev_capability[i] = (struct libusb_bos_dev_capability_descriptor *)malloc(header->bLength);
 		if (!_bos->dev_capability[i]) {
 			libusb_free_bos_descriptor(_bos);
 			return LIBUSB_ERROR_NO_MEM;
@@ -878,7 +878,7 @@ int API_EXPORTED libusb_get_bos_descriptor(libusb_device_handle *dev_handle,
 	bos_len = libusb_le16_to_cpu(_bos.desc.wTotalLength);
 	usbi_dbg(ctx, "found BOS descriptor: size %u bytes, %u capabilities",
 		 bos_len, _bos.desc.bNumDeviceCaps);
-	bos_data = calloc(1, bos_len);
+	bos_data = (uint8_t *)calloc(1, bos_len);
 	if (!bos_data)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -945,7 +945,7 @@ int API_EXPORTED libusb_get_usb_2_0_extension_descriptor(
 		return LIBUSB_ERROR_IO;
 	}
 
-	_usb_2_0_extension = malloc(sizeof(*_usb_2_0_extension));
+	_usb_2_0_extension = (struct libusb_usb_2_0_extension_descriptor *)malloc(sizeof(*_usb_2_0_extension));
 	if (!_usb_2_0_extension)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1003,7 +1003,7 @@ int API_EXPORTED libusb_get_ss_usb_device_capability_descriptor(
 		return LIBUSB_ERROR_IO;
 	}
 
-	_ss_usb_device_cap = malloc(sizeof(*_ss_usb_device_cap));
+	_ss_usb_device_cap = (struct libusb_ss_usb_device_capability_descriptor *)malloc(sizeof(*_ss_usb_device_cap));
 	if (!_ss_usb_device_cap)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1097,7 +1097,7 @@ int API_EXPORTED libusb_get_ssplus_usb_device_capability_descriptor(
 	parsedDescriptor.wReserved = ReadLittleEndian16(&dev_capability_data[7]);
 
 	uint8_t numSublikSpeedAttributes = (parsedDescriptor.bmAttributes & 0xF) + 1;
-	_ssplus_cap = malloc(sizeof(struct libusb_ssplus_usb_device_capability_descriptor) + (numSublikSpeedAttributes * sizeof(struct libusb_ssplus_sublink_attribute)));
+	_ssplus_cap = (struct libusb_ssplus_usb_device_capability_descriptor *)malloc(sizeof(struct libusb_ssplus_usb_device_capability_descriptor) + (numSublikSpeedAttributes * sizeof(struct libusb_ssplus_sublink_attribute)));
 	if (!_ssplus_cap)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1123,7 +1123,7 @@ int API_EXPORTED libusb_get_ssplus_usb_device_capability_descriptor(
 		uint32_t attr = ReadLittleEndian32(base + (i * sizeof(uint32_t)));
 		_ssplus_cap->sublinkSpeedAttributes[i].ssid = attr & 0x0f;
 		_ssplus_cap->sublinkSpeedAttributes[i].mantissa = attr >> 16;
-		_ssplus_cap->sublinkSpeedAttributes[i].exponent = (attr >> 4) & 0x3 ;
+		_ssplus_cap->sublinkSpeedAttributes[i].exponent = (enum libusb_superspeedplus_sublink_attribute_exponent)((attr >> 4) & 0x3);
 		_ssplus_cap->sublinkSpeedAttributes[i].type = attr & 0x40 ? 	LIBUSB_SSPLUS_ATTR_TYPE_ASYM : LIBUSB_SSPLUS_ATTR_TYPE_SYM;
 		_ssplus_cap->sublinkSpeedAttributes[i].direction = attr & 0x80 ? 	LIBUSB_SSPLUS_ATTR_DIR_TX : 	LIBUSB_SSPLUS_ATTR_DIR_RX;
 		_ssplus_cap->sublinkSpeedAttributes[i].protocol = attr & 0x4000 ? LIBUSB_SSPLUS_ATTR_PROT_SSPLUS: LIBUSB_SSPLUS_ATTR_PROT_SS;
@@ -1197,7 +1197,7 @@ int API_EXPORTED libusb_get_container_id_descriptor(libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	_container_id = malloc(sizeof(*_container_id));
+	_container_id = (struct libusb_container_id_descriptor *)malloc(sizeof(*_container_id));
 	if (!_container_id)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1257,7 +1257,7 @@ int API_EXPORTED libusb_get_platform_descriptor(libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	_platform_descriptor = malloc(dev_cap->bLength);
+	_platform_descriptor = (struct libusb_platform_descriptor *)malloc(dev_cap->bLength);
 	if (!_platform_descriptor)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1405,7 +1405,7 @@ static int parse_iad_array(struct libusb_context *ctx,
 	}
 
 	if (iad_length > 0) {
-		iad = calloc((size_t)iad_length, sizeof(*iad));
+		iad = (struct libusb_interface_association_descriptor *)calloc((size_t)iad_length, sizeof(*iad));
 		if (!iad)
 			return LIBUSB_ERROR_NO_MEM;
 
@@ -1445,7 +1445,7 @@ static int raw_desc_to_iad_array(struct libusb_context *ctx, const uint8_t *buf,
 		int size, struct libusb_interface_association_descriptor_array **iad_array)
 {
 	struct libusb_interface_association_descriptor_array *_iad_array
-		= calloc(1, sizeof(*_iad_array));
+		= (struct libusb_interface_association_descriptor_array *)calloc(1, sizeof(*_iad_array));
 	int r;
 
 	if (!_iad_array)
@@ -1501,7 +1501,7 @@ int API_EXPORTED libusb_get_interface_association_descriptors(libusb_device *dev
 		return r;
 
 	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
-	buf = malloc(config_len);
+	buf = (uint8_t *)malloc(config_len);
 	if (!buf)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1546,7 +1546,7 @@ int API_EXPORTED libusb_get_active_interface_association_descriptors(libusb_devi
 		return r;
 
 	config_len = libusb_le16_to_cpu(_config.desc.wTotalLength);
-	buf = malloc(config_len);
+	buf = (uint8_t *)malloc(config_len);
 	if (!buf)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -1690,7 +1690,7 @@ int API_EXPORTED libusb_get_device_string(libusb_device *dev,
 
 	if (NULL == dev->device_strings_utf8[string_type]) {
 		if (usbi_backend.get_device_string) {
-			s = malloc(LIBUSB_DEVICE_STRING_BYTES_MAX);
+			s = (char *)malloc(LIBUSB_DEVICE_STRING_BYTES_MAX);
 			int rv = usbi_backend.get_device_string(dev, string_type, s, LIBUSB_DEVICE_STRING_BYTES_MAX);
 			if (rv < 0) {
 				free(s);

--- a/libusb/hotplug.c
+++ b/libusb/hotplug.c
@@ -272,7 +272,7 @@ void usbi_hotplug_notification(struct libusb_context *ctx, struct libusb_device 
 	if (!usbi_atomic_load(&ctx->hotplug_ready))
 		return;
 
-	msg = calloc(1, sizeof(*msg));
+	msg = (struct usbi_hotplug_message *)calloc(1, sizeof(*msg));
 	if (!msg) {
 		usbi_err(ctx, "error allocating hotplug message");
 		return;
@@ -365,7 +365,7 @@ int API_EXPORTED libusb_hotplug_register_callback(libusb_context *ctx,
 
 	ctx = usbi_get_context(ctx);
 
-	hotplug_cb = calloc(1, sizeof(*hotplug_cb));
+	hotplug_cb = (struct usbi_hotplug_callback *)calloc(1, sizeof(*hotplug_cb));
 	if (!hotplug_cb)
 		return LIBUSB_ERROR_NO_MEM;
 

--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1300,7 +1300,7 @@ struct libusb_transfer * LIBUSB_CALL libusb_alloc_transfer(
 	size_t libusb_transfer_size = PTR_ALIGN(sizeof(struct libusb_transfer));
 	size_t iso_packets_size = sizeof(struct libusb_iso_packet_descriptor) * (size_t)iso_packets;
 	size_t alloc_size = priv_size + usbi_transfer_size + libusb_transfer_size + iso_packets_size;
-	unsigned char *ptr = calloc(1, alloc_size);
+	unsigned char *ptr = (unsigned char *)calloc(1, alloc_size);
 	if (!ptr)
 		return NULL;
 
@@ -2686,7 +2686,7 @@ static void usbi_event_source_notification(struct libusb_context *ctx)
  * POLLIN and/or POLLOUT. */
 int usbi_add_event_source(struct libusb_context *ctx, usbi_os_handle_t os_handle, short poll_events)
 {
-	struct usbi_event_source *ievent_source = malloc(sizeof(*ievent_source));
+	struct usbi_event_source *ievent_source = (struct usbi_event_source *)malloc(sizeof(*ievent_source));
 
 	if (!ievent_source)
 		return LIBUSB_ERROR_NO_MEM;
@@ -2774,7 +2774,7 @@ const struct libusb_pollfd ** LIBUSB_CALL libusb_get_pollfds(
 	for_each_event_source(ctx, ievent_source)
 		i++;
 
-	ret = calloc(i + 1, sizeof(struct libusb_pollfd *));
+	ret = (struct libusb_pollfd **)calloc(i + 1, sizeof(struct libusb_pollfd *));
 	if (!ret)
 		goto out;
 

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -817,7 +817,7 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 	unsigned long session_id);
 struct libusb_device *usbi_get_device_by_session_id(struct libusb_context *ctx,
 	unsigned long session_id);
-int usbi_sanitize_device(struct libusb_device *dev);
+enum libusb_error usbi_sanitize_device(struct libusb_device *dev);
 void usbi_handle_disconnect(struct libusb_context *ctx, struct libusb_device_handle *dev_handle);
 
 int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -468,7 +468,7 @@ static void darwin_ref_cached_device(struct darwin_cached_device *cached_dev) {
 }
 
 static int ep_to_pipeRef(struct libusb_device_handle *dev_handle, uint8_t ep, uint8_t *pipep, uint8_t *ifcp, struct darwin_interface **interface_out) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
 
   /* current interface */
   struct darwin_interface *cInterface;
@@ -548,7 +548,7 @@ static bool get_ioregistry_value_number (io_service_t service, CFStringRef prope
 
   if (cfNumber) {
     if (CFGetTypeID(cfNumber) == CFNumberGetTypeID()) {
-      success = CFNumberGetValue(cfNumber, type, p);
+      success = CFNumberGetValue((CFNumberRef)cfNumber, type, p);
     }
 
     CFRelease (cfNumber);
@@ -564,12 +564,12 @@ static bool get_ioregistry_value_data (io_service_t service, CFStringRef propert
 
   if (cfData) {
     if (CFGetTypeID (cfData) == CFDataGetTypeID ()) {
-      CFIndex length = CFDataGetLength (cfData);
+      CFIndex length = CFDataGetLength ((CFDataRef)cfData);
       if (length < size) {
         size = length;
       }
 
-      CFDataGetBytes (cfData, CFRangeMake(0, size), p);
+      CFDataGetBytes ((CFDataRef)cfData, CFRangeMake(0, size), (UInt8*)p);
       success = true;
     }
 
@@ -994,13 +994,13 @@ static int darwin_get_device_string(struct libusb_device *dev,
 
   switch (string_type) {
     case LIBUSB_DEVICE_STRING_MANUFACTURER:
-      cf = IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
+      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
       break;
     case LIBUSB_DEVICE_STRING_PRODUCT:
-      cf = IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
+      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
       break;
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
-      cf = IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
+      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
       break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:
@@ -1407,7 +1407,7 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
     }
 
     if (!(*old_session_id)) {
-      new_device = calloc (1, sizeof (*new_device));
+      new_device = (struct darwin_cached_device *)calloc (1, sizeof (*new_device));
       if (!new_device) {
         ret = LIBUSB_ERROR_NO_MEM;
         break;
@@ -1490,7 +1490,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
         return LIBUSB_ERROR_NO_MEM;
       }
 
-      priv = usbi_get_device_priv(dev);
+      priv = (struct darwin_device_priv *)usbi_get_device_priv(dev);
 
       priv->dev = cached_device;
       darwin_ref_cached_device (priv->dev);
@@ -1501,7 +1501,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
       assert(cached_device->address <= UINT8_MAX);
       dev->device_address = (uint8_t)cached_device->address;
     } else {
-      priv = usbi_get_device_priv(dev);
+      priv = (struct darwin_device_priv *)usbi_get_device_priv(dev);
     }
 
     static_assert(sizeof(dev->device_descriptor) == sizeof(cached_device->dev_descriptor),
@@ -1586,7 +1586,7 @@ static enum libusb_error darwin_scan_devices(struct libusb_context *ctx) {
 }
 
 static int darwin_open (struct libusb_device_handle *dev_handle) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
 
@@ -1640,7 +1640,7 @@ static int darwin_open (struct libusb_device_handle *dev_handle) {
 }
 
 static void darwin_close (struct libusb_device_handle *dev_handle) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
   int i;
@@ -1771,7 +1771,7 @@ static const struct libusb_interface_descriptor *get_interface_descriptor_by_num
 }
 
 static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
 
   /* current interface */
   struct darwin_interface *cInterface = &priv->interfaces[iface];
@@ -1837,7 +1837,7 @@ static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle,
 
 static int darwin_claim_interface(struct libusb_device_handle *dev_handle, uint8_t iface) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   io_service_t          usbInterface = IO_OBJECT_NULL;
   IOReturn              kresult;
   enum libusb_error     ret;
@@ -1947,7 +1947,7 @@ static int darwin_claim_interface(struct libusb_device_handle *dev_handle, uint8
 }
 
 static int darwin_release_interface(struct libusb_device_handle *dev_handle, uint8_t iface) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   IOReturn kresult;
 
   /* current interface */
@@ -2007,7 +2007,7 @@ static int check_alt_setting_and_clear_halt(struct libusb_device_handle *dev_han
 }
 
 static int darwin_set_interface_altsetting(struct libusb_device_handle *dev_handle, uint8_t iface, uint8_t altsetting) {
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   IOReturn kresult;
   enum libusb_error ret;
 
@@ -2080,7 +2080,7 @@ static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned c
 static int darwin_restore_state (struct libusb_device_handle *dev_handle, uint8_t active_config,
                                  unsigned long claimed_interfaces) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
-  struct darwin_device_handle_priv *priv = usbi_get_device_handle_priv(dev_handle);
+  struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   int open_count = dpriv->open_count;
   int ret;
 
@@ -2164,7 +2164,7 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
 
   /* store copies of descriptors so they can be compared after the reset */
   memcpy (&descriptor, &dpriv->dev_descriptor, sizeof (descriptor));
-  cached_configurations = alloca (sizeof (*cached_configurations) * descriptor.bNumConfigurations);
+  cached_configurations = (IOUSBConfigurationDescriptor *)alloca (sizeof (*cached_configurations) * descriptor.bNumConfigurations);
 
   for (i = 0 ; i < descriptor.bNumConfigurations ; ++i) {
     kresult = (*dpriv->device)->GetConfigurationDescriptorPtr (dpriv->device, i, &cached_configuration);
@@ -2330,7 +2330,7 @@ static int darwin_kernel_driver_active(struct libusb_device_handle *dev_handle, 
 }
 
 static void darwin_destroy_device(struct libusb_device *dev) {
-  struct darwin_device_priv *dpriv = usbi_get_device_priv(dev);
+  struct darwin_device_priv *dpriv = (struct darwin_device_priv *)usbi_get_device_priv(dev);
 
   if (dpriv->dev) {
     /* need to hold the lock in case this is the last reference to the device */
@@ -2437,7 +2437,7 @@ static int submit_stream_transfer(struct usbi_transfer *itransfer) {
 
 static int submit_iso_transfer(struct usbi_transfer *itransfer) {
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-  struct darwin_transfer_priv *tpriv = usbi_get_transfer_priv(itransfer);
+  struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   IOReturn kresult;
   uint8_t pipeRef;
@@ -2531,7 +2531,7 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) {
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
   struct libusb_control_setup *setup = (struct libusb_control_setup *) transfer->buffer;
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(transfer->dev_handle->dev);
-  struct darwin_transfer_priv *tpriv = usbi_get_transfer_priv(itransfer);
+  struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   IOReturn               kresult;
 
@@ -2676,7 +2676,7 @@ static int darwin_cancel_transfer(struct usbi_transfer *itransfer) {
 static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0) {
   struct usbi_transfer *itransfer = (struct usbi_transfer *)refcon;
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-  struct darwin_transfer_priv *tpriv = usbi_get_transfer_priv(itransfer);
+  struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 
   usbi_dbg (TRANSFER_CTX(transfer), "an async io operation has completed");
 
@@ -2727,7 +2727,7 @@ static enum libusb_transfer_status darwin_transfer_status (struct usbi_transfer 
 
 static int darwin_handle_transfer_completion (struct usbi_transfer *itransfer) {
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
-  struct darwin_transfer_priv *tpriv = usbi_get_transfer_priv(itransfer);
+  struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
   const unsigned char max_transfer_type = LIBUSB_TRANSFER_TYPE_BULK_STREAM;
 #ifdef ENABLE_LOGGING
   const char *transfer_types[] = {"control", "isoc", "bulk", "interrupt", "bulk-stream", NULL};
@@ -2880,7 +2880,7 @@ static bool darwin_has_capture_entitlements (void) {
   }
   value = SecTaskCopyValueForEntitlement(task, CFSTR("com.apple.vm.device-access"), NULL);
   CFRelease (task);
-  entitled = value && (CFGetTypeID (value) == CFBooleanGetTypeID ()) && CFBooleanGetValue (value);
+  entitled = value && (CFGetTypeID (value) == CFBooleanGetTypeID ()) && CFBooleanGetValue ((CFBooleanRef)value);
   if (value) {
     CFRelease (value);
   }

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -579,7 +579,7 @@ static bool get_ioregistry_value_data (io_service_t service, CFStringRef propert
   return success;
 }
 
-static int darwin_device_from_service (struct libusb_context *ctx, io_service_t service, usb_device_t* device)
+static enum libusb_error darwin_device_from_service (struct libusb_context *ctx, io_service_t service, usb_device_t* device)
 {
   io_cf_plugin_ref_t *plugInInterface = NULL;
   IOReturn kresult;
@@ -1691,7 +1691,7 @@ static int darwin_get_configuration(struct libusb_device_handle *dev_handle, uin
   return LIBUSB_SUCCESS;
 }
 
-static enum libusb_error darwin_set_configuration(struct libusb_device_handle *dev_handle, int config) {
+static int darwin_set_configuration(struct libusb_device_handle *dev_handle, int config) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
   uint8_t i;
@@ -1770,7 +1770,7 @@ static const struct libusb_interface_descriptor *get_interface_descriptor_by_num
   return NULL;
 }
 
-static enum libusb_error get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface) {
+static int get_endpoints (struct libusb_device_handle *dev_handle, uint8_t iface) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
 
   /* current interface */
@@ -1840,7 +1840,7 @@ static int darwin_claim_interface(struct libusb_device_handle *dev_handle, uint8
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   io_service_t          usbInterface = IO_OBJECT_NULL;
   IOReturn              kresult;
-  enum libusb_error     ret;
+  int                   ret;
   IOCFPlugInInterface **plugInInterface = NULL;
   SInt32                score;
 
@@ -1983,7 +1983,7 @@ static int darwin_release_interface(struct libusb_device_handle *dev_handle, uin
 }
 
 static int check_alt_setting_and_clear_halt(struct libusb_device_handle *dev_handle, uint8_t altsetting, struct darwin_interface *cInterface) {
-  enum libusb_error ret;
+  int ret;
   IOReturn kresult;
   uint8_t current_alt_setting;
 
@@ -2009,7 +2009,7 @@ static int check_alt_setting_and_clear_halt(struct libusb_device_handle *dev_han
 static int darwin_set_interface_altsetting(struct libusb_device_handle *dev_handle, uint8_t iface, uint8_t altsetting) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   IOReturn kresult;
-  enum libusb_error ret;
+  int ret;
 
   /* current interface */
   struct darwin_interface *cInterface = &priv->interfaces[iface];
@@ -2077,8 +2077,8 @@ static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned c
   return darwin_to_libusb (kresult);
 }
 
-static int darwin_restore_state (struct libusb_device_handle *dev_handle, uint8_t active_config,
-                                 unsigned long claimed_interfaces) {
+static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_handle, uint8_t active_config,
+                                               unsigned long claimed_interfaces) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   int open_count = dpriv->open_count;
@@ -2248,7 +2248,7 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
 static int darwin_reset_device (struct libusb_device_handle *dev_handle) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
-  enum libusb_error ret;
+  int ret;
 
 #if !defined(TARGET_OS_OSX) || TARGET_OS_OSX == 1
   if (dpriv->capture_count > 0) {
@@ -2905,7 +2905,7 @@ static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle,
   UNUSED(interface);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
-  enum libusb_error err;
+  int err;
   struct libusb_context *ctx = HANDLE_CTX (dev_handle);
 
   if (get_interface_interface_version() < 700) {
@@ -2967,7 +2967,7 @@ static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle,
 }
 
 static int darwin_capture_claim_interface(struct libusb_device_handle *dev_handle, uint8_t iface) {
-  enum libusb_error ret;
+  int ret;
   if (dev_handle->auto_detach_kernel_driver && darwin_kernel_driver_active(dev_handle, iface)) {
     ret = darwin_detach_kernel_driver (dev_handle, iface);
     if (ret != LIBUSB_SUCCESS) {
@@ -2979,7 +2979,7 @@ static int darwin_capture_claim_interface(struct libusb_device_handle *dev_handl
 }
 
 static int darwin_capture_release_interface(struct libusb_device_handle *dev_handle, uint8_t iface) {
-  enum libusb_error ret;
+  int ret;
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
 
   ret = darwin_release_interface (dev_handle, iface);

--- a/libusb/os/events_posix.c
+++ b/libusb/os/events_posix.c
@@ -236,7 +236,7 @@ int usbi_alloc_event_data(struct libusb_context *ctx)
 		return 0;
 	}
 
-	struct pollfd *fds = calloc(cnt, sizeof(*fds));
+	struct pollfd *fds = (struct pollfd *)calloc(cnt, sizeof(*fds));
 	if (!fds)
 		return LIBUSB_ERROR_NO_MEM;
 
@@ -256,7 +256,7 @@ int usbi_alloc_event_data(struct libusb_context *ctx)
 int usbi_wait_for_events(struct libusb_context *ctx,
 	struct usbi_reported_events *reported_events, int timeout_ms)
 {
-	struct pollfd *fds = ctx->event_data;
+	struct pollfd *fds = (struct pollfd *)ctx->event_data;
 	usbi_nfds_t nfds = (usbi_nfds_t)ctx->event_data_cnt;
 	int internal_fds, num_ready;
 

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -39,7 +39,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 {
 	usbi_dbg(TRANSFER_CTX(transfer), "actual_length=%d", transfer->actual_length);
 
-	int *completed = transfer->user_data;
+	int *completed = (int *)transfer->user_data;
 	*completed = 1;
 	/*
 	 * Right after setting 'completed', another thread might free the transfer, so don't
@@ -50,7 +50,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 
 static void sync_transfer_wait_for_completion(struct libusb_transfer *transfer)
 {
-	int r, *completed = transfer->user_data;
+	int r, *completed = (int *)transfer->user_data;
 	struct libusb_context *ctx = HANDLE_CTX(transfer->dev_handle);
 
 	while (!*completed) {
@@ -118,7 +118,7 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 	if (!transfer)
 		return LIBUSB_ERROR_NO_MEM;
 
-	buffer = malloc(LIBUSB_CONTROL_SETUP_SIZE + wLength);
+	buffer = (unsigned char *)malloc(LIBUSB_CONTROL_SETUP_SIZE + wLength);
 	if (!buffer) {
 		libusb_free_transfer(transfer);
 		return LIBUSB_ERROR_NO_MEM;


### PR DESCRIPTION
Building as C++ can be useful for various code analysis tools or compiler flags that only work in C++.  And so few changes are needed to achieve this, and C compatibility is of course not broken.