### PR TITLE
Spelling fixes, updates to codespell config file

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = strerror.c,AUTHORS
-ignore-words-list = numer,ser,xwindows
+skip = strerror.c,AUTHORS,config.guess,libtool,XCBuildData,autom4te.cache,ltmain.sh
+ignore-words-list = numer,ser,xwindows,maked,pre-emptively

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1049,7 +1049,7 @@ struct usbi_os_backend {
 	 * including the null terminator.
 	 *
 	 * Return:
-	 * - The actual length in bytes including the null termintor on success.
+	 * - The actual length in bytes including the null terminator on success.
 	 * - LIBUSB_ERROR_NO_DEVICE if device not found.
 	 * - LIBUSB_ERROR_INVALID_PARAM if any parameter is invalid.
 	 * - another LIBUSB_ERROR code on other failure

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1475,7 +1475,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
       break;
 
     if (0 != old_session_id) {
-      usbi_dbg (ctx, "re-using existing device from context %p for with session 0x%" PRIx64 " new session 0x%" PRIx64,
+      usbi_dbg (ctx, "reusing existing device from context %p for with session 0x%" PRIx64 " new session 0x%" PRIx64,
                 ctx, old_session_id, cached_device->session);
       /* save the libusb device before the session id is updated */
       dev = usbi_get_device_by_session_id (ctx, (unsigned long) old_session_id);


### PR DESCRIPTION
Codespell once again gives no warnings after these changes.