### PR TITLE
darwin: serialize open/capture state (supersedes #1679)

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -65,6 +65,15 @@ static usbi_cond_t libusb_darwin_at_cond = USBI_COND_INITIALIZER;
 static CFRunLoopRef libusb_darwin_acfl = NULL; /* event cf loop */
 static CFRunLoopSourceRef libusb_darwin_acfls = NULL; /* shutdown signal for event cf loop */
 
+/* Lock ordering: the per-device lock (struct darwin_cached_device, dpriv->lock)
+   may be held when acquiring darwin_cached_devices_mutex (e.g. via
+   darwin_reload_device), so never acquire dpriv->lock while holding
+   darwin_cached_devices_mutex. The core acquires dev_handle->lock before
+   calling into the backend (libusb_claim_interface/libusb_release_interface),
+   so dev_handle->lock always sits above dpriv->lock. Consequently, code
+   holding dpriv->lock must not call public libusb_* functions that take
+   locks (e.g. libusb_release_interface). Lock-free ones such as
+   libusb_get_active_config_descriptor are tolerated but discouraged. */
 static usbi_mutex_t darwin_cached_devices_mutex = USBI_MUTEX_INITIALIZER;
 static struct list_head darwin_cached_devices GUARDED_BY(darwin_cached_devices_mutex);
 static int init_count GUARDED_BY(darwin_cached_devices_mutex);
@@ -92,6 +101,7 @@ static int darwin_reenumerate_device(struct libusb_device_handle *dev_handle, bo
 static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned char endpoint);
 static int darwin_reset_device(struct libusb_device_handle *dev_handle);
 static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface);
+static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock);
 static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0);
 
 static enum libusb_error darwin_scan_devices(struct libusb_context *ctx);
@@ -459,6 +469,7 @@ static void darwin_deref_cached_device(struct darwin_cached_device *cached_dev) 
       cached_dev->device = NULL;
     }
     IOObjectRelease (cached_dev->service);
+    usbi_mutex_destroy(&cached_dev->lock);
     free (cached_dev);
   }
 }
@@ -1432,6 +1443,8 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
       (*device)->GetLocationID (device, &new_device->location);
       new_device->port = port;
       new_device->parent_session = parent_sessionID;
+
+      usbi_mutex_init(&new_device->lock);
     } else {
       /* release the ref to old device's service */
       IOObjectRelease (new_device->service);
@@ -1593,7 +1606,8 @@ static enum libusb_error darwin_scan_devices(struct libusb_context *ctx) {
   return LIBUSB_SUCCESS;
 }
 
-static int darwin_open (struct libusb_device_handle *dev_handle) {
+/* must be called while holding dpriv->lock */
+static int darwin_open_locked (struct libusb_device_handle *dev_handle) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
@@ -1647,11 +1661,23 @@ static int darwin_open (struct libusb_device_handle *dev_handle) {
   return 0;
 }
 
-static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+static int darwin_open (struct libusb_device_handle *dev_handle) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_open_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
+}
+
+/* must be called while holding dpriv->lock. any claimed interfaces must have
+   been released by the caller beforehand. */
+static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
-  int i;
 
   if (dpriv->open_count == 0) {
     /* something is probably very wrong if this is the case */
@@ -1664,11 +1690,6 @@ static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_
     usbi_warn (HANDLE_CTX (dev_handle), "darwin_close device missing IOService");
     return;
   }
-
-  /* make sure all interfaces are released */
-  for (i = 0 ; i < USB_MAXINTERFACES ; i++)
-    if (dev_handle->claimed_interfaces & (1U << i))
-      libusb_release_interface (dev_handle, i);
 
   if (0 == dpriv->open_count) {
     /* delete the device's async event source */
@@ -1689,6 +1710,25 @@ static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_
       }
     }
   }
+}
+
+static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int i;
+
+  /* make sure all interfaces are released before taking the device lock.
+     releasing an interface may reattach the kernel driver
+     (auto_detach_kernel_driver) via darwin_capture_release_interface, which
+     acquires dpriv->lock itself. this is safe even if the device is gone:
+     the interface plug-ins are per-handle objects and every path below
+     checks dpriv->device before using it. */
+  for (i = 0 ; i < USB_MAXINTERFACES ; i++)
+    if (dev_handle->claimed_interfaces & (1U << i))
+      libusb_release_interface (dev_handle, i);
+
+  usbi_mutex_lock(&dpriv->lock);
+  darwin_close_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
 }
 
 static int darwin_get_configuration(struct libusb_device_handle *dev_handle, uint8_t *config) {
@@ -2085,6 +2125,9 @@ static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned c
   return darwin_to_libusb (kresult);
 }
 
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses, as on
+   the pre-split code. */
 static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_handle, uint8_t active_config,
                                                unsigned long claimed_interfaces) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
@@ -2102,10 +2145,10 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   dpriv->open_count = 1;
 
   /* clean up open interfaces */
