### PR TITLE
darwin: take cached-devices mutex when referencing device in process_new_device

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -474,6 +474,7 @@ static void darwin_deref_cached_device(struct darwin_cached_device *cached_dev) 
   }
 }
 
+/* this function must be called with the darwin_cached_devices_mutex held */
 static void darwin_ref_cached_device(struct darwin_cached_device *cached_dev) REQUIRES(darwin_cached_devices_mutex) {
   cached_dev->refcount++;
 }
@@ -1514,7 +1515,9 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
       priv = (struct darwin_device_priv *)usbi_get_device_priv(dev);
 
       priv->dev = cached_device;
+      usbi_mutex_lock(&darwin_cached_devices_mutex);
       darwin_ref_cached_device (priv->dev);
+      usbi_mutex_unlock(&darwin_cached_devices_mutex);
       dev->port_number    = cached_device->port;
       /* the location ID encodes the path to the device. the top byte of the location ID contains the bus number
          (numbered from 0). the remaining bytes can be used to construct the device tree for that bus. */


### PR DESCRIPTION
Fixes item 8 of the concurrency audit in #1798.

`darwin_ref_cached_device` increments `cached_dev->refcount` with no synchronization.
Every caller holds `darwin_cached_devices_mutex` except `process_new_device`, whose increment can race a concurrent `darwin_deref_cached_device` (always under the mutex) from the hotplug thread or from another context tearing down devices, tearing the counter. TSan traces in #1635 show the refcount going negative, which frees the cached device while still in use.

This takes `darwin_cached_devices_mutex` around the increment and documents the locking requirement on `darwin_ref_cached_device`, mirroring the existing comment on `darwin_deref_cached_device`.

No new lock ordering: both `process_new_device` call sites (`darwin_scan_devices`, `darwin_devices_attached`) hold at most `active_contexts_lock`, and the `active_contexts_lock` to `darwin_cached_devices_mutex` nesting already exists in `darwin_devices_attached` and `darwin_devices_detached`.

**Independent of #1864 and #1865** — no overlapping hunks; can be reviewed and merged in parallel, in any order.

Scope note: this fixes the torn increment only. A narrower pre-existing window remains where `darwin_get_cached_device` returns the pointer without taking a reference for the caller, so a detach event can in principle free the cached device before `process_new_device` runs (unchanged from master; requires attach followed by instant unplug). Closing it properly means having `darwin_get_cached_device` take the reference under its own mutex before returning
This will be a follow-up to the re-enumeration lifetime work in #1865.

Reference: #1798 (item 8)
Reference: #1635