### PR TITLE
ci: bump GitHub Actions to latest major versions to drop Node.js 20

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show ANDROID_NDK_ROOT
         run: |
@@ -47,7 +47,7 @@ jobs:
           file "${NDK_LIBS_DIR}/"* || true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: libusb-android-${{ matrix.abi }}-api${{ matrix.api }}
           path: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: setup prerequisites
         run: |
@@ -29,7 +29,7 @@ jobs:
       - name: disable-log
         run: .private/ci-build.sh --werror --build-dir build-nolog -- --disable-log
 
-      - uses: mymindstorm/setup-emsdk@v13
+      - uses: mymindstorm/setup-emsdk@v16
 
       - run: npm ci
         working-directory: tests/webusb-test-shim

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job
       # can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: setup prerequisites
         shell: bash

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -8,7 +8,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -8,7 +8,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: msys2/setup-msys2@v2
         with:
           msystem: clangarm64
@@ -20,7 +20,7 @@ jobs:
           ./bootstrap.sh
           ./.private/ci-build.sh --no-asan --build-dir build-msys2-clang64-aarch64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-msys2-clang64-aarch64
           path: |

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -8,7 +8,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: msys2/setup-msys2@v2
         with:
           msystem: clang64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,17 +27,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build solution
         run: |
           msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.architecture }}
           path: |


### PR DESCRIPTION
## Summary

Fixes the Node.js 20 deprecation warnings from GitHub Actions runners by bumping every action to its latest major version, pinning to the major tag only:

- `actions/checkout` — v2 / v3 / v4 → **v6**
- `actions/upload-artifact` — v4 → **v7**
- `mymindstorm/setup-emsdk` — v13 → **v16**
- `microsoft/setup-msbuild` — v1.3 → **v3**
- `msys2/setup-msys2` — v2 (already at latest major, unchanged)

All bumped actions now run on Node.js 24 (verified via each action's `runs.using` in the latest release).

## Test plan

All 7 workflows green on `bump-gha-actions-node24`:

- [x] Android
- [x] linux
- [x] macOS
- [x] MSYS2 build
- [x] MSYS2 clang64 build
- [x] MSYS2 aarch64 clang64
- [x] Windows build and Package (full `windows-2022`/`windows-2025` × 8 configurations × 3 architectures matrix)

Closes: #1817

Assisted-by: claude-code:claude-opus-4-7