### PR TITLE
windows: Use #pragma pack consistently instead of includes (2)

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -160,7 +160,7 @@ enum windows_version {
 
 extern enum windows_version windows_version;
 
-#include <pshpack1.h>
+#pragma pack(push, 1)
 
 typedef struct USB_DEVICE_DESCRIPTOR {
 	UCHAR  bLength;
@@ -190,7 +190,7 @@ typedef struct USB_CONFIGURATION_DESCRIPTOR {
 	UCHAR  MaxPower;
 } USB_CONFIGURATION_DESCRIPTOR, *PUSB_CONFIGURATION_DESCRIPTOR;
 
-#include <poppack.h>
+#pragma pack(pop)
 
 #define MAX_DEVICE_ID_LEN	200
 


### PR DESCRIPTION
A leftover commit from #1826 that I somehow missed out on when merging that PR (commit 47495346).

Below from Nicolas' original commit summary:

> The Microsoft headers <pshpack1.h> / <poppack.h> exist solely to issue emits -Wpragma-pack every time these headers are included, since the alignment is modified inside an included file. The same warnings do not appear under Apple Clang or OpenBSD clang, so this is specific to MSYS2 clang.
> Replace the includes by the equivalent #pragma pack directives, which are already used elsewhere in the codebase (libusb.h, libusbi.h, os/windows_winusb.c) and are portable across MSVC, GCC, and Clang. The semantics are identical on all targets.
> Tested on MSYS2 UCRT64 + Clang: build is now warning-free for the Windows backend headers.
