### PR TITLE
libusbi.h: make usbi_reallocf() C23-safe for size 0

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -261,9 +261,20 @@ static inline void list_splice_front(struct list_head *list, struct list_head *h
 
 static inline void *usbi_reallocf(void *ptr, size_t size)
 {
-	void *ret = realloc(ptr, size);
+	void *ret;
 
-	if (!ret && size != 0)
+	/*
+	 * Never call realloc(ptr, 0): it is implementation-defined before C23
+	 * and undefined behavior since C23, and libcs disagree on it anyway
+	 * (e.g. musl returns a non-NULL 1-byte allocation, while glibc/MSVC
+	 * free ptr and return NULL). Handle a zero size explicitly instead.
+	 */
+	if (size == 0) {
+		free(ptr);
+		return NULL;
+	}
+	ret = realloc(ptr, size);
+	if (!ret)
 		free(ptr);
 	return ret;
 }


### PR DESCRIPTION
## Summary

Make `usbi_reallocf()` **C23-compliant**.

The current implementation calls `realloc(ptr, size)` unconditionally:

```c
void *ret = realloc(ptr, size);
if (!ret && size != 0)
	free(ptr);
return ret;
```

`realloc(ptr, 0)` is **implementation-defined before C23 and undefined behavior since C23** ([cppreference](https://en.cppreference.com/w/c/memory/realloc)), so calling `usbi_reallocf(ptr, 0)` is not C23-safe. The existing `&& size != 0` guard does **not** make it safe — it only skips the redundant second `free()`; the offending `realloc(ptr, 0)` has already run one line earlier.

This PR handles `size == 0` explicitly (free `ptr`, return `NULL`) so `realloc()` is never called with a zero size.

## Why not rely on `realloc(ptr, 0)`

`realloc(ptr, 0)` is not portable even setting C23 aside — implementations genuinely disagree. For example, [musl](https://git.musl-libc.org/cgit/musl/tree/src/malloc) frees `ptr` and returns a **non-NULL** pointer to a fresh 1-byte allocation, whereas glibc/MSVC free `ptr` and return `NULL`. So `usbi_reallocf(ptr, 0)` yields a non-NULL result on musl but `NULL` on glibc — same input, different answer, both conforming.

(For the record this divergence does not make the *current* code crash on musl: the double-free it guards against only occurs on the NULL-returning libcs; on musl the only edge case is a leak, were a zero-size `realloc` to fail.) Handling `size == 0` ourselves drops the dependency entirely and gives one deterministic behaviour everywhere.

## Impact

No functional change for the current sole caller (`os/linux_usbfs.c`), which always passes a non-zero size. This is a defensive correctness change for C23 conformance and any future caller.

Refs: #1598
Assisted-by: claude-code:claude-opus-4-8
