### PR TITLE
tests: Add tests/testcore.c, a multi-threaded stress test that hammers

### DIFF
--- a/msvc/libusb.sln
+++ b/msvc/libusb.sln
@@ -32,6 +32,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xusb", "xusb.vcxproj", "{3F
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "set_option", "set_option.vcxproj", "{35BD5D4B-5102-4A08-81C0-AAF3285FCB01}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testcore", "testcore.vcxproj", "{57BDB9C3-DC00-49FA-B27B-73805699E846}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -779,6 +781,54 @@ Global
 		{35BD5D4B-5102-4A08-81C0-AAF3285FCB01}.Release-MT|Win32.Build.0 = Release-MT|Win32
 		{35BD5D4B-5102-4A08-81C0-AAF3285FCB01}.Release-MT|x64.ActiveCfg = Release-MT|x64
 		{35BD5D4B-5102-4A08-81C0-AAF3285FCB01}.Release-MT|x64.Build.0 = Release-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|ARM64.Build.0 = Debug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|Win32.ActiveCfg = Debug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|Win32.Build.0 = Debug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|x64.ActiveCfg = Debug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug|x64.Build.0 = Debug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|ARM64.ActiveCfg = Debug-Hotplug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|ARM64.Build.0 = Debug-Hotplug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|Win32.ActiveCfg = Debug-Hotplug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|Win32.Build.0 = Debug-Hotplug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|x64.ActiveCfg = Debug-Hotplug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug|x64.Build.0 = Debug-Hotplug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|ARM64.ActiveCfg = Debug-Hotplug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|ARM64.Build.0 = Debug-Hotplug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|Win32.ActiveCfg = Debug-Hotplug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|Win32.Build.0 = Debug-Hotplug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|x64.ActiveCfg = Debug-Hotplug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-Hotplug-MT|x64.Build.0 = Debug-Hotplug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|ARM64.ActiveCfg = Debug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|ARM64.Build.0 = Debug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|Win32.ActiveCfg = Debug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|Win32.Build.0 = Debug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|x64.ActiveCfg = Debug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Debug-MT|x64.Build.0 = Debug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|ARM64.ActiveCfg = Release|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|ARM64.Build.0 = Release|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|Win32.ActiveCfg = Release|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|Win32.Build.0 = Release|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|x64.ActiveCfg = Release|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release|x64.Build.0 = Release|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|ARM64.ActiveCfg = Release-Hotplug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|ARM64.Build.0 = Release-Hotplug|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|Win32.ActiveCfg = Release-Hotplug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|Win32.Build.0 = Release-Hotplug|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|x64.ActiveCfg = Release-Hotplug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug|x64.Build.0 = Release-Hotplug|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|ARM64.ActiveCfg = Release-Hotplug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|ARM64.Build.0 = Release-Hotplug-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|Win32.ActiveCfg = Release-Hotplug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|Win32.Build.0 = Release-Hotplug-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|x64.ActiveCfg = Release-Hotplug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-Hotplug-MT|x64.Build.0 = Release-Hotplug-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|ARM64.ActiveCfg = Release-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|ARM64.Build.0 = Release-MT|ARM64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|Win32.ActiveCfg = Release-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|Win32.Build.0 = Release-MT|Win32
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|x64.ActiveCfg = Release-MT|x64
+		{57BDB9C3-DC00-49FA-B27B-73805699E846}.Release-MT|x64.Build.0 = Release-MT|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/msvc/testcore.vcxproj
+++ b/msvc/testcore.vcxproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ProjectConfigurations.Base.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{57BDB9C3-DC00-49FA-B27B-73805699E846}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="Configuration.Application.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Base.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClCompile Include="..\tests\testcore.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include=".\config.h" />
+    <ClInclude Include="..\libusb\libusb.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=".\libusb_static.vcxproj">
+      <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,10 +16,15 @@ stress_mt_SOURCES = stress_mt.c
 set_option_SOURCES = set_option.c testlib.c
 init_context_SOURCES = init_context.c testlib.c
 macos_SOURCES = macos.c testlib.c
+testcore_SOURCES = testcore.c
 
 stress_mt_CFLAGS = $(AM_CFLAGS) $(THREAD_CFLAGS)
 stress_mt_LDADD = $(LDADD) $(THREAD_LIBS)
 stress_mt_LDFLAGS = $(AM_LDFLAGS)
+
+testcore_CFLAGS = $(AM_CFLAGS) $(THREAD_CFLAGS)
+testcore_LDADD = $(LDADD) $(THREAD_LIBS)
+testcore_LDFLAGS = $(AM_LDFLAGS)
 
 if OS_EMSCRIPTEN
 # On the Web you can't block the main thread as this blocks the event loop itself,
@@ -27,10 +32,11 @@ if OS_EMSCRIPTEN
 # We use the PROXY_TO_PTHREAD Emscripten's feature to move the main app to a separate thread
 # where it can block safely.
 stress_mt_LDFLAGS += ${AM_LDFLAGS} -s PROXY_TO_PTHREAD -s EXIT_RUNTIME
+testcore_LDFLAGS += ${AM_LDFLAGS} -s PROXY_TO_PTHREAD -s EXIT_RUNTIME
 endif
 
 noinst_HEADERS = libusb_testlib.h
-noinst_PROGRAMS = stress stress_mt set_option init_context
+noinst_PROGRAMS = stress stress_mt set_option init_context testcore
 if OS_DARWIN
 noinst_PROGRAMS += macos
 endif

--- a/tests/testcore.c
+++ b/tests/testcore.c
@@ -1,0 +1,170 @@
+/*
+ * libusb concurrent get/free_device_list reproducer for issue #1793
+ *
+ * Repeatedly enumerates and frees the device list from multiple threads
+ * to stress concurrent access to:
+ *   - usbi_get_device_by_session_id()
+ *   - usbi_alloc_device()
+ *   - usbi_connect_device()
+ *   - libusb_unref_device()
+ *   - ctx->usb_devs_lock correctness
+ *   - winusb_device_priv setup race in set_composite_interface (Windows)
+ *
+ * Originally posted by mcuee in
+ * https://github.com/libusb/libusb/pull/1795#issuecomment-4258288585
+ * Adapted here to use the platform thread abstraction from stress_mt.c
+ * so it builds with MSVC.
+ */
+
+#include <config.h>
+
+#include <libusb.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(PLATFORM_POSIX)
+
+#include <pthread.h>
+#include <sched.h>
+typedef pthread_t thread_t;
+typedef void * thread_return_t;
+#define THREAD_RETURN_VALUE NULL
+#define THREAD_CALL_TYPE
+
+static inline int thread_create(thread_t *thread,
+	thread_return_t (*thread_entry)(void *arg), void *arg)
+{
+	return pthread_create(thread, NULL, thread_entry, arg) == 0 ? 0 : -1;
+}
+
+static inline void thread_join(thread_t thread)
+{
+	(void)pthread_join(thread, NULL);
+}
+
+static inline void thread_yield(void)
+{
+	sched_yield();
+}
+
+#elif defined(PLATFORM_WINDOWS)
+
+typedef HANDLE thread_t;
+#define THREAD_RETURN_VALUE 0
+#define THREAD_CALL_TYPE __stdcall
+
+#if defined(__CYGWIN__)
+typedef DWORD thread_return_t;
+#else
+#include <process.h>
+typedef unsigned thread_return_t;
+#endif
+
+static inline int thread_create(thread_t *thread,
+	thread_return_t (__stdcall *thread_entry)(void *arg), void *arg)
+{
+#if defined(__CYGWIN__)
+	*thread = CreateThread(NULL, 0, thread_entry, arg, 0, NULL);
+#else
+	*thread = (HANDLE)_beginthreadex(NULL, 0, thread_entry, arg, 0, NULL);
+#endif
+	return *thread != NULL ? 0 : -1;
+}
+
+static inline void thread_join(thread_t thread)
+{
+	(void)WaitForSingleObject(thread, INFINITE);
+	(void)CloseHandle(thread);
+}
+
+static inline void thread_yield(void)
+{
+	Sleep(0);
+}
+
+#endif /* PLATFORM_WINDOWS */
+
+#define THREADS 12
+#define LOOPS   100000
+
+struct worker_arg {
+	libusb_context *ctx;
+	int index;
+};
+
+static thread_return_t THREAD_CALL_TYPE worker(void *arg)
+{
+	struct worker_arg *wa = (struct worker_arg *)arg;
+	int i;
+
+	for (i = 0; i < LOOPS; i++) {
+		libusb_device **list = NULL;
+		ssize_t cnt = libusb_get_device_list(wa->ctx, &list);
+
+		if (cnt < 0) {
+			fprintf(stderr,
+				"thread %d: get_device_list failed: %ld\n",
+				wa->index, (long)cnt);
+			break;
+		}
+
+		/*
+		 * Intentionally no inspection of devices.
+		 * Just exercise concurrent visibility + refcounting.
+		 */
+
+		libusb_free_device_list(list, 1);
+
+		/* Small yield to encourage interleaving */
+		if ((i & 0xFF) == 0)
+			thread_yield();
+	}
+
+	return (thread_return_t)THREAD_RETURN_VALUE;
+}
+
+int main(void)
+{
+	libusb_context *ctx = NULL;
+	thread_t threads[THREADS];
+	struct worker_arg args[THREADS];
+	int i;
+
+	if (libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0) != 0) {
+		fprintf(stderr, "libusb_init_context failed\n");
+		return EXIT_FAILURE;
+	}
+
+	//libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
+
+	libusb_device **list;
+	ssize_t cnt = libusb_get_device_list(NULL, &list);
+	for (i = 0; i < cnt; i++) {
+	    struct libusb_device_descriptor desc;
+	    libusb_get_device_descriptor(list[i], &desc);
+	    printf("Device %d: %04x:%04x class=0x%02x\n",
+	        i, desc.idVendor, desc.idProduct, desc.bDeviceClass);
+	}
+	libusb_free_device_list(list, 1);
+
+	printf("Starting %d threads, %d loops each...\n", THREADS, LOOPS);
+
+	for (i = 0; i < THREADS; i++) {
+		args[i].ctx = ctx;
+		args[i].index = i;
+
+		if (thread_create(&threads[i], worker, &args[i]) != 0) {
+			fprintf(stderr, "thread_create failed for thread %d\n", i);
+			libusb_exit(ctx);
+			return EXIT_FAILURE;
+		}
+	}
+
+	for (i = 0; i < THREADS; i++)
+		thread_join(threads[i]);
+
+	printf("Completed without crash.\n");
+
+	libusb_exit(ctx);
+	return EXIT_SUCCESS;
+}

