### PR TITLE
darwin: null-terminate device string buffer

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1673,7 +1673,7 @@ int API_EXPORTED libusb_get_device_string(libusb_device *dev,
 	if ((string_type < 0) || (string_type >= LIBUSB_DEVICE_STRING_COUNT)) {
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
-	if (length < 0) {
+	if (length <= 0) {
 		return LIBUSB_ERROR_INVALID_PARAM;
 	}
 	if (NULL == data) {

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1009,13 +1009,14 @@ static int darwin_get_device_string(struct libusb_device *dev,
 
   long cfUsedIndex = 0;
   CFStringGetBytes(cf, CFRangeMake(0, CFStringGetLength(cf)), kCFStringEncodingUTF8, '?', false,
-    (uint8_t *) buffer, length, &cfUsedIndex);
+    (uint8_t *) buffer, length - 1, &cfUsedIndex);
   CFRelease(cf);
 
   if (cfUsedIndex <= 0)
     return LIBUSB_ERROR_NOT_FOUND;
 
-  return (int) cfUsedIndex;
+  buffer[cfUsedIndex] = '\0';
+  return (int) cfUsedIndex + 1;
 }
 
 static int get_configuration_index (struct libusb_device *dev, UInt8 config_value) {

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -972,6 +972,9 @@ static void darwin_exit (struct libusb_context *ctx) {
 static int darwin_get_device_string(struct libusb_device *dev, 
     enum libusb_device_string_type string_type, char *buffer, int length) {
   
+  if (length <= 0)
+    return LIBUSB_ERROR_INVALID_PARAM;
+
   struct darwin_cached_device *priv = DARWIN_CACHED_DEVICE(dev);
   io_iterator_t deviceIterator;
   io_service_t service;


### PR DESCRIPTION
The `get_device_string` documentation ([libusbi.h](https://github.com/libusb/libusb/blob/master/libusb/libusbi.h)) states:

> _"This function must not write more than length bytes into data, including the null terminator. Returns the actual length in bytes including the null terminator on success."_

The macOS implementation (`darwin_get_device_string` in `os/darwin_usb.c`) doesn't properly handle the null terminator.

`CFStringGetBytes` writes into the buffer without adding a null terminator. `libusb_get_device_string` then calls `usbi_utf8_copy` that reads past the valid string bytes into uninitialised heap memory, sometimes appending garbage to device strings.

I observed this symptom on one of my projects and found a fix to be consistent with the behavior we already have on windows and linux, and the documentation:

Pass `length - 1` to `CFStringGetBytes` to reserve one byte, then explicitly write `'\0'` at the end of the string. Return value updated to `cfUsedIndex + 1` to stay consistent with the documented `get_device_string` function (length including null terminator).

I couldn't find any issue referencing this bug, but I may have missed it!