### PR TITLE
core: fix crash on device destruction when already detached

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1338,7 +1338,8 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 		if (usbi_backend.destroy_device)
 			usbi_backend.destroy_device(dev);
 
-		if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
+		if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) &&
+		    usbi_atomic_load(&dev->attached)) {
 			/* backend does not support hotplug */
 			usbi_disconnect_device(dev);
 		}

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12018
+#define LIBUSB_NANO 12020


### PR DESCRIPTION
When a device's class GUID or instance ID changes during re-enumeration, the Windows backend calls usbi_detach_device() followed by libusb_unref_device(). If the application still holds a reference, the device is not freed immediately. Later, when the application drops its last reference, libusb_unref_device() calls usbi_disconnect_device() again (only for non-hotplug backends), causing a double list_del() on already-stale list pointers and crashing.

Guard the disconnect call with a check on dev->attached, which is already set to 0 by the earlier usbi_detach_device() call.

This fix is safe for all backends, not just Windows: if any backend detaches a device before its refcount drops to zero, the double- disconnect is now prevented.

Closes #1599