### PR TITLE
windows: configure endpoints for composite devices

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -575,6 +575,9 @@ static int windows_assign_endpoints(struct libusb_device_handle *dev_handle, uin
 	// Extra init may be required to configure endpoints
 	if (priv->apib->configure_endpoints)
 		r = priv->apib->configure_endpoints(SUB_API_NOTSET, dev_handle, iface);
+	else if (priv->usb_interface[iface].apib->configure_endpoints)
+		priv->usb_interface[iface].apib->configure_endpoints(
+			priv->usb_interface[iface].sub_api, dev_handle, iface);
 
 	if (r == LIBUSB_SUCCESS)
 		priv->usb_interface[iface].current_altsetting = altsetting;


### PR DESCRIPTION
For composite USB devices (USB_API_COMPOSITE), the configure_endpoints function pointer is NULL, causing winusbx_configure_endpoints() to never be called. This means pipe policies like AUTO_CLEAR_STALL are not set for composite device interfaces, unlike non-composite WinUSB devices.

Without AUTO_CLEAR_STALL, endpoint stalls on composite devices become unrecoverable - libusb_clear_halt() works unreliably due to timing issues with async transfers, often requiring device re-enumeration.

Add an else-if branch in windows_assign_endpoints() to call winusbx_configure_endpoints() directly for composite device interfaces that have a valid WinUSB sub_api, ensuring consistent pipe policy configuration regardless of device topology.

Closes #1835