### PR TITLE
windows: fix winusb_get_device_string failing for strict USB devices

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -248,6 +248,7 @@ struct winusb_device_priv {
 #endif
 	bool root_hub;
 	uint8_t active_config;
+	uint16_t langid; // cached USB language ID for string descriptor requests
 	uint8_t depth; // distance to HCD
 	const struct windows_usb_api_backend *apib;
 	char *dev_id;

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2250,7 +2250,7 @@ static int winusb_get_device_string(libusb_device *dev,
 	}
 
 	if (0 == string_descriptor_idx) {
-		return 0;
+		return LIBUSB_ERROR_NOT_FOUND;
 	}
 
 	struct winusb_device_priv* hub_priv = usbi_get_device_priv(dev->parent_dev);
@@ -2260,13 +2260,45 @@ static int winusb_get_device_string(libusb_device *dev,
 		return LIBUSB_ERROR_ACCESS;
 	}
 
+	// Fetch and cache the device's primary USB language ID.
+	// String descriptor 0 with wIndex=0 returns the supported language table
+	// (USB 2.0 spec section 9.6.7). We use the first (primary) LANGID for
+	// all subsequent string descriptor requests.
+	if (0 == priv->langid) {
+		size = sizeof(sd);
+		memset(&sd, 0, size);
+		sd.req.ConnectionIndex = (ULONG)dev->port_number;
+		sd.req.SetupPacket.bmRequest = LIBUSB_ENDPOINT_IN;
+		sd.req.SetupPacket.bRequest = LIBUSB_REQUEST_GET_DESCRIPTOR;
+		sd.req.SetupPacket.wValue = (LIBUSB_DT_STRING << 8) | 0;
+		sd.req.SetupPacket.wIndex = 0;
+		sd.req.SetupPacket.wLength = (USHORT)sizeof(sd.desc);
+
+		if (!DeviceIoControl(hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, &sd, size,
+			&sd, size, &ret_size, NULL)) {
+			usbi_warn(ctx, "could not retrieve language IDs for '%s': %s",
+				priv->dev_id, windows_error_str(0));
+			CloseHandle(hub_handle);
+			return LIBUSB_ERROR_IO;
+		}
+
+		if (sd.desc.bDescriptorType != LIBUSB_DT_STRING || sd.desc.bLength < 4) {
+			usbi_warn(ctx, "invalid language ID descriptor for '%s'", priv->dev_id);
+			CloseHandle(hub_handle);
+			return LIBUSB_ERROR_IO;
+		}
+
+		priv->langid = (uint16_t)sd.desc.bString[0] | ((uint16_t)sd.desc.bString[1] << 8);
+		usbi_dbg(ctx, "cached language ID 0x%04x for '%s'", priv->langid, priv->dev_id);
+	}
+
 	size = sizeof(sd);
 	memset(&sd, 0, size);
 	sd.req.ConnectionIndex = (ULONG)dev->port_number;
 	sd.req.SetupPacket.bmRequest = LIBUSB_ENDPOINT_IN;
 	sd.req.SetupPacket.bRequest = LIBUSB_REQUEST_GET_DESCRIPTOR;
 	sd.req.SetupPacket.wValue = (LIBUSB_DT_STRING << 8) | string_descriptor_idx;
-	sd.req.SetupPacket.wIndex = 0;
+	sd.req.SetupPacket.wIndex = priv->langid;
 	sd.req.SetupPacket.wLength = (USHORT)sizeof(sd.desc);
 
 	BOOL rv = DeviceIoControl(hub_handle, IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION, &sd, size,
@@ -2275,12 +2307,12 @@ static int winusb_get_device_string(libusb_device *dev,
 	if (!rv) {
 		usbi_err(ctx, "could not access string descriptor %u for '%s': %s", string_descriptor_idx,
 			priv->dev_id, windows_error_str(0));
-		return 0;
+		return LIBUSB_ERROR_IO;
 	}
 
 	if (sd.desc.bDescriptorType != LIBUSB_DT_STRING) {
 		usbi_err(ctx, "descriptor %u not a string descriptor for '%s'", string_descriptor_idx, priv->dev_id);
-		return 0;
+		return LIBUSB_ERROR_IO;
 	}
 
 	return usbi_utf16le_to_utf8(sd.desc.bString, (int) (sd.desc.bLength - 2), data, length);

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12023
+#define LIBUSB_NANO 12024


### PR DESCRIPTION
[EDITED for description of the third issue]
Three bugs in winusb_get_device_string caused libusb_get_device_string
to return empty strings instead of actual device strings on Windows:

1. The function used wIndex=0 (invalid LANGID) when requesting string
   descriptors via IOCTL_USB_GET_DESCRIPTOR_FROM_NODE_CONNECTION. While
   some devices tolerate LANGID 0, strict USB devices correctly STALL
   the request (Windows error 31). Fix: first fetch string descriptor 0
   to get the device's language table (USB 2.0 section 9.6.7), then use
   the primary LANGID for actual string requests. The LANGID is cached
   per device to avoid redundant IOCTLs.

2. On IOCTL failure, the function returned 0 instead of a negative
   LIBUSB_ERROR code. The caller in libusb_get_device_string only
   checks for rv < 0, so 0 was treated as success: an empty string
   was permanently cached, and subsequent calls returned 1 (empty
   string + null terminator) without ever retrying. Fix: return
   LIBUSB_ERROR_IO on both error paths.

3. When a device has no string descriptor of a given type
   (descriptor index is 0 in the device descriptor), the function
   returned 0 instead of an error. This caused an empty string to be
   cached and returned as success, while Linux and Darwin return an
   error in the same situation. Fix: return LIBUSB_ERROR_NOT_FOUND
   for consistency with other backends (using Darwing value which seemed
   more precise than Linux.

Closes #1794