### PR TITLE
Windows: Fix Error 31 in libusb_get_device_string by querying Language ID

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2272,7 +2272,20 @@ static int winusb_get_device_string(libusb_device *dev,
 	BOOL result = DeviceIoControl(hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, &sd, size,
 		&sd, size, &ret_size, NULL);
 
-	USHORT langId = result ? (USHORT)(sd.desc.bString[0] | (sd.desc.bString[1] << 8)) : 0;
+	if (!result) {
+		usbi_err(ctx, "could not access string descriptor 0 for '%s': %s", priv->dev_id, windows_error_str(0));
+		CloseHandle(hub_handle);
+		return LIBUSB_ERROR_ACCESS;
+	}
+
+	USHORT langId = 0;
+	if (sd.desc.bDescriptorType != LIBUSB_DT_STRING) {
+		usbi_warn(ctx, "descriptor 0 not a string descriptor for '%s'", priv->dev_id);
+	} else if (sd.desc.bLength < 4) {
+		usbi_warn(ctx, "string descriptor 0 too short for '%s'", priv->dev_id);
+	} else {
+		langId = (USHORT)(sd.desc.bString[0] | (sd.desc.bString[1] << 8));
+	}
 
 	size = sizeof(sd);
 	memset(&sd, 0, size);


### PR DESCRIPTION
### Description of the Issue
Currently, on Windows, when `libusb_get_device_string()` is called, the underlying implementation constructs the control request for the string descriptor with the Language ID strictly hardcoded to `0`. 

While some devices tolerate a Language ID of `0`, on certain USB devices this results in a failure during the `DeviceIoControl` call, returning Windows System Error 31 (`ERROR_GEN_FAILURE` - A device attached to the system is not functioning).

### Root Cause
The USB specification dictates that string descriptors should be requested using a valid Language ID (LANGID) supported by the device. Requesting a specific string descriptor with `LANGID = 0` is out of spec, as index 0 is reserved for retrieving the array of supported LANGIDs itself.

### Proposed Fix
This patch modifies the behavior to correctly follow the USB specification:
1. It first issues a request for string descriptor index `0` to retrieve the array of supported Language IDs.
2. It extracts a valid Language ID (typically the first available one).
3. It then uses this correctly retrieved Language ID in the subsequent `DeviceIoControl` request to fetch the actual string descriptor.

This ensures proper compatibility with strictly compliant USB devices and resolves the Error 31 without breaking existing functional devices.