### PR TITLE
Address issue: race in libusb get device list and libusb free device list with win usb backend + claim_interface race

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -728,8 +728,11 @@ struct libusb_device *usbi_alloc_device(struct libusb_context *ctx,
 	dev->session_data = session_id;
 	dev->speed = LIBUSB_SPEED_UNKNOWN;
 
-	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
-		usbi_connect_device(dev);
+	/* Note: the device is NOT added to ctx->usb_devs here. The caller
+	 * (backend) must call usbi_connect_device() after fully initializing
+	 * the device's private data. This prevents a concurrent
+	 * usbi_get_device_by_session_id() from finding a half-initialized
+	 * device. */
 
 	return dev;
 }
@@ -1327,8 +1330,27 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 	if (!dev)
 		return;
 
-	refcnt = usbi_atomic_dec(&dev->refcnt);
-	assert(refcnt >= 0);
+	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
+		/* Non-hotplug path: the decrement and conditional list removal
+		 * must be atomic with respect to usbi_get_device_by_session_id(),
+		 * which searches the list and refs the device under the same lock.
+		 * Without this, a concurrent search could find a device whose
+		 * refcnt has already reached zero and hit the assert in
+		 * libusb_ref_device(). */
+		struct libusb_context *ctx = DEVICE_CTX(dev);
+
+		usbi_mutex_lock(&ctx->usb_devs_lock);
+		refcnt = usbi_atomic_dec(&dev->refcnt);
+		assert(refcnt >= 0);
+		if (refcnt == 0 && usbi_atomic_load(&dev->attached)) {
+			list_del(&dev->list);
+			usbi_atomic_store(&dev->attached, 0);
+		}
+		usbi_mutex_unlock(&ctx->usb_devs_lock);
+	} else {
+		refcnt = usbi_atomic_dec(&dev->refcnt);
+		assert(refcnt >= 0);
+	}
 
 	if (refcnt == 0) {
 		usbi_dbg(DEVICE_CTX(dev), "destroy device %d.%d", dev->bus_number, dev->device_address);
@@ -1337,12 +1359,6 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
 
 		if (usbi_backend.destroy_device)
 			usbi_backend.destroy_device(dev);
-
-		if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) &&
-		    usbi_atomic_load(&dev->attached)) {
-			/* backend does not support hotplug */
-			usbi_disconnect_device(dev);
-		}
 
 		for (int idx = 0; idx < LIBUSB_DEVICE_STRING_COUNT; ++idx) {
 			free(dev->device_strings_utf8[idx]);

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1002,7 +1002,9 @@ struct usbi_os_backend {
 	 * this point, you should be ready to provide device descriptors and so
 	 * on through the get_*_descriptor functions. Finally, call
 	 * usbi_sanitize_device() to perform some final sanity checks on the
-	 * device. Assuming all of the above succeeded, we can now continue.
+	 * device. Assuming all of the above succeeded, call
+	 * usbi_connect_device() to add the device to the context's device list
+	 * and make it discoverable by usbi_get_device_by_session_id().
 	 * If any of the above failed, remember to unreference the device that
 	 * was returned by usbi_alloc_device().
 	 *

--- a/libusb/os/emscripten_webusb.cpp
+++ b/libusb/os/emscripten_webusb.cpp
@@ -642,6 +642,8 @@ val getDeviceList(libusb_context* ctx, discovered_devs** devs) {
 			// This can wrap around but it's the best approximation of a stable
 			// device address and port number we can provide.
 			dev->device_address = dev->port_number = (uint8_t)session_id;
+
+			usbi_connect_device(dev);
 		}
 		*devs = discovered_devs_append(*devs, dev);
 		libusb_unref_device(dev);

--- a/libusb/os/netbsd_usb.c
+++ b/libusb/os/netbsd_usb.c
@@ -171,6 +171,8 @@ netbsd_get_device_list(struct libusb_context * ctx,
 
 			if ((err = usbi_sanitize_device(dev)))
 				goto error;
+
+			usbi_connect_device(dev);
 		}
 		close(fd);
 

--- a/libusb/os/openbsd_usb.c
+++ b/libusb/os/openbsd_usb.c
@@ -200,6 +200,8 @@ obsd_get_device_list(struct libusb_context * ctx,
 					libusb_unref_device(dev);
 					continue;
 				}
+
+				usbi_connect_device(dev);
 			}
 
 			ddd = discovered_devs_append(*discdevs, dev);

--- a/libusb/os/sunos_usb.c
+++ b/libusb/os/sunos_usb.c
@@ -627,6 +627,8 @@ sunos_add_devices(di_devlink_t link, void *arg)
 				usbi_dbg(NULL, "sanitize failed: ");
 				return (DI_WALK_TERMINATE);
 			}
