### PR TITLE
Update altsetting and num_altsetting back-to-back as needed by -fboun…

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -364,40 +364,39 @@ static int parse_configuration(struct libusb_context *ctx,
 		return LIBUSB_ERROR_IO;
 	}
 
-	config->bLength = buffer[0];
-	config->bDescriptorType = buffer[1];
-	config->wTotalLength = ReadLittleEndian16(&buffer[2]);
-	config->bNumInterfaces = buffer[4];
-	config->bConfigurationValue = buffer[5];
-	config->iConfiguration = buffer[6];
-	config->bmAttributes = buffer[7];
-	config->MaxPower = buffer[8];
-	if (config->bDescriptorType != LIBUSB_DT_CONFIG) {
+	uint8_t bLength = buffer[0];
+	uint8_t bDescriptorType = buffer[1];
+	uint16_t wTotalLength = ReadLittleEndian16(&buffer[2]);
+	uint8_t bNumInterfaces = buffer[4];
+	uint8_t bConfigurationValue = buffer[5];
+	uint8_t iConfiguration = buffer[6];
+	uint8_t bmAttributes = buffer[7];
+	uint8_t MaxPower = buffer[8];
+
+	if (bDescriptorType != LIBUSB_DT_CONFIG) {
 		usbi_err(ctx, "unexpected descriptor 0x%x (expected 0x%x)",
-			 config->bDescriptorType, LIBUSB_DT_CONFIG);
+			 bDescriptorType, LIBUSB_DT_CONFIG);
 		return LIBUSB_ERROR_IO;
-	} else if (config->bLength < LIBUSB_DT_CONFIG_SIZE) {
-		usbi_err(ctx, "invalid config bLength (%u)", config->bLength);
+	} else if (bLength < LIBUSB_DT_CONFIG_SIZE) {
+		usbi_err(ctx, "invalid config bLength (%u)", bLength);
 		return LIBUSB_ERROR_IO;
-	} else if (config->bLength > size) {
+	} else if (bLength > size) {
 		usbi_err(ctx, "short config descriptor read %d/%u",
-			 size, config->bLength);
+			 size, bLength);
 		return LIBUSB_ERROR_IO;
-	} else if (config->bNumInterfaces > USB_MAXINTERFACES) {
-		usbi_err(ctx, "too many interfaces (%u)", config->bNumInterfaces);
+	} else if (bNumInterfaces > USB_MAXINTERFACES) {
+		usbi_err(ctx, "too many interfaces (%u)", bNumInterfaces);
 		return LIBUSB_ERROR_IO;
 	}
 
-	usb_interface = (struct libusb_interface *)calloc(config->bNumInterfaces, sizeof(*usb_interface));
+	usb_interface = (struct libusb_interface *)calloc(bNumInterfaces, sizeof(*usb_interface));
 	if (!usb_interface)
 		return LIBUSB_ERROR_NO_MEM;
 
-	config->interface = usb_interface;
+	buffer += bLength;
+	size -= bLength;
 
