### PR TITLE
CI: Create MSI libusb runtime installers for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }}
 
+      - name: Build MSI installer
+        if: startsWith(matrix.configuration, 'Release')
+        run: msbuild msvc/installer/libusb_installer.wixproj -restore -p:Platform=${{ matrix.architecture }} -p:LibusbDllConfiguration=${{ matrix.configuration }} -p:BuildLibusbDll=false
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -52,3 +56,4 @@ jobs:
             build/**/dll/libusb-1.0.exp
             build/**/dll/libusb-1.0.pdb
             build/**/lib/libusb-1.0.lib
+            build/installer/**/*.msi

--- a/msvc/installer/libusb.wxs
+++ b/msvc/installer/libusb.wxs
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  WiX source for the libusb runtime MSI installer.
+
+  It installs the DLL under "Program Files\libusb\bin"
+  (or "Program Files (x86)\libusb\bin" for x86) and prepends
+  that directory to the system PATH.
+
+  Values supplied on the command line with `wix build -d NAME=VALUE`:
+    Version  - product version, e.g. "1.0.30.0" (must be numeric a.b.c.d)
+    DllPath  - absolute path to the built libusb-1.0.dll for this arch
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <!-- Stable, per-arch UpgradeCodes so each flavour installs side by side and upgrades independently. Do not change these. -->
+  <?if $(sys.BUILDARCH) = x64 ?>
+    <?define PlatformName = "x64" ?>
+    <?define ProgramFilesDir = "ProgramFiles64Folder" ?>
+    <?define ComponentBitness = "always64" ?>
+    <?define UpgradeCode = "5C9F3A2B-AD4E-4F7A-B2C3-8D9E0F1A2B3C" ?>
+  <?elseif $(sys.BUILDARCH) = arm64 ?>
+    <?define PlatformName = "arm64" ?>
+    <?define ProgramFilesDir = "ProgramFiles64Folder" ?>
+    <?define ComponentBitness = "always64" ?>
+    <?define UpgradeCode = "7E1D4C3B-2F5A-4B8C-9D0E-3A6B1C2D3E4F" ?>
+  <?else?>
+    <?define PlatformName = "x86" ?>
+    <?define ProgramFilesDir = "ProgramFilesFolder" ?>
+    <?define ComponentBitness = "always32" ?>
+    <?define UpgradeCode = "4B8E2F1A-9C3D-4E6F-A1B2-7C8D9E0F1A2B" ?>
+  <?endif?>
+
+  <Package
+      Name="libusb $(PlatformName) runtime"
+      Manufacturer="The libusb project"
+      Version="$(Version)"
+      UpgradeCode="$(UpgradeCode)"
+      Compressed="yes"
+      Scope="perMachine">
+
+    <SummaryInformation Description="libusb $(PlatformName) runtime library" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of the libusb $(PlatformName) runtime is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="$(ProgramFilesDir)">
+      <Directory Id="INSTALLFOLDER" Name="libusb">
+        <Directory Id="BINFOLDER" Name="bin" />
+      </Directory>
+    </StandardDirectory>
+
+    <ComponentGroup Id="ProductComponents" Directory="BINFOLDER">
+      <!-- The runtime DLL itself. -->
+      <Component Id="LibusbRuntimeDll" Bitness="$(ComponentBitness)">
+        <File Id="LibusbDll" Source="$(DllPath)" Name="libusb-1.0.dll" KeyPath="yes" />
+      </Component>
+
+      <!-- Prepend the install directory to the system PATH. The registry
+           value acts as the component key path; the PATH entry is removed
+           on uninstall (Permanent="no"). -->
+      <Component Id="LibusbPath" Bitness="$(ComponentBitness)">
+        <Environment Id="LibusbPathEnv" Name="PATH" Value="[BINFOLDER]"
+                     Action="set" Part="last" System="yes" Permanent="no" />
+        <RegistryValue Root="HKLM" Key="Software\libusb\$(PlatformName)"
+                       Name="InstallDir" Type="string" Value="[BINFOLDER]" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+  </Package>
+</Wix>