-  darwin_close (dev_handle);
+  darwin_close_locked (dev_handle);
 
   /* re-open the device */
-  ret = darwin_open (dev_handle);
+  ret = darwin_open_locked (dev_handle);
   dpriv->open_count = open_count;
   if (LIBUSB_SUCCESS != ret) {
     /* could not restore configuration */
@@ -2147,6 +2190,12 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   return LIBUSB_SUCCESS;
 }
 
+/* must be called while holding dpriv->lock. the lock is held during the wait
+   for re-enumeration to complete, which serializes open/close/capture
+   operations on the device while it is being reset. the hotplug thread that
+   signals completion (via dpriv->in_reenumerate) does not take this lock.
+   the REQUIRES annotation carries the dev_handle->lock contract of the
+   claimed_interfaces accesses, as before this change. */
 static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, bool capture) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   unsigned long claimed_interfaces = dev_handle->claimed_interfaces;
@@ -2253,7 +2302,10 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
   return darwin_restore_state (dev_handle, active_config, claimed_interfaces);
 }
 
-static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_reset_device_locked (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
   int ret;
@@ -2279,7 +2331,7 @@ static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRE
     /* reset capture count */
     dpriv->capture_count = 0;
     /* attempt to detach kernel driver again as it is now re-attached */
-    ret = darwin_detach_kernel_driver (dev_handle, 0);
+    ret = darwin_detach_kernel_driver_locked (dev_handle, 0);
     if (ret != LIBUSB_SUCCESS) {
       return ret;
     }
@@ -2289,6 +2341,17 @@ static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRE
     ret = darwin_restore_state (dev_handle, active_config, claimed_interfaces);
   }
 #endif
+  return ret;
+}
+
+static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_reset_device_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
+
   return ret;
 }
 
@@ -2913,7 +2976,10 @@ static int darwin_reload_device (struct libusb_device_handle *dev_handle) EXCLUD
 
 /* On macOS, we capture an entire device at once, not individual interfaces. */
 
-static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
   UNUSED(interface);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
@@ -2958,8 +3024,21 @@ static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle,
   return LIBUSB_SUCCESS;
 }
 
+static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
 
-static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_detach_kernel_driver_locked (dev_handle, interface);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
+}
+
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_attach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
   UNUSED(interface);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
 
@@ -2976,6 +3055,17 @@ static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle,
 
   /* reset device to attach kernel drivers */
   return darwin_reenumerate_device (dev_handle, false);
+}
+
+static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_attach_kernel_driver_locked (dev_handle, interface);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
 }
 
 static int darwin_capture_claim_interface(struct libusb_device_handle *dev_handle, uint8_t iface) REQUIRES(dev_handle->lock) {
@@ -2999,13 +3089,15 @@ static int darwin_capture_release_interface(struct libusb_device_handle *dev_han
     return ret;
   }
 
+  usbi_mutex_lock(&dpriv->lock);
   if (dev_handle->auto_detach_kernel_driver && dpriv->capture_count > 0) {
-    ret = darwin_attach_kernel_driver (dev_handle, iface);
+    ret = darwin_attach_kernel_driver_locked (dev_handle, iface);
     if (LIBUSB_SUCCESS != ret) {
       usbi_info (HANDLE_CTX (dev_handle), "on attempt to reattach the kernel driver got ret=%d", ret);
     }
     /* ignore the error as the interface was successfully released */
   }
+  usbi_mutex_unlock(&dpriv->lock);
 
   return LIBUSB_SUCCESS;
 }

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2897,11 +2897,15 @@ static bool darwin_has_capture_entitlements (void) {
 
 static int darwin_reload_device (struct libusb_device_handle *dev_handle) EXCLUDES(darwin_cached_devices_mutex) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  usb_device_t new_device;
   enum libusb_error err;
 
   usbi_mutex_lock(&darwin_cached_devices_mutex);
-  (*dpriv->device)->Release(dpriv->device);
-  err = darwin_device_from_service (HANDLE_CTX (dev_handle), dpriv->service, &dpriv->device);
+  err = darwin_device_from_service (HANDLE_CTX (dev_handle), dpriv->service, &new_device);
+  if (err == LIBUSB_SUCCESS) {
+    (*dpriv->device)->Release(dpriv->device);
+    dpriv->device = new_device;
+  }
   usbi_mutex_unlock(&darwin_cached_devices_mutex);
 
   return err;

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1712,18 +1712,29 @@ static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
   }
 }
 
-static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+static void darwin_close (struct libusb_device_handle *dev_handle) EXCLUDES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  unsigned long claimed_interfaces;
   int i;
 