-	buffer += config->bLength;
-	size -= config->bLength;
-
-	for (i = 0; i < config->bNumInterfaces; i++) {
+	for (i = 0; i < bNumInterfaces; i++) {
 		const uint8_t *begin;
 
 		/* Skip over the rest of the Class Specific or Vendor */
@@ -415,8 +414,8 @@ static int parse_configuration(struct libusb_context *ctx,
 				usbi_warn(ctx,
 					  "short extra config desc read %d/%u",
 					  size, header->bLength);
-				config->bNumInterfaces = i;
-				return size;
+				bNumInterfaces = i;
+				goto finish;
 			}
 
 			/* If we find another "proper" descriptor then we're done */
@@ -435,24 +434,24 @@ static int parse_configuration(struct libusb_context *ctx,
 		/*  drivers to later parse */
 		ptrdiff_t len = buffer - begin;
 		if (len > 0) {
-			uint8_t *extra = (uint8_t *)realloc((void *)config->extra,
-						 (size_t)(config->extra_length) + (size_t)len);
+			size_t new_extra_len = (size_t)(config->extra_length) + (size_t)len;
+			uint8_t *new_extra = (uint8_t *)realloc((void *)config->extra, new_extra_len);
 
-			if (!extra) {
+			if (!new_extra) {
 				r = LIBUSB_ERROR_NO_MEM;
 				goto err;
 			}
 
-			memcpy(extra + config->extra_length, begin, (size_t)len);
-			config->extra = extra;
-			config->extra_length += (int)len;
+			memcpy(new_extra + config->extra_length, begin, (size_t)len);
+			config->extra = new_extra;
+			config->extra_length = (int)new_extra_len;
 		}
 
 		r = parse_interface(ctx, usb_interface + i, buffer, size);
 		if (r < 0)
 			goto err;
 		if (r == 0) {
-			config->bNumInterfaces = i;
+			bNumInterfaces = i;
 			break;
 		}
 
@@ -460,9 +459,24 @@ static int parse_configuration(struct libusb_context *ctx,
 		size -= r;
 	}
 
+finish:
+	config->interface = usb_interface;
+	config->bNumInterfaces = bNumInterfaces;
+	config->bLength = bLength;
+	config->bDescriptorType = bDescriptorType;
+	config->wTotalLength = wTotalLength;
+	config->bConfigurationValue = bConfigurationValue;
+	config->iConfiguration = iConfiguration;
+	config->bmAttributes = bmAttributes;
+	config->MaxPower = MaxPower;
+
 	return size;
 
 err:
+	/* Even though we've failed, set these 2 fields so clear_configuration() can dealloc memory. */
+	config->interface = usb_interface;
+	config->bNumInterfaces = bNumInterfaces;
+
 	clear_configuration(config);
 	return r;
 }

--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -181,49 +181,59 @@ static int parse_interface(libusb_context *ctx,
 	const uint8_t *begin;
 
 	while (size >= LIBUSB_DT_INTERFACE_SIZE) {
-		struct libusb_interface_descriptor *altsetting;
+		uint8_t bLength = buffer[0];
+		uint8_t bDescriptorType = buffer[1];
+		uint8_t bInterfaceNumber = buffer[2];
+		uint8_t bAlternateSetting = buffer[3];
+		uint8_t bNumEndpoints = buffer[4];
+		uint8_t bInterfaceClass = buffer[5];
+		uint8_t bInterfaceSubClass = buffer[6];
+		uint8_t bInterfaceProtocol = buffer[7];
+		uint8_t iInterface = buffer[8];
 
+		if (bDescriptorType != LIBUSB_DT_INTERFACE) {
+			usbi_err(ctx, "unexpected descriptor 0x%x (expected 0x%x)",
+				 bDescriptorType, LIBUSB_DT_INTERFACE);
+			return parsed;
+		} else if (bLength < LIBUSB_DT_INTERFACE_SIZE) {
+			usbi_err(ctx, "invalid interface bLength (%u)",
+				 bLength);
+			r = LIBUSB_ERROR_IO;
+			goto err;
+		} else if (bLength > size) {
+			usbi_warn(ctx, "short intf descriptor read %d/%u",
+				 size, bLength);
+			return parsed;
+		} else if (bNumEndpoints > USB_MAXENDPOINTS) {
+			usbi_err(ctx, "too many endpoints (%u)", bNumEndpoints);
+			r = LIBUSB_ERROR_IO;
+			goto err;
+		}
+
+		struct libusb_interface_descriptor *altsetting;
 		altsetting = (struct libusb_interface_descriptor *)realloc((void *)usb_interface->altsetting,
 			sizeof(*altsetting) * (size_t)(usb_interface->num_altsetting + 1));
 		if (!altsetting) {
 			r = LIBUSB_ERROR_NO_MEM;
 			goto err;
 		}
-		usb_interface->altsetting = altsetting;
 
 		ifp = altsetting + usb_interface->num_altsetting;
-		ifp->bLength = buffer[0];
-		ifp->bDescriptorType = buffer[1];
-		ifp->bInterfaceNumber = buffer[2];
-		ifp->bAlternateSetting = buffer[3];
-		ifp->bNumEndpoints = buffer[4];
-		ifp->bInterfaceClass = buffer[5];
-		ifp->bInterfaceSubClass = buffer[6];
-		ifp->bInterfaceProtocol = buffer[7];
-		ifp->iInterface = buffer[8];
-		if (ifp->bDescriptorType != LIBUSB_DT_INTERFACE) {
-			usbi_err(ctx, "unexpected descriptor 0x%x (expected 0x%x)",
-				 ifp->bDescriptorType, LIBUSB_DT_INTERFACE);
-			return parsed;
-		} else if (ifp->bLength < LIBUSB_DT_INTERFACE_SIZE) {
-			usbi_err(ctx, "invalid interface bLength (%u)",
-				 ifp->bLength);
-			r = LIBUSB_ERROR_IO;
-			goto err;
-		} else if (ifp->bLength > size) {
-			usbi_warn(ctx, "short intf descriptor read %d/%u",
-				 size, ifp->bLength);
-			return parsed;
-		} else if (ifp->bNumEndpoints > USB_MAXENDPOINTS) {
-			usbi_err(ctx, "too many endpoints (%u)", ifp->bNumEndpoints);
-			r = LIBUSB_ERROR_IO;
-			goto err;
-		}
-
-		usb_interface->num_altsetting++;
+		ifp->bLength = bLength;
+		ifp->bDescriptorType = bDescriptorType;
+		ifp->bInterfaceNumber = bInterfaceNumber;
+		ifp->bAlternateSetting = bAlternateSetting;
+		ifp->bNumEndpoints = bNumEndpoints;
+		ifp->bInterfaceClass = bInterfaceClass;
+		ifp->bInterfaceSubClass = bInterfaceSubClass;
+		ifp->bInterfaceProtocol = bInterfaceProtocol;
+		ifp->iInterface = iInterface;
 		ifp->extra = NULL;
 		ifp->extra_length = 0;
 		ifp->endpoint = NULL;
+
+		usb_interface->altsetting = altsetting;
+		usb_interface->num_altsetting++;
 
 		if (interface_number == -1)
 			interface_number = ifp->bInterfaceNumber;


### PR DESCRIPTION
…ds-safety

Update altsetting and num_altsetting back-to-back as needed by -fbounds-safety which requires a pointer and the variable that counts its size be updated together with no intervening statements. This was not the case before, with ->altsetting updated first, then the fields would be partially populated, then the possibility of early return, then -> num_altsetting was updated.

Now extract fields from the buffer into temp variables and check those for the early return situation. Only if early return does not occur, then realloc the buffer and populate the new libusb_interface_descriptor.