--- a/msvc/installer/libusb_installer.wixproj
+++ b/msvc/installer/libusb_installer.wixproj
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MSBuild project that builds the libusb runtime MSI installer using the
+  WiX Toolset MSBuild SDK. Building this project *is* the installer build:
+
+      msbuild msvc\installer\libusb_installer.wixproj -restore -p:Platform=x64
+      msbuild msvc\installer\libusb_installer.wixproj -restore -p:Platform=x86
+      msbuild msvc\installer\libusb_installer.wixproj -restore -p:Platform=arm64
+
+  The project does the following:
+    * Reads the product version from libusb/version.h (pure MSBuild),
+    * Builds the libusb-1.0 DLL for the requested architecture,
+    * Discovers the freshly built DLL in the MSVC output tree,
+    * Feeds Version + DllPath to libusb.wxs as preprocessor constants.
+-->
+<Project Sdk="WixToolset.Sdk/6.0.2">
+
+  <PropertyGroup>
+    <OutputType>Package</OutputType>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+
+    <!-- Normalise the requested platform to a lowercase WiX arch. -->
+    <InstallerArch Condition="'$(Platform)' == 'Win32' or '$(Platform)' == 'x86' or '$(Platform)' == 'AnyCPU' or '$(Platform)' == 'Any CPU'">x86</InstallerArch>
+    <InstallerArch Condition="'$(Platform)' == 'x64'">x64</InstallerArch>
+    <InstallerArch Condition="'$(Platform)' == 'ARM64' or '$(Platform)' == 'arm64'">arm64</InstallerArch>
+    <InstallerArch Condition="'$(InstallerArch)' == ''">$(Platform)</InstallerArch>
+    <InstallerPlatform>$(InstallerArch)</InstallerPlatform>
+
+    <!-- MSVC platform name (matches libusb.sln output folders): Win32, not x86. -->
+    <LibusbMsvcPlatform Condition="'$(InstallerArch)' == 'x86'">Win32</LibusbMsvcPlatform>
+    <LibusbMsvcPlatform Condition="'$(InstallerArch)' == 'x64'">x64</LibusbMsvcPlatform>
+    <LibusbMsvcPlatform Condition="'$(InstallerArch)' == 'arm64'">ARM64</LibusbMsvcPlatform>
+    <LibusbMsvcPlatform Condition="'$(LibusbMsvcPlatform)' == ''">$(InstallerArch)</LibusbMsvcPlatform>
+
+    <!-- Configuration of the DLL to package. Defaults to Release-MT, which statically links the CRT so the shipped DLL needs no Visual C++ runtime redistributable. -->
+    <LibusbDllConfiguration Condition="'$(LibusbDllConfiguration)' == ''">Release-MT</LibusbDllConfiguration>
+
+    <!-- When false, skip compiling the DLL and just package an existing build output. -->
+    <BuildLibusbDll Condition="'$(BuildLibusbDll)' == ''">true</BuildLibusbDll>
+
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..'))\</RepoRoot>
+
+    <!-- Read the version straight out of the canonical header. -->
+    <_VersionHeader>$([System.IO.File]::ReadAllText('$(RepoRoot)libusb\version.h'))</_VersionHeader>
+    <_LibusbMajor>$([System.Text.RegularExpressions.Regex]::Match($(_VersionHeader), 'define\s+LIBUSB_MAJOR\s+(\d+)').Groups.get_Item(1).Value)</_LibusbMajor>
+    <_LibusbMinor>$([System.Text.RegularExpressions.Regex]::Match($(_VersionHeader), 'define\s+LIBUSB_MINOR\s+(\d+)').Groups.get_Item(1).Value)</_LibusbMinor>
+    <_LibusbMicro>$([System.Text.RegularExpressions.Regex]::Match($(_VersionHeader), 'define\s+LIBUSB_MICRO\s+(\d+)').Groups.get_Item(1).Value)</_LibusbMicro>
+    <LibusbVersion>$(_LibusbMajor).$(_LibusbMinor).$(_LibusbMicro).0</LibusbVersion>
+    <DefineConstants>Version=$(LibusbVersion)</DefineConstants>
+
+    <!-- build/installer/<arch>/libusb-<version>-<arch>.msi -->
+    <OutputName>libusb-$(LibusbVersion)-$(InstallerArch)</OutputName>
+    <OutputPath>$(RepoRoot)build\installer\$(InstallerArch)\</OutputPath>
+  </PropertyGroup>
+
+  <!--
+    Build the libusb DLL for this architecture and resolve its path, then
+    expose it to the WiX compiler as the DllPath preprocessor constant.
+    Runs before CoreCompile so $(DefineConstants) is updated before the
+    WixBuild task reads it.
+  -->
+  <Target Name="ResolveLibusbDll" BeforeTargets="CoreCompile">
+    <Message Condition="'$(BuildLibusbDll)' == 'true'" 
+             Importance="high" Text="Building libusb-1.0.dll ($(LibusbDllConfiguration) | $(LibusbMsvcPlatform))" />
+
+    <MSBuild Condition="'$(BuildLibusbDll)' == 'true'"
+             Projects="$(RepoRoot)msvc\libusb_dll.vcxproj"
+             Targets="Build"
+             Properties="Configuration=$(LibusbDllConfiguration);Platform=$(LibusbMsvcPlatform)" />
+
+    <!-- MSVC layout: build\<toolset>\<platform>\<configuration>\dll\libusb-1.0.dll.
+         A clean tree has exactly one toolset, hence one match. -->
+    <ItemGroup>
+      <_LibusbDll Include="$(RepoRoot)build\**\$(LibusbMsvcPlatform)\$(LibusbDllConfiguration)\dll\libusb-1.0.dll" />
+    </ItemGroup>
+
+    <Error Condition="'@(_LibusbDll)' == ''"
+           Text="libusb-1.0.dll not found for $(LibusbMsvcPlatform)/$(LibusbDllConfiguration) under $(RepoRoot)build." />
+
+    <PropertyGroup>
+      <DllPath>@(_LibusbDll)</DllPath>
+      <DefineConstants>$(DefineConstants);DllPath=$(DllPath)</DefineConstants>
+    </PropertyGroup>
+
+    <Message Importance="high" Text="Packaging DLL: $(DllPath)" />
+    <Message Importance="high" Text="Installer version: $(LibusbVersion)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
In linux, LibUSB is usually packaged by the distros but this is not true for Windows. Also, there is no official LibUSB runtime installer packages for windows.

This leads to a lack of common practices for apps that use LibUSB on Windows...
For example, pyocd has created https://pypi.org/project/libusb-package/ as a way to ship the library in python.
For the pyusb or libusbdotnet packages it is difficult to locate the libusb library because of a lack of standardized path and also being unable to point to an official libusb runtime installation...
Some people opt for bundling the library but it is not that easy because of the different supported architectures and not being among the best practices in some package environments.

I think it would be positive to have an official runtime installation package for Windows that could be referenced whenever an application does not find the LibUSB library in the path. That would simplify things for the dependent applications. Also people may opt for bundling the libusb installer in their installers.

I hope this is useful.
Thanks!