-  /* make sure all interfaces are released before taking the device lock.
-     releasing an interface may reattach the kernel driver
-     (auto_detach_kernel_driver) via darwin_capture_release_interface, which
-     acquires dpriv->lock itself. this is safe even if the device is gone:
-     the interface plug-ins are per-handle objects and every path below
-     checks dpriv->device before using it. */
+  /* snapshot the claimed interfaces under dev_handle->lock, which guards
+     claimed_interfaces. the interfaces must be released before taking the
+     device lock and without holding dev_handle->lock:
+     libusb_release_interface takes dev_handle->lock itself, and releasing
+     an interface may reattach the kernel driver
+     (auto_detach_kernel_driver) via darwin_capture_release_interface,
+     which acquires dpriv->lock. a stale snapshot is harmless because
+     libusb_release_interface rechecks the bit under the lock, and using
+     the handle concurrently with libusb_close is undefined anyway.
+     releasing is safe even if the device is gone: the interface plug-ins
+     are per-handle objects and every path below checks dpriv->device
+     before using it. */
+  usbi_mutex_lock(&dev_handle->lock);
+  claimed_interfaces = dev_handle->claimed_interfaces;
+  usbi_mutex_unlock(&dev_handle->lock);
+
   for (i = 0 ; i < USB_MAXINTERFACES ; i++)
-    if (dev_handle->claimed_interfaces & (1U << i))
+    if (claimed_interfaces & (1U << i))
       libusb_release_interface (dev_handle, i);
 
   usbi_mutex_lock(&dpriv->lock);

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -116,12 +116,13 @@ struct darwin_cached_device {
   char                  sys_path[21];
   usb_device_t          device;
   io_service_t          service;
-  int                   open_count;
+  usbi_mutex_t          lock;          /* protects open_count and capture_count */
+  int                   open_count;    /* GUARDED_BY(lock) */
+  int                   capture_count; /* GUARDED_BY(lock) */
   UInt8                 first_config, active_config, port;
   int                   can_enumerate;
   int                   refcount;
   atomic_bool           in_reenumerate;
-  int                   capture_count;
 };
 
 struct darwin_device_priv {


### PR DESCRIPTION
This PR fixes items 1 and 2 of the concurrency audit in #1798, superseding #1679 per
[@osy's suggestion](https://github.com/libusb/libusb/pull/1679#issuecomment-4233506257) that a new PR take over the stalled one.

**Item 1: unsynchronized `open_count` / `capture_count`.** Both counters on `struct darwin_cached_device` were read-modify-written with no synchronization from `darwin_open`, `darwin_close`, `darwin_restore_state`, `darwin_reset_device`, `darwin_detach_kernel_driver`, `darwin_attach_kernel_driver` and `darwin_capture_release_interface`. Concurrent open/close/detach on different handles to the same physical device could double-`USBDeviceOpenSeize`, skip last-close cleanup, or corrupt capture state. This is the crash class behind #1635 and the `test4.cpp` (sudo) reproducer from the #1798 thread.

**Item 2: same-thread deadlock in the close path.** Any per-device locking scheme deadlocks if `darwin_close` holds the lock while releasing claimed interfaces, because `libusb_release_interface` chains into `darwin_capture_release_interface` -> `darwin_attach_kernel_driver` -> `darwin_reenumerate_device` -> `darwin_restore_state`, which need the same lock.

- One per-device mutex `dpriv->lock` guards **both** counters. A single lock (instead of   #1679's `open_mutex` + `capture_mutex`) removes the ABBA deadlock by construction: the   close path (open -> capture order) and the reset path (capture -> open order) can no longer nest two locks in opposite orders.

- Public entry points are thin wrappers taking the lock; internal callers that already   hold it use the `*_locked` variants (same structure as #1679; names avoid the leading  underscore since file-scope identifiers starting with `_` are reserved in C).

- `darwin_close` releases claimed interfaces **before** entering the critical section.   The release loop only touches per-handle state, so it doesn't need the device lock.  It now also runs when `dpriv->device` is NULL (disconnected device); the interface plug-ins are per-handle objects and every downstream path checks `dpriv->device`;  previously those plug-ins and their run-loop sources were leaked.  `darwin_restore_state`'s internal close/open cycle is unaffected (it temporarily zeroes `claimed_interfaces`, so it never released interfaces there anyway).

- Serializing first-open against last-close also closes a window where a concurrent  `USBDeviceOpenSeize` could race the closing thread's `USBDeviceClose`.
-
- The hotplug  and enumeration paths never take `dpriv->lock`, so holding it across the re-enumeration wait (completion is signaled via the `in_reenumerate` atomic from the hotplug thread) cannot deadlock.
-
- Includes #1679's `darwin_reload_device` use-after-free fix as a separate first commit, with the declaration corrected (`usb_device_t new_device`, not `usb_device_t **`).

From #1679: mutex declared before the fields it guards, with`GUARDED_BY(lock)` comments (per @seanm), ready for the #1419 annotations later.

@mcuee This needs testing on macOS with the reproducers from #1798 / #1793 (`test4.cpp` under sudo with TSan/ASan builds) and #1635's test. Your test matrix would be very welcome here!

Reference: #1798 (items 1 and 2)
Closes: #1679
Fixes: #1635