### PR TITLE
ci: bound job runtimes and preserve test logs on failure

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Build Fuzzers
       id: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,3 +85,15 @@ jobs:
           ./fuzz_bos_descriptor tests/fuzz/corpus/bos \
             -seed=1 -runs=200 -max_total_time=15 -timeout=5 -rss_limit_mb=1536 -print_final_stats=1
       # --- end sanitizers + fuzzer smoke ---
+
+      # The autotools test driver buffers each test's output into its own
+      # tests/<test>.log; keep them (and config.log) when something goes wrong.
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: failure() || cancelled()
+        with:
+          name: test-logs-linux
+          path: |
+            build*/config.log
+            build*/tests/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     runs-on: macos-latest
+    timeout-minutes: 60
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -37,3 +38,15 @@ jobs:
       - name: Xcode
         shell: bash
         run: cd Xcode && xcodebuild -project libusb.xcodeproj
+
+      # The autotools test driver buffers each test's output into its own
+      # tests/<test>.log; keep them (and config.log) when something goes wrong.
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: failure() || cancelled()
+        with:
+          name: test-logs-macos
+          path: |
+            build*/config.log
+            build*/tests/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 60
     defaults:
       run:
         shell: msys2 {0}
@@ -24,3 +25,14 @@ jobs:
         run: ./.private/ci-build.sh --build-dir build-msys2 --no-asan
       - name: Build with logging disabled
         run: ./.private/ci-build.sh --build-dir build-msys2-nolog --no-asan -- --disable-log
+      # The autotools test driver buffers each test's output into its own
+      # tests/<test>.log; keep them (and config.log) when something goes wrong.
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: failure() || cancelled()
+        with:
+          name: test-logs-msys2
+          path: |
+            build*/config.log
+            build*/tests/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-11-arm
+    timeout-minutes: 60
     defaults:
       run:
         shell: msys2 {0}
@@ -30,3 +31,15 @@ jobs:
             build-msys2-clang64-aarch64/libusb/.libs/libusb-1.0.dll.a
             build-msys2-clang64-aarch64/libusb/.libs/libusb-1.0.a
             build-msys2-clang64-aarch64/libusb/.libs/libusb-1.0.dll
+
+      # The autotools test driver buffers each test's output into its own
+      # tests/<test>.log; keep them (and config.log) when something goes wrong.
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: failure() || cancelled()
+        with:
+          name: test-logs-msys2-clang64-aarch64
+          path: |
+            build*/config.log
+            build*/tests/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 60
     defaults:
       run:
         shell: msys2 {0}
@@ -22,3 +23,14 @@ jobs:
           echo 'Running in MSYS2!'
           ./bootstrap.sh
           ./.private/ci-build.sh --build-dir build-msys2-clang64
+      # The autotools test driver buffers each test's output into its own
+      # tests/<test>.log; keep them (and config.log) when something goes wrong.
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: failure() || cancelled()
+        with:
+          name: test-logs-msys2-clang64
+          path: |
+            build*/config.log
+            build*/tests/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,7 @@ jobs:
           - 'ARM64'
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Two small, independent CI robustness improvements, applicable to all platforms:

## 1. `timeout-minutes: 60` on every workflow job

All jobs previously ran with GitHub's default 6-hour limit, so a single wedged job (a hung test, a stuck runner, an unresponsive external service) burned six hours of runner time before dying as `cancelled`. Job *execution* time (`started_at`→`completed_at` per job, which is what `timeout-minutes` actually measures — not run-level `createdAt`/`updatedAt`, which is skewed by queueing and unrelated metadata updates and can be off by orders of magnitude) over the last ~60 completed runs per workflow:

| Workflow | median | p90 | slowest observed |
|---|---|---|---|
| Android (per matrix job) | <1 min | <1 min | ~1 min |
| CIFuzz | ~12 min | ~12 min | ~12 min |
| linux | ~4.5 min | ~5 min | ~5 min |
| macOS | ~1.5 min | ~2 min | ~2.4 min |
| MSYS2 build | ~5.5 min | ~6 min | ~6.5 min |
| MSYS2 clang64 build | ~3.5 min | ~4 min | ~8.5 min |
| MSYS2 aarch64 clang64 | ~7 min | ~7.5 min | ~8 min |
| Windows (per matrix job) | <1 min | ~1.5 min | ~3.5 min |

A uniform 60-minute cap is 5–100× the slowest observed job of any workflow — no realistic false-positive risk — while cutting worst-case waste up to 6×.

CIFuzz is worth calling out specifically since fuzzing time isn't inherently bounded by build size the way a normal compile is: the tight, low-variance distribution above (~12 min every time, over 59 sampled runs including 8 failures) isn't luck, it's structural — the workflow already passes `fuzz-seconds: 600` to `run_fuzzers`, hard-capping the actual fuzzing at 10 minutes regardless of what changed; the rest is fixed build overhead. `timeout-minutes: 60` is ~5× that ceiling, not a guess.

(The `macOS` figures above exclude the pre-fix `stress_mt` hangs from #1869 — those runs legitimately ran until the old 6-hour default killed them, which is exactly the failure mode this PR's timeout is meant to bound. With #1864/#1865 merged, that class of run no longer occurs; every macOS run in the current history completes in ~1–2.5 min.)

## 2. Preserve test logs when a test-running job fails or is cancelled

The autotools test driver buffers each test's stdout/stderr into `tests/<test>.log`; the console only shows a PASS/FAIL summary. `ci-build.sh` already dumps `test-suite.log` inline when `make check` fails, but that dump is lost when the job is cancelled (e.g. hits the new timeout) and doesn't include `config.log`. The five workflows that run the test suite (linux, macOS, and the three MSYS2 flavors) now upload `build*/config.log` + `build*/tests/*.log` with `actions/upload-artifact` (already used elsewhere in these workflows) under `if: failure() || cancelled()`, so whatever evidence exists survives in downloadable form.

On the "is there a third-party action for this" question: for log preservation the official `actions/upload-artifact` *is* the idiomatic tool, so nothing exotic is needed. (No popular off-the-shelf action covers the other thing this branch briefly did — sampling a hung process's stacks before killing it — but that machinery is no longer needed here.)

---

History: this branch originally carried a temporary `stress_mt` hang watchdog that was used to capture the stack trace which root-caused #1869 (since fixed by #1864/#1865, verified over 71 consecutive clean CI runs). That diagnostic served its purpose and has been replaced by this general, issue-agnostic cleanup; the old machinery remains documented in #1869/#1872 if it's ever needed again.

Assisted-by: claude-code:claude-fable-5

