### PR TITLE
Release 1.0.30

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Angus Gratton
 Anil Nair
 Ankur Verma
 Anthony Clay
+Antoine Moreau
 Antonio Ospite
 Artem Egorkine
 Aurelien Jarno
@@ -159,6 +160,7 @@ Moritz Fischer
 Nancy Li
 Nia Alarie
 Nicholas Corgan
+Nicolas Bats
 Niklas Gürtler
 Ole André Vadla Ravnås
 Oleksand Radovenchyk

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 For detailed information about the changes below, please see the git log.
 
-2026-05-03: v1.0.30-rc2
+2026-05-17: v1.0.30
 * Add hotplug support on Microsoft Windows
 * Add RAW_IO support in WinUSB backend
 * Work around a macOS 26 Tahoe compatibility breakage due to Apple changing kUSBHostPortPropertyPortNumber

--- a/configure.ac
+++ b/configure.ac
@@ -31,9 +31,9 @@ dnl Library versioning
 dnl These numbers should be tweaked on every release. Read carefully:
 dnl http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 dnl http://sourceware.org/autobook/autobook/autobook_91.html
-lt_current=5
+lt_current=6
 lt_revision=0
-lt_age=5
+lt_age=6
 LT_LDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age} -no-undefined"
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/libusb/version.h
+++ b/libusb/version.h
@@ -14,5 +14,5 @@
 #endif
 /* LIBUSB_RC is the release candidate suffix. Should normally be empty. */
 #ifndef LIBUSB_RC
-#define LIBUSB_RC "-rc2"
+#define LIBUSB_RC ""
 #endif

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12036
+#define LIBUSB_NANO 12037

--- a/libusb/version_nano.h
+++ b/libusb/version_nano.h
@@ -1,1 +1,1 @@
-#define LIBUSB_NANO 12035
+#define LIBUSB_NANO 12036


### PR DESCRIPTION
(exceptionally including nano version change, for build artifacts to have them correct)

Things to mention in release announcements apart from the normal summary, let me know if I missed something:

- after release, probably replacing "nano" version tick with git describe string (1812)
- after release, probably ditch VS2013 and VS2015 support (1784)