--- a/tests/testcore.c
+++ b/tests/testcore.c
@@ -19,8 +19,11 @@
 #include <config.h>
 
 #include <libusb.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #if defined(PLATFORM_POSIX)
 
@@ -84,12 +87,14 @@ static inline void thread_yield(void)
 
 #endif /* PLATFORM_WINDOWS */
 
-#define THREADS 12
-#define LOOPS   100000
+static const int DEFAULT_THREADS = 4;
+static const int DEFAULT_LOOPS = 10000;
 
 struct worker_arg {
 	libusb_context *ctx;
 	int index;
+	int loops;
+	int failed;
 };
 
 static thread_return_t THREAD_CALL_TYPE worker(void *arg)
@@ -97,7 +102,7 @@ static thread_return_t THREAD_CALL_TYPE worker(void *arg)
 	struct worker_arg *wa = (struct worker_arg *)arg;
 	int i;
 
-	for (i = 0; i < LOOPS; i++) {
+	for (i = 0; i < wa->loops; i++) {
 		libusb_device **list = NULL;
 		ssize_t cnt = libusb_get_device_list(wa->ctx, &list);
 
@@ -105,6 +110,7 @@ static thread_return_t THREAD_CALL_TYPE worker(void *arg)
 			fprintf(stderr,
 				"thread %d: get_device_list failed: %ld\n",
 				wa->index, (long)cnt);
+			wa->failed = 1;
 			break;
 		}
 
@@ -123,13 +129,67 @@ static thread_return_t THREAD_CALL_TYPE worker(void *arg)
 	return (thread_return_t)THREAD_RETURN_VALUE;
 }
 
