### PR TITLE
Release 1.0.30-rc2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Alexander Mot
 Alexander Pyhalov
 Alexander Schlarb
 Alexander Stein
+Alex Birkett
 Alex Feinman
 Alex Vatchenko
 Andrew Aldridge
@@ -137,6 +138,7 @@ Marco Trevisan (Treviño)
 Marcus Meissner
 Mario Kleiner
 Mark Kuo
+Mark Lee
 Markus Heidelberg
 Martin Ettl
 Martin Koegler

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,14 @@
 For detailed information about the changes below, please see the git log.
 
-2026-02-22: v1.0.30-rc1
+2026-05-03: v1.0.30-rc2
 * Add hotplug support on Microsoft Windows
 * Add RAW_IO support in WinUSB backend
 * Work around a macOS 26 Tahoe compatibility breakage due to Apple changing kUSBHostPortPropertyPortNumber
 * Add new API libusb_get_device_string() to access device strings without opening the device
 * Add new API libusb_get_session_data() which returns the OS-specific handle
+* Fix device removal races on non-hotplug builds
+* Improve descriptor parsing memory safety
+* On Darwin, fix concurrency issues
 * On Android, fix intermittent failures in get_usbfs_fd()
 * On Windows, fix bus number assignment for root hub device, preventing duplicate bus number assignments
 * Fix compilation with Microsoft Visual Studio 2026

--- a/libusb/version.h
+++ b/libusb/version.h
@@ -14,5 +14,5 @@
 #endif
 /* LIBUSB_RC is the release candidate suffix. Should normally be empty. */
 #ifndef LIBUSB_RC
-#define LIBUSB_RC "-rc1"
+#define LIBUSB_RC "-rc2"
 #endif

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12030
+#define LIBUSB_NANO 12031


### PR DESCRIPTION
(exceptionally including nano version change, for build artifacts to have them correct)