### PR TITLE
Remove warning "async cancel failed" when transfer is canceled as it times out

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -2061,6 +2061,9 @@ static void handle_timeout(struct usbi_transfer *itransfer)
 	r = libusb_cancel_transfer(transfer);
 	if (r == LIBUSB_SUCCESS)
 		itransfer->timeout_flags |= USBI_TRANSFER_TIMED_OUT;
+	else if (r == LIBUSB_ERROR_NOT_FOUND)
+		usbi_dbg(TRANSFER_CTX(transfer),
+			"transfer already complete");
 	else
 		usbi_warn(TRANSFER_CTX(transfer),
 			"async cancel failed %d", r);


### PR DESCRIPTION
This `warning [handle_timeout] async cancel failed -5` message was happening regularly in my test suite when I was cancelling the transfer at the same time it would be timing out. This simultaneous cancel happened to be a mistake in my tests, but I found this warning sufficiently weird to warrant tracking it down.

The log during an event looked like this:
```
[ 2.366935] [000078ec] libusb: debug [libusb_handle_events_timeout_completed] doing our own event handling
[ 2.366937] [000078ec] libusb: debug [usbi_wait_for_events] WaitForMultipleObjects() for 2 HANDLEs with timeout in 60000ms
[ 2.366973] [00007ea0] libusb: debug [libusb_submit_transfer] transfer 0000025084e643f8
[ 2.366977] [00007ea0] libusb: debug [add_to_flying_list] arm timer for timeout in 100ms (first in line)
[ 2.366979] [00007ea0] libusb: debug [winusbx_submit_bulk_transfer] matched endpoint 82 with interface 0
[ 2.366981] [00007ea0] libusb: debug [winusbx_submit_bulk_transfer] reading 32 bytes
starting libusb_cancel_transfer(libusb.struct_libusb_transfer@25084e643f8) in StreamTransfers.stopLocked
[ 2.473978] [000078ec] libusb: debug [usbi_wait_for_events] WaitForMultipleObjects() returned 1
[ 2.474000] [00007ea0] libusb: debug [libusb_cancel_transfer] transfer 0000025084e643f8
[ 2.474027] [000078ec] libusb: debug [libusb_cancel_transfer] transfer 0000025084e643f8
finished libusb_cancel_transfer(libusb.struct_libusb_transfer@25084e643f8) in StreamTransfers.stopLocked
[ 2.474067] [000078ec] libusb: warning [handle_timeout] async cancel failed -5
[ 2.474079] [000078ec] libusb: debug [arm_timer_for_next_timeout] next timeout originally 10000ms
[ 2.474087] [000078ec] libusb: debug [libusb_handle_events_timeout_completed] doing our own event handling
[ 2.474090] [000078ec] libusb: debug [usbi_wait_for_events] WaitForMultipleObjects() for 2 HANDLEs with timeout in 60000ms
[ 2.474427] [00007340] libusb: debug [windows_iocp_thread] transfer 0000025084e643f8 completed, length 0
[ 2.474447] [000078ec] libusb: debug [usbi_wait_for_events] WaitForMultipleObjects() returned 0
[ 2.474463] [000078ec] libusb: debug [handle_event_trigger] event triggered
[ 2.474468] [000078ec] libusb: debug [windows_handle_transfer_completion] handling transfer 0000025084e643f8 completion with errcode 995, length 0
[ 2.474472] [000078ec] libusb: debug [windows_handle_transfer_completion] detected operation aborted
[ 2.474476] [000078ec] libusb: debug [arm_timer_for_next_timeout] next timeout originally 10000ms
[ 2.474486] [000078ec] libusb: debug [usbi_handle_transfer_completion] transfer 0000025084e643f8 has callback 00007ffdb1ebaa10
[ 2.474497] [000078ec] libusb: debug [libusb_handle_events_timeout_completed] doing our own event handling
[ 2.474501] [000078ec] libusb: debug [usbi_wait_for_events] WaitForMultipleObjects() for 2 HANDLEs with timeout in 60000ms
[ 2.474501] [00007ea0] libusb: debug [libusb_free_transfer] transfer 0000025084e643f8
```

Between my `starting` and `finished` debug lines I'm calling `libusb_cancel_transfer()` once. In the log there's two cancel entries, but they've got different thread_ids.

Basically, libusb was calling `libusb_cancel_transfer()` inside `handle_timeout()`, but my code had just cancelled the transfer, so the return code was `LIBUSB_ERROR_NOT_FOUND`. This doesn't really indicate anything wrong, so I have downgraded the warning to a debug message if the error is `LIBUSB_ERROR_NOT_FOUND`.

My test was unusual in that it was triggering this regularly, but this warning could be generated less frequently in any code that cancels a transfer with a timeout.