-int main(void)
+static void usage(const char *argv0)
+{
+	printf("Usage: %s [-h] [num_threads [num_loops]]\n", argv0);
+	printf("Concurrently enumerates and frees the USB device list.\n");
+	printf("  num_threads  number of worker threads (default %d)\n",
+		DEFAULT_THREADS);
+	printf("  num_loops    get/free device list iterations per thread (default %d)\n",
+		DEFAULT_LOOPS);
+	printf("On backends without hotplug support (e.g. Windows), every\n"
+	       "libusb_get_device_list() performs a full enumeration (~10-100 ms),\n"
+	       "so large loop counts (e.g. 100000, useful for bug hunting) can\n"
+	       "run for hours.\n");
+}
+
+static int parse_count(const char *str, int *out)
+{
+	char *end;
+	long val;
+
+	errno = 0;
+	val = strtol(str, &end, 10);
+	if (end == str || *end != '\0' || errno != 0 || val <= 0 || val > INT_MAX)
+		return -1;
+
+	*out = (int)val;
+	return 0;
+}
+
+int main(int argc, char *argv[])
 {
 	libusb_context *ctx = NULL;
-	thread_t threads[THREADS];
-	struct worker_arg args[THREADS];
+	thread_t *threads;
+	struct worker_arg *args;
+	int num_threads = DEFAULT_THREADS;
+	int num_loops = DEFAULT_LOOPS;
+	int failed = 0;
 	int i;
 
+	if (argc > 1 &&
+	    (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+		usage(argv[0]);
+		return EXIT_SUCCESS;
+	}
+
+	if (argc > 3 ||
+	    (argc > 1 && parse_count(argv[1], &num_threads) != 0) ||
+	    (argc > 2 && parse_count(argv[2], &num_loops) != 0)) {
+		usage(argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	/*
+	 * To exercise the Linux non-hotplug code path, where every
+	 * libusb_get_device_list() rescans instead of returning the
+	 * cached list, initialize with:
+	 *
+	 *   struct libusb_init_option opts[] = {
+	 *       { .option = LIBUSB_OPTION_NO_DEVICE_DISCOVERY },
+	 *   };
+	 *   libusb_init_context(&ctx, opts, 1);
+	 */
 	if (libusb_init_context(&ctx, /*options=*/NULL, /*num_options=*/0) != 0) {
 		fprintf(stderr, "libusb_init_context failed\n");
 		return EXIT_FAILURE;
@@ -137,8 +197,8 @@ int main(void)
 
 	//libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 
-	libusb_device **list;
-	ssize_t cnt = libusb_get_device_list(NULL, &list);
+	libusb_device **list = NULL;
+	ssize_t cnt = libusb_get_device_list(ctx, &list);
 	for (i = 0; i < cnt; i++) {
 	    struct libusb_device_descriptor desc;
 	    libusb_get_device_descriptor(list[i], &desc);
@@ -147,24 +207,47 @@ int main(void)
 	}
 	libusb_free_device_list(list, 1);
 
-	printf("Starting %d threads, %d loops each...\n", THREADS, LOOPS);
+	threads = calloc((size_t)num_threads, sizeof(*threads));
+	args = calloc((size_t)num_threads, sizeof(*args));
+	if (threads == NULL || args == NULL) {
+		fprintf(stderr, "out of memory\n");
+		free(threads);
+		free(args);
+		libusb_exit(ctx);
+		return EXIT_FAILURE;
+	}
 
-	for (i = 0; i < THREADS; i++) {
+	printf("Starting %d threads, %d loops each...\n", num_threads, num_loops);
+
+	for (i = 0; i < num_threads; i++) {
 		args[i].ctx = ctx;
 		args[i].index = i;
+		args[i].loops = num_loops;
+		args[i].failed = 0;
 
 		if (thread_create(&threads[i], worker, &args[i]) != 0) {
 			fprintf(stderr, "thread_create failed for thread %d\n", i);
-			libusb_exit(ctx);
-			return EXIT_FAILURE;
+			num_threads = i;
+			failed = 1;
+			break;
 		}
 	}
 
-	for (i = 0; i < THREADS; i++)
+	for (i = 0; i < num_threads; i++)
 		thread_join(threads[i]);
 
-	printf("Completed without crash.\n");
+	for (i = 0; i < num_threads; i++)
+		failed |= args[i].failed;
 
+	free(threads);
+	free(args);
 	libusb_exit(ctx);
+
+	if (failed) {
+		fprintf(stderr, "FAILED\n");
+		return EXIT_FAILURE;
+	}
+
+	printf("Completed without crash.\n");
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
libusb_get_device_list / libusb_free_device_list from N threads in parallel. It exists primarily to reproduce the concurrent-enumeration crashes reported in #1793 and the related set_composite_interface race surfaced during PR #1795 review.
The stressed code paths include:
 - usbi_get_device_by_session_id()
 - usbi_alloc_device()
 - usbi_connect_device()
 - libusb_unref_device() / ctx->usb_devs_lock
 - winusb_device_priv setup races in set_composite_interface and set_hid_interface (Windows, non-hotplug builds) The original C++20 reproducer was posted by smarvonohr and the C version with Win32 threads by mcuee in
https://github.com/libusb/libusb/pull/1795#issuecomment-4258288585 This version is adapted from mcuee's C version, with two changes that make it portable and easier to build:
 - Use the same PLATFORM_POSIX / PLATFORM_WINDOWS thread abstraction that stress_mt.c uses (pthread_create on POSIX, _beginthreadex on Windows, CreateThread on Cygwin), instead of bare pthread. The original would not build with MSVC.
 - Print the device list once before starting the worker threads, so the operator can confirm at a glance which devices are present. This is useful because the bug only manifests when enumeration touches certain device shapes (e.g. composite devices with HID children that exercise set_composite_interface). Add msvc/testcore.vcxproj following the same template as msvc/stress_mt.vcxproj so the test builds out of the box in Visual Studio against libusb_static.
Notes for runners:
 - The test only triggers the enumeration races in non-HOTPLUG builds. With Windows hotplug enabled, libusb_get_device_list is served from a cache and winusb_get_device_list never runs concurrently, so the bug does not manifest.
 - The default LOOPS = 100000 is intentionally large for the original bug-hunting use case but takes hours of real work even when the library is correct (each non-hotplug get_device_list does a full Windows USB enumeration, ~10-100 ms). Reduce LOOPS for a quick smoke test.
 - At least one composite USB device with HID-class child interfaces (USB game controller, headset with controls, Logitech Unifying receiver, etc.) must be present to exercise set_composite_interface. Pure UVC/UAC composite devices like webcams will NOT trigger that path because their child interfaces are not HID class and are not bound to any libusb-supported driver.
 
 Closes https://github.com/libusb/libusb/issues/1808