### PR TITLE
libusb.h: Fix typo in comment

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1684,7 +1684,7 @@ enum libusb_device_string_type {
  *  => 126 * 3 + 1
  *  => 382 bytes
  * 
- * Stay with 256 * 2/3 = 384 to be safe.
+ * Stay with 256 * 3/2 = 384 to be safe.
  */
 #define LIBUSB_DEVICE_STRING_BYTES_MAX  (384U)
  

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1681,7 +1681,7 @@ enum libusb_device_string_type {
  * 255 max descriptor length with 2 byte header 
  *  => 253 bytes UTF-16LE, no null termination (USB 2.0 9.6.7)
  *  => 126.5 codepoints
- *  => 126 * 3 + 1
+ *  => 127 * 3 + 1
  *  => 382 bytes
  * 
  * Stay with 256 * 3/2 = 384 to be safe.


### PR DESCRIPTION
The comment surely meant to say 3/2 instead of 2/3.