### PR TITLE
ci: add permissions and pin all actions to full commit SHAs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,9 @@ name: Android
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history + tags so build-aux/gen-describe.sh can produce a
           # tag-prefixed describe string.
@@ -51,7 +54,7 @@ jobs:
           file "${NDK_LIBS_DIR}/"* || true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: libusb-android-${{ matrix.abi }}-api${{ matrix.api }}
           path: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,11 +2,14 @@ name: linux
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Fetch full history + tags so build-aux/gen-describe.sh can
           # produce a tag-prefixed `git describe` string.
@@ -33,7 +36,7 @@ jobs:
       - name: disable-log
         run: .private/ci-build.sh --werror --build-dir build-nolog -- --disable-log
 
-      - uses: emscripten-core/setup-emsdk@v16
+      - uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
 
       - run: npm ci
         working-directory: tests/webusb-test-shim

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,9 @@ on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run
 # sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   build:
@@ -16,7 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job
       # can access it. Full history + tags are needed by
       # build-aux/gen-describe.sh.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,6 +1,9 @@
 name: MSYS2 build
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -8,11 +11,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history + tags for build-aux/gen-describe.sh.
           fetch-depth: 0
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: MINGW64
           update: true

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -1,6 +1,9 @@
 name: MSYS2 aarch64 clang64
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-11-arm
@@ -8,11 +11,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history + tags for build-aux/gen-describe.sh.
           fetch-depth: 0
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: clangarm64
           update: true
@@ -23,7 +26,7 @@ jobs:
           ./bootstrap.sh
           ./.private/ci-build.sh --no-asan --build-dir build-msys2-clang64-aarch64
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-msys2-clang64-aarch64
           path: |

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -1,6 +1,9 @@
 name: MSYS2 clang64 build
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -8,11 +11,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history + tags for build-aux/gen-describe.sh.
           fetch-depth: 0
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: clang64
           update: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,9 @@ name: Windows build and Package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history + tags so the MSVC PreBuildEvent's call to
           # build-aux/gen-describe.ps1 can produce a tag-prefixed
@@ -35,14 +38,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v3
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
       - name: Build solution
         run: |
           msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.architecture }}
           path: |


### PR DESCRIPTION
All 7 workflow files were missing `permissions:` blocks and used mutable tag references. Add `permissions: contents: read` and pin every action to its full commit SHA:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` | `@df4cb1c0` |
| `actions/upload-artifact` | `@v7` | `@043fb46d` |
| `emscripten-core/setup-emsdk` | `@v16` | `@4528d102` |
| `microsoft/setup-msbuild` | `@v3` | `@30375c66` |
| `msys2/setup-msys2` | `@v2` | `@66cd2cce` |

Note: oss-fuzz action refs in `android.yml` are from `google/oss-fuzz` infra and intentionally left unchanged.

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).