+
+			usbi_connect_device(dev);
 		} else {
 			devpriv = usbi_get_device_priv(dev);
 			usbi_dbg(NULL, "Dev %s exists", devpriv->ugenpath);

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -254,6 +254,11 @@ struct winusb_device_priv {
 	char *dev_id;
 	char *path;  // device interface path
 	int sub_api; // for WinUSB-like APIs
+	usbi_mutex_t interface_lock; // protects usb_interface[] against concurrent
+	                             // claim/release/altsetting from different handles,
+	                             // and concurrent enumeration setup
+	                             // (set_composite_interface, set_hid_interface,
+	                             // and HUB_PASS/DEV_PASS in winusb_get_device_list)
 	struct {
 		char *path; // each interface needs a device interface path,
 		const struct windows_usb_api_backend *apib; // an API backend (multiple drivers support),

--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -158,6 +158,10 @@ static void windows_refresh_device_list(struct libusb_context *ctx)
 			else
 			{
 				usbi_detach_device(dev);
+				// No DEVICE_LEFT message is posted for uninitialized
+				// devices, so no message handler will drop the initial
+				// ref. We must drop it here to avoid a leak.
+				libusb_unref_device(dev);
 			}
 		}
 		else if (!priv->seen_before_scan)

--- a/libusb/os/windows_usbdk.c
+++ b/libusb/os/windows_usbdk.c
@@ -341,6 +341,8 @@ static int usbdk_get_device_list(struct libusb_context *ctx, struct discovered_d
 				libusb_unref_device(dev);
 				continue;
 			}
+
+			usbi_connect_device(dev);
 		}
 
 		if (_discdevs) {

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -1376,6 +1376,7 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	char* endptr;
 	struct libusb_interface_association_descriptor_array *iad_array;
 	const struct libusb_interface_association_descriptor *iad;
+	int r = LIBUSB_SUCCESS;
 
 	// Because MI_## are not necessarily in sequential order (some composite
 	// devices will have only MI_00 & MI_03 for instance), we retrieve the actual
@@ -1400,12 +1401,18 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 		return LIBUSB_ERROR_ACCESS;
 	}
 
+	// Serialize concurrent enumeration callers that all reach this for the
+	// same parent device. Without this, the check-then-modify on
+	// priv->usb_interface[].path causes double-free / use-after-free.
+	usbi_mutex_lock(&priv->interface_lock);
+
 	if (priv->usb_interface[interface_number].path != NULL) {
 		if (api == USB_API_HID) {
 			// HID devices can have multiple collections (COL##) for each MI_## interface
 			usbi_dbg(ctx, "interface[%d] already set - ignoring HID collection: %s",
 				interface_number, device_id);
-			return LIBUSB_ERROR_ACCESS;
+			r = LIBUSB_ERROR_ACCESS;
+			goto out;
 		}
 		// In other cases, just use the latest data
 		safe_free(priv->usb_interface[interface_number].path);
@@ -1417,8 +1424,10 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	priv->usb_interface[interface_number].sub_api = sub_api;
 	if ((api == USB_API_HID) && (priv->hid == NULL)) {
 		priv->hid = calloc(1, sizeof(struct hid_device_priv));
-		if (priv->hid == NULL)
-			return LIBUSB_ERROR_NO_MEM;
+		if (priv->hid == NULL) {
+			r = LIBUSB_ERROR_NO_MEM;
+			goto out;
+		}
 	}
 
 	// For WinUSBX, set up associations for interfaces grouped by an IAD
@@ -1442,7 +1451,9 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 		libusb_free_interface_association_descriptors(iad_array);
 	}
 
-	return LIBUSB_SUCCESS;
+out:
+	usbi_mutex_unlock(&priv->interface_lock);
+	return r;
 }
 
 static int set_hid_interface(struct libusb_context *ctx, struct libusb_device *dev,
@@ -1450,19 +1461,28 @@ static int set_hid_interface(struct libusb_context *ctx, struct libusb_device *d
 {
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
 	uint8_t i;
+	int r = LIBUSB_SUCCESS;
+
+	// Serialize concurrent enumeration callers that all reach this for the
+	// same parent device. Protects priv->hid->nb_interfaces and
+	// priv->usb_interface[].path / apib.
+	usbi_mutex_lock(&priv->interface_lock);
 
 	if (priv->hid == NULL) {
 		usbi_err(ctx, "program assertion failed - parent is not HID");
-		return LIBUSB_ERROR_NO_DEVICE;
+		r = LIBUSB_ERROR_NO_DEVICE;
+		goto out;
 	} else if (priv->hid->nb_interfaces == USB_MAXINTERFACES) {
 		usbi_err(ctx, "program assertion failed - max USB interfaces reached for HID device");
-		return LIBUSB_ERROR_NO_DEVICE;
+		r = LIBUSB_ERROR_NO_DEVICE;
+		goto out;
 	}
 
 	for (i = 0; i < priv->hid->nb_interfaces; i++) {
 		if ((priv->usb_interface[i].path != NULL) && strcmp(priv->usb_interface[i].path, dev_interface_path) == 0) {
 			usbi_dbg(ctx, "interface[%u] already set to %s", i, dev_interface_path);
-			return LIBUSB_ERROR_ACCESS;
+			r = LIBUSB_ERROR_ACCESS;
+			goto out;
 		}
 	}
 
@@ -1470,7 +1490,10 @@ static int set_hid_interface(struct libusb_context *ctx, struct libusb_device *d
 	priv->usb_interface[priv->hid->nb_interfaces].apib = &usb_api_backend[USB_API_HID];
 	usbi_dbg(ctx, "interface[%u] = %s", priv->hid->nb_interfaces, dev_interface_path);
 	priv->hid->nb_interfaces++;
-	return LIBUSB_SUCCESS;
+
+out:
+	usbi_mutex_unlock(&priv->interface_lock);
+	return r;
 }
 
 // get the n-th device interface GUID indexed by guid_number
@@ -1882,13 +1905,19 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 					dev = usbi_alloc_device(ctx, session_id);
 					if (dev == NULL)
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
-#if defined(LIBUSB_WINDOWS_HOTPLUG)
-					usbi_attach_device(dev);
-#endif
+					// Initialize priv (including interface_lock) and the
+					// fields read by concurrent enumeration paths
+					// (dev_id, class_guid) BEFORE making the device visible
+					// via usbi_attach_device or usbi_connect_device. This
+					// closes a use-after-free in the HOTPLUG error path:
+					// if usbi_attach_device runs before _strdup(dev_id) and
+					// the strdup then fails, libusb_unref_device frees the
+					// device while it is still in ctx->usb_devs, leaving a
+					// dangling pointer for the next list traversal. It also
+					// removes the (theoretical, in practice unreachable in
+					// HOTPLUG mode) window where concurrent paths could see
+					// the device with priv->dev_id == NULL.
 					priv = winusb_device_priv_init(dev);
-#if defined(LIBUSB_WINDOWS_HOTPLUG)
-					priv->seen_during_scan = true;
-#endif
 					priv->dev_id = _strdup(dev_id);
 					priv->class_guid = dev_info_data.ClassGuid;
 					if (priv->dev_id == NULL) {
@@ -1896,7 +1925,13 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
 					}
 #if defined(LIBUSB_WINDOWS_HOTPLUG)
+					usbi_attach_device(dev);
+					priv->seen_during_scan = true;
 					goto dont_track_unref;
+#else
+					// Device priv is now initialized; make it
+					// discoverable via usbi_get_device_by_session_id
+					usbi_connect_device(dev);
 #endif
 				} else {
 					usbi_dbg(ctx, "found existing device for session [%lX]", session_id);
@@ -1945,9 +1980,15 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 			switch (pass_type) {
 			case HUB_PASS:
 			case DEV_PASS:
+				// Serialize concurrent enumerations so they don't both see
+				// priv->path == NULL and both run setup, racing on the
+				// writes below.
+				usbi_mutex_lock(&priv->interface_lock);
 				// If the device has already been setup, don't do it again
-				if (priv->path != NULL)
+				if (priv->path != NULL) {
+					usbi_mutex_unlock(&priv->interface_lock);
 					break;
+				}
 				// Take care of API initialization
 				priv->path = dev_interface_path;
 				dev_interface_path = NULL;
@@ -1974,33 +2015,46 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 					break;
 				case USB_API_HID:
 					priv->hid = calloc(1, sizeof(struct hid_device_priv));
-					if (priv->hid == NULL)
+					if (priv->hid == NULL) {
+						usbi_mutex_unlock(&priv->interface_lock);
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
+					}
 					break;
 				default:
 					// For other devices, the first interface is the same as the device
 					priv->usb_interface[0].path = _strdup(priv->path);
-					if (priv->usb_interface[0].path == NULL)
+					if (priv->usb_interface[0].path == NULL) {
+						usbi_mutex_unlock(&priv->interface_lock);
 						LOOP_BREAK(LIBUSB_ERROR_NO_MEM);
+					}
 					// The following is needed if we want API calls to work for both simple
 					// and composite devices.
 					for (j = 0; j < USB_MAXINTERFACES; j++)
 						priv->usb_interface[j].apib = &usb_api_backend[api];
 					break;
 				}
+				usbi_mutex_unlock(&priv->interface_lock);
 				break;
 			case HCD_PASS:
 				r = enumerate_hcd_root_hub(ctx, dev_id, dev_info_data.DevInst);
 				break;
 			case GEN_PASS:
 				port_nr = 0;
+				// Serialize concurrent enumerations so they don't both see
+				// priv->initialized == false and both run init_device,
+				// which allocates priv->config_descriptor[] and other
+				// per-device state. Without this, the loser of the race
+				// overwrites the winner's allocations, leaking them.
+				usbi_mutex_lock(&priv->interface_lock);
 				if (priv->initialized) {
+					usbi_mutex_unlock(&priv->interface_lock);
 					libusb_unref_device(parent_dev);
 					r = LIBUSB_SUCCESS;
 				} else {
 					if (!get_dev_port_number(*dev_info, &dev_info_data, &port_nr))
 						usbi_warn(ctx, "could not retrieve port number for device '%s': %s", dev_id, windows_error_str(0));
 					r = init_device(dev, parent_dev, (uint8_t)port_nr, dev_info_data.DevInst);
+					usbi_mutex_unlock(&priv->interface_lock);
 				}
 				if (r == LIBUSB_SUCCESS) {
 					// Append device to the list of discovered devices
@@ -2430,6 +2484,8 @@ static int winusb_claim_interface(struct libusb_device_handle *dev_handle, uint8
 
 	CHECK_SUPPORTED_API(priv->apib, claim_interface);
 
+	usbi_mutex_lock(&priv->interface_lock);
+
 	safe_free(priv->usb_interface[iface].endpoint);
 	priv->usb_interface[iface].nb_endpoints = 0;
 
@@ -2437,6 +2493,8 @@ static int winusb_claim_interface(struct libusb_device_handle *dev_handle, uint8
 
 	if (r == LIBUSB_SUCCESS)
 		r = windows_assign_endpoints(dev_handle, iface, 0);
+
+	usbi_mutex_unlock(&priv->interface_lock);
 
 	return r;
 }
@@ -2448,6 +2506,8 @@ static int winusb_set_interface_altsetting(struct libusb_device_handle *dev_hand
 
 	CHECK_SUPPORTED_API(priv->apib, set_interface_altsetting);
 
+	usbi_mutex_lock(&priv->interface_lock);
+
 	safe_free(priv->usb_interface[iface].endpoint);
 	priv->usb_interface[iface].nb_endpoints = 0;
 
@@ -2456,16 +2516,28 @@ static int winusb_set_interface_altsetting(struct libusb_device_handle *dev_hand
 	if (r == LIBUSB_SUCCESS)
 		r = windows_assign_endpoints(dev_handle, iface, altsetting);
 
+	usbi_mutex_unlock(&priv->interface_lock);
+
 	return r;
 }
 
 static int winusb_release_interface(struct libusb_device_handle *dev_handle, uint8_t iface)
 {
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev_handle->dev);
+	int r;
 
 	CHECK_SUPPORTED_API(priv->apib, release_interface);
 
-	return priv->apib->release_interface(SUB_API_NOTSET, dev_handle, iface);
+	// The backend release paths (composite_release_interface,
+	// hid_release_interface) read priv->usb_interface[iface].apib /
+	// .path, which are written under interface_lock by claim/altsetting
+	// and by the enumeration setup paths. Take the lock to make those
+	// reads safe against concurrent writers.
+	usbi_mutex_lock(&priv->interface_lock);
+	r = priv->apib->release_interface(SUB_API_NOTSET, dev_handle, iface);
+	usbi_mutex_unlock(&priv->interface_lock);
+
+	return r;
 }
 
 static int winusb_clear_halt(struct libusb_device_handle *dev_handle, unsigned char endpoint)
@@ -3303,6 +3375,13 @@ static int interface_by_endpoint(struct winusb_device_priv *priv,
 	struct winusb_device_handle_priv *handle_priv, uint8_t endpoint_address)
 {
 	int i, j;
+	int result = -1;
+
+	// priv->usb_interface[].endpoint and .nb_endpoints are written
+	// under interface_lock by claim/altsetting and the enumeration
+	// setup paths. Take the lock so we don't read a freed endpoint
+	// pointer or an inconsistent (nb_endpoints, endpoint[]) pair.
+	usbi_mutex_lock(&priv->interface_lock);
 
 	for (i = 0; i < USB_MAXINTERFACES; i++) {
 		if (!HANDLE_VALID(handle_priv->interface_handle[i].api_handle))
@@ -3310,12 +3389,16 @@ static int interface_by_endpoint(struct winusb_device_priv *priv,
 		if (priv->usb_interface[i].endpoint == NULL)
 			continue;
 		for (j = 0; j < priv->usb_interface[i].nb_endpoints; j++) {
-			if (priv->usb_interface[i].endpoint[j] == endpoint_address)
-				return i;
+			if (priv->usb_interface[i].endpoint[j] == endpoint_address) {
+				result = i;
+				goto out;
+			}
 		}
 	}
 
-	return -1;
+out:
+	usbi_mutex_unlock(&priv->interface_lock);
+	return result;
 }
 
 static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *itransfer)
@@ -3518,21 +3601,34 @@ static int winusbx_submit_iso_transfer(int sub_api, struct usbi_transfer *itrans
 		}
 
 		// Query the pipe extended information to find the pipe index corresponding to the endpoint.
-		for (idx = 0; idx < priv->usb_interface[current_interface].nb_endpoints; ++idx) {
-			ret = WinUSBX[sub_api].QueryPipeEx(winusb_handle, (UINT8)priv->usb_interface[current_interface].current_altsetting, (UCHAR)idx, &pipe_info_ex);
-			if (!ret) {
-				usbi_err(TRANSFER_CTX(transfer), "couldn't query interface settings for USB pipe with index %d. Error: %s", idx, windows_error_str(0));
-				return LIBUSB_ERROR_NOT_FOUND;
+		// nb_endpoints and current_altsetting are written under interface_lock by claim/altsetting
+		// and enumeration setup; take the lock so the loop bound and the QueryPipeEx altsetting
+		// argument come from a consistent snapshot.
+		{
+			int nb_endpoints;
+			uint8_t altsetting;
+
+			usbi_mutex_lock(&priv->interface_lock);
+			nb_endpoints = priv->usb_interface[current_interface].nb_endpoints;
+			altsetting = (uint8_t)priv->usb_interface[current_interface].current_altsetting;
+			usbi_mutex_unlock(&priv->interface_lock);
+
+			for (idx = 0; idx < nb_endpoints; ++idx) {
+				ret = WinUSBX[sub_api].QueryPipeEx(winusb_handle, altsetting, (UCHAR)idx, &pipe_info_ex);
+				if (!ret) {
+					usbi_err(TRANSFER_CTX(transfer), "couldn't query interface settings for USB pipe with index %d. Error: %s", idx, windows_error_str(0));
+					return LIBUSB_ERROR_NOT_FOUND;
+				}
+
+				if (pipe_info_ex.PipeId == transfer->endpoint && pipe_info_ex.PipeType == UsbdPipeTypeIsochronous)
+					break;
 			}
 
-			if (pipe_info_ex.PipeId == transfer->endpoint && pipe_info_ex.PipeType == UsbdPipeTypeIsochronous)
-				break;
-		}
-
-		// Make sure we found the index.
-		if (idx == priv->usb_interface[current_interface].nb_endpoints) {
-			usbi_err(TRANSFER_CTX(transfer), "couldn't find isoch endpoint 0x%02x", transfer->endpoint);
-			return LIBUSB_ERROR_NOT_FOUND;
+			// Make sure we found the index.
+			if (idx == nb_endpoints) {
+				usbi_err(TRANSFER_CTX(transfer), "couldn't find isoch endpoint 0x%02x", transfer->endpoint);
+				return LIBUSB_ERROR_NOT_FOUND;
+			}
 		}
 
 		if (IS_XFERIN(transfer)) {
@@ -3750,7 +3846,12 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
-	// Reset any available pipe (except control)
+	// Reset any available pipe (except control).
+	// priv->usb_interface[].endpoint and .nb_endpoints are written under
+	// interface_lock by claim/altsetting and the enumeration setup paths;
+	// take the lock so we don't read a freed endpoint pointer or an
+	// inconsistent (nb_endpoints, endpoint[]) pair.
+	usbi_mutex_lock(&priv->interface_lock);
 	for (i = 0; i < USB_MAXINTERFACES; i++) {
 		winusb_handle = handle_priv->interface_handle[i].api_handle;
 		if (HANDLE_VALID(winusb_handle)) {
@@ -3772,6 +3873,7 @@ static int winusbx_reset_device(int sub_api, struct libusb_device_handle *dev_ha
 			}
 		}
 	}
+	usbi_mutex_unlock(&priv->interface_lock);
 
 	// libusbK & libusb0 have the ability to issue an actual device reset
 	if ((sub_api != SUB_API_WINUSB) && (WinUSBX[sub_api].ResetDevice != NULL)) {

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -179,6 +179,7 @@ static inline struct winusb_device_priv *winusb_device_priv_init(struct libusb_d
 	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
 	int i;
 
+	usbi_mutex_init(&priv->interface_lock);
 	priv->apib = &usb_api_backend[USB_API_UNSUPPORTED];
 	priv->sub_api = SUB_API_NOTSET;
 	for (i = 0; i < USB_MAXINTERFACES; i++) {
@@ -209,6 +210,7 @@ static inline void winusb_device_priv_release(struct libusb_device *dev)
 		free(priv->usb_interface[i].path);
 		free(priv->usb_interface[i].endpoint);
 	}
+	usbi_mutex_destroy(&priv->interface_lock);
 }
 
 // used to match a device driver (including filter drivers) against a supported API


### PR DESCRIPTION
windows hotplug: fix device leak on detach of uninitialized devices:

When a physically removed device was never successfully initialized,
windows_refresh_device_list correctly calls usbi_detach_device (not
usbi_disconnect_device) since the device was never announced to users.

However, usbi_detach_device only removes the device from the list —
unlike usbi_disconnect_device, it does not post a DEVICE_LEFT hotplug
message. This means no message handler will ever drop the initial
allocation reference (refcnt=1 from usbi_alloc_device), so the device
struct is leaked.

Add the missing libusb_unref_device call after usbi_detach_device.
This is safe because:
 - The device was never initialized, so no user handle can exist.
 - The device has been removed from ctx->usb_devs, so it is no longer
   discoverable via libusb_get_device_list.
 - If a concurrent libusb_get_device_list snapshot holds a ref, unref
   drops refcnt to 1 (not 0), and the user's later
   libusb_free_device_list completes the cleanup.
   
windows: fix claim_interface race on shared device state:

libusb_claim_interface acquires dev_handle->lock before calling the
backend, but this lock is per-handle — created fresh during
libusb_open. When the same device is opened twice, each handle gets
its own independent mutex. Concurrent claim_interface calls on
different handles to the same device race on the shared
priv->usb_interface[] fields (endpoint, nb_endpoints), causing
double-free and use-after-free of the endpoint array.

The problem is worse for libusb_set_interface_alt_setting, which
releases dev_handle->lock *before* calling the backend (core.c:1921),
so winusb_set_interface_altsetting runs with no lock at all — even
a single-device single-handle scenario is unprotected against a
concurrent call from another thread using a different handle.

Add a per-device interface_lock mutex to struct winusb_device_priv
that serializes all modifications to usb_interface[] from
winusb_claim_interface and winusb_set_interface_altsetting, regardless
of which handle initiates the operation.

No lock is needed in the enumeration path (set_composite_interface,
set_hid_interface) because those run during winusb_get_device_list
under active_contexts_lock, before any handle can exist for the
device.

core: fix two race conditions in non-hotplug device list management

Fix two races between concurrent libusb_get_device_list and
libusb_free_device_list calls on non-hotplug backends (Windows
without hotplug, OpenBSD, NetBSD, Solaris, Emscripten, UsbDk).

Race 1 — half-initialized device visible in list:
usbi_alloc_device() automatically called usbi_connect_device(), adding
the device to ctx->usb_devs before the caller had a chance to
initialize backend-private fields. A concurrent thread calling
usbi_get_device_by_session_id() could find this device and crash
accessing uninitialized private data (e.g. NULL priv->dev_id in the
WinUSB backend).

Fix: remove the automatic usbi_connect_device() from usbi_alloc_device
and require each backend to call it explicitly after initialization.
All hotplug backends (Linux, Darwin, Haiku) already followed this
pattern. The six non-hotplug backends are updated accordingly.

Race 2 — refcount reaches zero while device is still in list:
libusb_unref_device() decremented refcnt atomically (no lock), then
much later removed the device from ctx->usb_devs via
usbi_disconnect_device(). A concurrent usbi_get_device_by_session_id()
could find the device (still in list) with refcnt=0 and attempt
libusb_ref_device(), hitting assert(refcnt >= 2).

Fix: for non-hotplug attached devices, perform the refcnt decrement
and conditional list removal atomically under ctx->usb_devs_lock —
the same lock held by usbi_get_device_by_session_id() during its
search-and-ref operation. This ensures no search can ever observe a
device at refcnt=0.

Closes #1793   