### PR TITLE
windows: avoid redundant WinUsb_Initialize when claiming interfaces out of order

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -3197,6 +3197,15 @@ static int winusbx_claim_interface(int sub_api, struct libusb_device_handle *dev
 	if (((is_using_usbccgp) || (iface == 0)) &&
 	    (!is_associated_interface || (iface==priv->usb_interface[iface].first_associated_interface))) {
 		// composite device (independent interfaces) or interface 0
+
+		// This interface may already have been auto-claimed as the first
+		// interface while another interface was claimed before it. Calling
+		// Initialize() again on the same handle would overwrite and leak the
+		// existing api_handle (the one any associated interface was derived
+		// from), so treat an already-initialized interface as done.
+		if (HANDLE_VALID(handle_priv->interface_handle[iface].api_handle))
+			return LIBUSB_SUCCESS;
+
 		file_handle = handle_priv->interface_handle[iface].dev_handle;
 		if (!HANDLE_VALID(file_handle))
 			return LIBUSB_ERROR_NOT_FOUND;


### PR DESCRIPTION
When a non-first interface is claimed before the first one, winusbx_claim_interface() auto-claims the first interface via Initialize() but does not record that claim with the core. If the application then claims the first interface explicitly, the core dispatches a real claim for it and winusbx_claim_interface() calls Initialize() on the same device handle a second time. That overwrites interface_handle[iface].api_handle and leaks the handle the already-claimed associated interface was derived from.

Return LIBUSB_SUCCESS up front when the interface already has a valid api_handle, so the redundant Initialize() is skipped.

I stumble on this issue while using libusb, while the issue is probably very unfrequent I thought it may worth a little PR.

Also: sorry for the inadvertently pushed commit directly onto master. I quickly reverted it, but the history is sealed with my mistake, all apologizes. 