### PR TITLE
windows: Avoid -Wpragma-pack warnings on Clang builds

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -160,7 +160,7 @@ enum windows_version {
 
 extern enum windows_version windows_version;
 
-#include <pshpack1.h>
+#pragma pack(push, 1)
 
 typedef struct USB_DEVICE_DESCRIPTOR {
 	UCHAR  bLength;
@@ -190,7 +190,7 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
 	UCHAR  MaxPower;
 } USB_CONFIGURATION_DESCRIPTOR, *PUSB_CONFIGURATION_DESCRIPTOR;
 
-#include <poppack.h>
+#pragma pack(pop)
 
 #define MAX_DEVICE_ID_LEN	200
 

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -312,7 +312,7 @@ typedef enum _USB_HUB_NODE {
 #endif
 
 // Most of the structures below need to be packed
-#include <pshpack1.h>
+#pragma pack(push, 1)
 
 typedef struct _USB_HUB_DESCRIPTOR {
 	UCHAR bDescriptorLength;
@@ -406,7 +406,7 @@ typedef struct _USB_NODE_CONNECTION_INFORMATION_EX_V2 {
 	USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS Flags;
 } USB_NODE_CONNECTION_INFORMATION_EX_V2, *PUSB_NODE_CONNECTION_INFORMATION_EX_V2;
 
-#include <poppack.h>
+#pragma pack(pop)
 
 #if defined(_MSC_VER)
 // Restore original warnings
@@ -448,7 +448,7 @@ typedef struct {
 	ULONG MaximumBytesPerInterval;
 } WINUSB_PIPE_INFORMATION_EX, *PWINUSB_PIPE_INFORMATION_EX;
 
-#include <pshpack1.h>
+#pragma pack(push, 1)
 
 typedef struct _WINUSB_SETUP_PACKET {
 	UCHAR RequestType;
@@ -458,7 +458,7 @@ typedef struct _WINUSB_SETUP_PACKET {
 	USHORT Length;
 } WINUSB_SETUP_PACKET, *PWINUSB_SETUP_PACKET;
 
-#include <poppack.h>
+#pragma pack(pop)
 
 typedef PVOID WINUSB_INTERFACE_HANDLE, *PWINUSB_INTERFACE_HANDLE;
 typedef PVOID WINUSB_ISOCH_BUFFER_HANDLE, *PWINUSB_ISOCH_BUFFER_HANDLE;
@@ -700,7 +700,7 @@ struct winusb_interface {
 #define HIDP_STATUS_SUCCESS	0x110000
 typedef void * PHIDP_PREPARSED_DATA;
 
-#include <pshpack1.h>
+#pragma pack(push, 1)
 
 typedef struct _HIDD_ATTIRBUTES {
 	ULONG Size;
@@ -709,7 +709,7 @@ typedef struct _HIDD_ATTIRBUTES {
 	USHORT VersionNumber;
 } HIDD_ATTRIBUTES, *PHIDD_ATTRIBUTES;
 
-#include <poppack.h>
+#pragma pack(pop)
 
 typedef USHORT USAGE;
 typedef struct _HIDP_CAPS {


### PR DESCRIPTION
The Microsoft headers <pshpack1.h> / <poppack.h> exist solely to issue
#pragma pack(push, 1) / #pragma pack(pop). Clang on MSYS2 (UCRT64)
emits -Wpragma-pack every time these headers are included, since the
alignment is modified inside an included file. The same warnings do
not appear under Apple Clang or OpenBSD clang, so this is specific to
MSYS2 clang.
Replace the includes by the equivalent #pragma pack directives, which
are already used elsewhere in the codebase (libusb.h, libusbi.h,
os/windows_winusb.c) and are portable across MSVC, GCC, and Clang.
The semantics are identical on all targets.
Tested on MSYS2 UCRT64 + Clang: build is now warning-free for the
Windows backend headers.
Closes: #1395
Assisted-by: claude-code:claude-opus-4-7
Signed-off-by: Nicolas Bats <sl1200mk2@gmail.com>