### PR TITLE
DRAFT: verify #1864+#1865 fix the stress_mt CI hang (+ watchdog from #1870)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,6 +61,17 @@ jobs:
             cat stress_mt_sample.txt
             echo '::endgroup::'
           fi
+          # automake's parallel-tests driver only prints PASS/FAIL to this
+          # log; the test's own stdout/stderr goes to its .log file, which
+          # otherwise only surfaces via ci-build.sh's test-suite.log dump on
+          # overall failure. Show it unconditionally so a pass doesn't hide
+          # non-fatal warnings (e.g. transient device-access skips) that are
+          # still worth auditing.
+          if [ -f build/tests/stress_mt.log ]; then
+            echo '::group::stress_mt.log (full test output, pass or fail)'
+            cat build/tests/stress_mt.log
+            echo '::endgroup::'
+          fi
           exit "${status}"
 
       - name: Xcode

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,9 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     runs-on: macos-latest
+    # Fail fast instead of burning the default 6-hour limit when a test
+    # hangs (see the stress_mt hang, issue #1869).
+    timeout-minutes: 60
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -32,7 +35,33 @@ jobs:
 
       - name: compile
         shell: bash
-        run: .private/ci-build.sh --build-dir build
+        # stress_mt sometimes hangs forever on the macOS runners (issue
+        # #1869). Without a watchdog the job dies at the GitHub timeout
+        # and every trace of the hang is lost with it (automake buffers
+        # the test output). A normal run of this step takes well under
+        # 15 minutes, so after 40 minutes assume a hang: capture stack
+        # samples of the hung test, then kill it so the job fails
+        # quickly with the evidence attached (ci-build.sh already dumps
+        # test-suite.log when make check fails).
+        run: |
+          (
+            sleep 2400
+            pid=$(pgrep -nx stress_mt || true)
+            if [ -n "${pid}" ]; then
+              sample "${pid}" 5 -file stress_mt_sample.txt || true
+              kill -ABRT "${pid}" || true
+            fi
+          ) >/dev/null 2>&1 &
+          watchdog_pid=$!
+          status=0
+          .private/ci-build.sh --build-dir build || status=$?
+          kill "${watchdog_pid}" 2>/dev/null || true
+          if [ -f stress_mt_sample.txt ]; then
+            echo '::group::stress_mt watchdog: hung process stack samples'
+            cat stress_mt_sample.txt
+            echo '::endgroup::'
+          fi
+          exit "${status}"
 
       - name: Xcode
         shell: bash

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -65,6 +65,15 @@ static usbi_cond_t libusb_darwin_at_cond = USBI_COND_INITIALIZER;
 static CFRunLoopRef libusb_darwin_acfl = NULL; /* event cf loop */
 static CFRunLoopSourceRef libusb_darwin_acfls = NULL; /* shutdown signal for event cf loop */
 
+/* Lock ordering: the per-device lock (struct darwin_cached_device, dpriv->lock)
+   may be held when acquiring darwin_cached_devices_mutex (e.g. via
+   darwin_reload_device), so never acquire dpriv->lock while holding
+   darwin_cached_devices_mutex. The core acquires dev_handle->lock before
+   calling into the backend (libusb_claim_interface/libusb_release_interface),
+   so dev_handle->lock always sits above dpriv->lock. Consequently, code
+   holding dpriv->lock must not call public libusb_* functions that take
+   locks (e.g. libusb_release_interface). Lock-free ones such as
+   libusb_get_active_config_descriptor are tolerated but discouraged. */
 static usbi_mutex_t darwin_cached_devices_mutex = USBI_MUTEX_INITIALIZER;
 static struct list_head darwin_cached_devices GUARDED_BY(darwin_cached_devices_mutex);
 static int init_count GUARDED_BY(darwin_cached_devices_mutex);
@@ -92,6 +101,7 @@ static int darwin_reenumerate_device(struct libusb_device_handle *dev_handle, bo
 static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned char endpoint);
 static int darwin_reset_device(struct libusb_device_handle *dev_handle);
 static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface);
+static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock);
 static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0);
 
 static enum libusb_error darwin_scan_devices(struct libusb_context *ctx);
@@ -459,6 +469,7 @@ static void darwin_deref_cached_device(struct darwin_cached_device *cached_dev) 
       cached_dev->device = NULL;
     }
     IOObjectRelease (cached_dev->service);
+    usbi_mutex_destroy(&cached_dev->lock);
     free (cached_dev);
   }
 }
@@ -1432,6 +1443,8 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
       (*device)->GetLocationID (device, &new_device->location);
       new_device->port = port;
       new_device->parent_session = parent_sessionID;
+
+      usbi_mutex_init(&new_device->lock);
     } else {
       /* release the ref to old device's service */
       IOObjectRelease (new_device->service);
@@ -1593,7 +1606,8 @@ static enum libusb_error darwin_scan_devices(struct libusb_context *ctx) {
   return LIBUSB_SUCCESS;
 }
 
-static int darwin_open (struct libusb_device_handle *dev_handle) {
+/* must be called while holding dpriv->lock */
+static int darwin_open_locked (struct libusb_device_handle *dev_handle) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
@@ -1647,11 +1661,23 @@ static int darwin_open (struct libusb_device_handle *dev_handle) {
   return 0;
 }
 
-static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+static int darwin_open (struct libusb_device_handle *dev_handle) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_open_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
+}
+
+/* must be called while holding dpriv->lock. any claimed interfaces must have
+   been released by the caller beforehand. */
+static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
   struct darwin_device_handle_priv *priv = (struct darwin_device_handle_priv *)usbi_get_device_handle_priv(dev_handle);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
-  int i;
 
   if (dpriv->open_count == 0) {
     /* something is probably very wrong if this is the case */
@@ -1664,11 +1690,6 @@ static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_
     usbi_warn (HANDLE_CTX (dev_handle), "darwin_close device missing IOService");
     return;
   }
-
-  /* make sure all interfaces are released */
-  for (i = 0 ; i < USB_MAXINTERFACES ; i++)
-    if (dev_handle->claimed_interfaces & (1U << i))
-      libusb_release_interface (dev_handle, i);
 
   if (0 == dpriv->open_count) {
     /* delete the device's async event source */
@@ -1689,6 +1710,25 @@ static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_
       }
     }
   }
+}
+
+static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int i;
+
+  /* make sure all interfaces are released before taking the device lock.
+     releasing an interface may reattach the kernel driver
+     (auto_detach_kernel_driver) via darwin_capture_release_interface, which
+     acquires dpriv->lock itself. this is safe even if the device is gone:
+     the interface plug-ins are per-handle objects and every path below
+     checks dpriv->device before using it. */
+  for (i = 0 ; i < USB_MAXINTERFACES ; i++)
+    if (dev_handle->claimed_interfaces & (1U << i))
+      libusb_release_interface (dev_handle, i);
+
+  usbi_mutex_lock(&dpriv->lock);
+  darwin_close_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
 }
 
 static int darwin_get_configuration(struct libusb_device_handle *dev_handle, uint8_t *config) {
@@ -2085,6 +2125,9 @@ static int darwin_clear_halt(struct libusb_device_handle *dev_handle, unsigned c
   return darwin_to_libusb (kresult);
 }
 
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses, as on
+   the pre-split code. */
 static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_handle, uint8_t active_config,
                                                unsigned long claimed_interfaces) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
@@ -2102,10 +2145,10 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   dpriv->open_count = 1;
 
   /* clean up open interfaces */
-  darwin_close (dev_handle);
+  darwin_close_locked (dev_handle);
 
   /* re-open the device */
-  ret = darwin_open (dev_handle);
+  ret = darwin_open_locked (dev_handle);
   dpriv->open_count = open_count;
   if (LIBUSB_SUCCESS != ret) {
     /* could not restore configuration */
@@ -2147,6 +2190,12 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   return LIBUSB_SUCCESS;
 }
 
+/* must be called while holding dpriv->lock. the lock is held during the wait
+   for re-enumeration to complete, which serializes open/close/capture
+   operations on the device while it is being reset. the hotplug thread that
+   signals completion (via dpriv->in_reenumerate) does not take this lock.
+   the REQUIRES annotation carries the dev_handle->lock contract of the
+   claimed_interfaces accesses, as before this change. */
 static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, bool capture) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   unsigned long claimed_interfaces = dev_handle->claimed_interfaces;
@@ -2253,7 +2302,10 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
   return darwin_restore_state (dev_handle, active_config, claimed_interfaces);
 }
 
-static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_reset_device_locked (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
   int ret;
@@ -2279,7 +2331,7 @@ static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRE
     /* reset capture count */
     dpriv->capture_count = 0;
     /* attempt to detach kernel driver again as it is now re-attached */
-    ret = darwin_detach_kernel_driver (dev_handle, 0);
+    ret = darwin_detach_kernel_driver_locked (dev_handle, 0);
     if (ret != LIBUSB_SUCCESS) {
       return ret;
     }
@@ -2289,6 +2341,17 @@ static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRE
     ret = darwin_restore_state (dev_handle, active_config, claimed_interfaces);
   }
 #endif
+  return ret;
+}
+
+static int darwin_reset_device (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_reset_device_locked (dev_handle);
+  usbi_mutex_unlock(&dpriv->lock);
+
   return ret;
 }
 
@@ -2913,7 +2976,10 @@ static int darwin_reload_device (struct libusb_device_handle *dev_handle) EXCLUD
 
 /* On macOS, we capture an entire device at once, not individual interfaces. */
 
-static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
   UNUSED(interface);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
   IOReturn kresult;
@@ -2958,8 +3024,21 @@ static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle,
   return LIBUSB_SUCCESS;
 }
 
+static int darwin_detach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
 
-static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_detach_kernel_driver_locked (dev_handle, interface);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
+}
+
+/* must be called while holding dpriv->lock. the REQUIRES annotation carries
+   the dev_handle->lock contract of the claimed_interfaces accesses further
+   down the re-enumeration path, as on the pre-split function. */
+static int darwin_attach_kernel_driver_locked (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
   UNUSED(interface);
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
 
@@ -2976,6 +3055,17 @@ static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle,
 
   /* reset device to attach kernel drivers */
   return darwin_reenumerate_device (dev_handle, false);
+}
+
+static int darwin_attach_kernel_driver (struct libusb_device_handle *dev_handle, uint8_t interface) REQUIRES(dev_handle->lock) {
+  struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  int ret;
+
+  usbi_mutex_lock(&dpriv->lock);
+  ret = darwin_attach_kernel_driver_locked (dev_handle, interface);
+  usbi_mutex_unlock(&dpriv->lock);
+
+  return ret;
 }
 
 static int darwin_capture_claim_interface(struct libusb_device_handle *dev_handle, uint8_t iface) REQUIRES(dev_handle->lock) {
@@ -2999,13 +3089,15 @@ static int darwin_capture_release_interface(struct libusb_device_handle *dev_han
     return ret;
   }
 
+  usbi_mutex_lock(&dpriv->lock);
   if (dev_handle->auto_detach_kernel_driver && dpriv->capture_count > 0) {
-    ret = darwin_attach_kernel_driver (dev_handle, iface);
+    ret = darwin_attach_kernel_driver_locked (dev_handle, iface);
     if (LIBUSB_SUCCESS != ret) {
       usbi_info (HANDLE_CTX (dev_handle), "on attempt to reattach the kernel driver got ret=%d", ret);
     }
     /* ignore the error as the interface was successfully released */
   }
+  usbi_mutex_unlock(&dpriv->lock);
 
   return LIBUSB_SUCCESS;
 }

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -468,7 +468,14 @@ static void darwin_deref_cached_device(struct darwin_cached_device *cached_dev) 
       (*cached_dev->device)->Release(cached_dev->device);
       cached_dev->device = NULL;
     }
+    if (cached_dev->pending_device) {
+      (*cached_dev->pending_device)->Release(cached_dev->pending_device);
+      cached_dev->pending_device = NULL;
+    }
     IOObjectRelease (cached_dev->service);
+    if (cached_dev->pending_service != IO_OBJECT_NULL) {
+      IOObjectRelease (cached_dev->pending_service);
+    }
     usbi_mutex_destroy(&cached_dev->lock);
     free (cached_dev);
   }
@@ -476,6 +483,21 @@ static void darwin_deref_cached_device(struct darwin_cached_device *cached_dev) 
 
 static void darwin_ref_cached_device(struct darwin_cached_device *cached_dev) REQUIRES(darwin_cached_devices_mutex) {
   cached_dev->refcount++;
+}
+
+/* returns the live device interface for enumeration purposes: while the
+   device is re-enumerating, the replacement discovered by the hotplug thread
+   (pending_device) is the interface that works; the one in device is the old,
+   no longer functional one that the re-enumerating thread still owns. must
+   NOT be called with darwin_cached_devices_mutex held. */
+static usb_device_t darwin_active_device_interface (struct darwin_cached_device *cached_dev) {
+  usb_device_t device;
+
+  usbi_mutex_lock(&darwin_cached_devices_mutex);
+  device = cached_dev->pending_device ? cached_dev->pending_device : cached_dev->device;
+  usbi_mutex_unlock(&darwin_cached_devices_mutex);
+
+  return device;
 }
 
 static int ep_to_pipeRef(struct libusb_device_handle *dev_handle, uint8_t ep, uint8_t *pipep, uint8_t *ifcp, struct darwin_interface **interface_out) {
@@ -1101,7 +1123,7 @@ static int darwin_get_config_descriptor(struct libusb_device *dev, uint8_t confi
 
 /* check whether the os has configured the device */
 static enum libusb_error darwin_check_configuration (struct libusb_context *ctx, struct darwin_cached_device *dev) {
-  usb_device_t darwin_device = dev->device;
+  usb_device_t darwin_device = darwin_active_device_interface (dev);
 
   IOUSBConfigurationDescriptorPtr configDesc;
   IOUSBFindInterfaceRequest request;
@@ -1186,8 +1208,10 @@ static IOReturn darwin_request_descriptor (usb_device_t device, UInt8 desc, UInt
   return (*device)->DeviceRequestTO (device, &req);
 }
 
-static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev) {
-  usb_device_t device = dev->device;
+/* device is passed explicitly because this is called from
+   darwin_get_cached_device with darwin_cached_devices_mutex held, before the
+   pending replacement (if any) has been adopted into dev->device */
+static enum libusb_error darwin_cache_device_descriptor (struct libusb_context *ctx, struct darwin_cached_device *dev, usb_device_t device) {
   int retries = 1;
   long delay = 30000; /* microseconds */
   int unsuspended = 0, try_unsuspend = 1, try_reconfigure = 1;
@@ -1371,8 +1395,7 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
   UInt64 sessionID = 0, parent_sessionID = 0;
   UInt32 locationID = 0;
   enum libusb_error ret = LIBUSB_SUCCESS;
-  usb_device_t device, old_device = NULL;
-  io_service_t old_service = IO_OBJECT_NULL;
+  usb_device_t device;
   UInt8 port = 0;
 
   /* assuming sessionID != 0 normally (never seen it be 0) */
@@ -1400,8 +1423,6 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
       if (new_device->location == locationID && atomic_load(&new_device->in_reenumerate)) {
         usbi_dbg (ctx, "found cached device with matching location that is being re-enumerated");
         *old_session_id = new_device->session;
-        old_device = new_device->device;
-        old_service = new_device->service;
         break;
       }
 
@@ -1449,25 +1470,29 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
     *cached_out = new_device;
 
     new_device->session = sessionID;
-    new_device->device = device;
-    new_device->service = service;
+    if (*old_session_id) {
+      /* the device is being re-enumerated: the re-enumerating thread may
+         still be using device and service, so do not touch them here. stash
+         the replacements instead; darwin_reenumerate_device adopts them (and
+         releases the old ones) once the re-enumeration completes. */
+      if (new_device->pending_device) {
+        (*new_device->pending_device)->Release (new_device->pending_device);
+      }
+      if (new_device->pending_service != IO_OBJECT_NULL) {
+        IOObjectRelease (new_device->pending_service);
+      }
+      new_device->pending_device = device;
+      new_device->pending_service = service;
+    } else {
+      new_device->device = device;
+      new_device->service = service;
+    }
 
     /* retain the service */
     IOObjectRetain (service);
 
-    /* release the old device */
-    if (old_device) {
-      (*old_device)->Release (old_device);
-      old_device = NULL;
-    }
-
-    /* release the ref to old device's service */
-    if (old_service) {
-      IOObjectRelease (old_service);
-    }
-
     /* cache the device descriptor */
-    ret = darwin_cache_device_descriptor(ctx, new_device);
+    ret = darwin_cache_device_descriptor(ctx, new_device, device);
     if (ret)
       break;
 
@@ -1545,7 +1570,8 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
       dev->parent_dev = usbi_get_device_by_session_id (ctx, (unsigned long) cached_device->parent_session);
     }
 
-    (*priv->dev->device)->GetDeviceSpeed (priv->dev->device, &devSpeed);
+    usb_device_t darwin_device = darwin_active_device_interface (priv->dev);
+    (*darwin_device)->GetDeviceSpeed (darwin_device, &devSpeed);
 
     switch (devSpeed) {
     case kUSBDeviceSpeedLow: dev->speed = LIBUSB_SPEED_LOW; break;
@@ -2206,6 +2232,33 @@ static enum libusb_error darwin_restore_state (struct libusb_device_handle *dev_
   return LIBUSB_SUCCESS;
 }
 
+/* adopt the replacement device interface and service discovered by the
+   hotplug thread during re-enumeration (see darwin_get_cached_device), and
+   release the old ones. after this, device and service have only ever been
+   written by threads holding dpriv->lock. must be called while holding
+   dpriv->lock. */
+static void darwin_adopt_pending_device (struct darwin_cached_device *dpriv) {
+  usbi_mutex_lock(&darwin_cached_devices_mutex);
+
+  if (dpriv->pending_device) {
+    if (dpriv->device) {
+      (*dpriv->device)->Release (dpriv->device);
+    }
+    dpriv->device = dpriv->pending_device;
+    dpriv->pending_device = NULL;
+  }
+
+  if (dpriv->pending_service != IO_OBJECT_NULL) {
+    if (dpriv->service != IO_OBJECT_NULL) {
+      IOObjectRelease (dpriv->service);
+    }
+    dpriv->service = dpriv->pending_service;
+    dpriv->pending_service = IO_OBJECT_NULL;
+  }
+
+  usbi_mutex_unlock(&darwin_cached_devices_mutex);
+}
+
 /* must be called while holding dpriv->lock. the lock is held during the wait
    for re-enumeration to complete, which serializes open/close/capture
    operations on the device while it is being reset. the hotplug thread that
@@ -2225,6 +2278,10 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
 
   struct libusb_context *ctx = HANDLE_CTX (dev_handle);
 
+  /* adopt any replacement left over from a previous re-enumeration that
+     returned (e.g. on timeout) before the device came back */
+  darwin_adopt_pending_device (dpriv);
+
   if (!dpriv->device) {
     usbi_warn(ctx, "darwin_reenumerate_device: device interface is NULL");
     return LIBUSB_ERROR_NO_DEVICE;
@@ -2235,8 +2292,13 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
     return LIBUSB_ERROR_NOT_FOUND;
   }
 
-  /* store copies of descriptors so they can be compared after the reset */
+  /* store copies of descriptors so they can be compared after the reset.
+     the mutex orders this read against the hotplug thread refreshing
+     dev_descriptor (under the same mutex) while an earlier re-enumeration
+     completes. */
+  usbi_mutex_lock(&darwin_cached_devices_mutex);
   memcpy (&descriptor, &dpriv->dev_descriptor, sizeof (descriptor));
+  usbi_mutex_unlock(&darwin_cached_devices_mutex);
   cached_configurations = (IOUSBConfigurationDescriptor *)alloca (sizeof (*cached_configurations) * descriptor.bNumConfigurations);
 
   for (i = 0 ; i < descriptor.bNumConfigurations ; ++i) {
@@ -2295,6 +2357,10 @@ static int darwin_reenumerate_device (struct libusb_device_handle *dev_handle, b
       return LIBUSB_ERROR_TIMEOUT;
     }
   }
+
+  /* the hotplug thread has processed the re-attach: adopt the replacement
+     device interface and service it discovered */
+  darwin_adopt_pending_device (dpriv);
 
   /* compare descriptors */
   usbi_dbg (ctx, "darwin/reenumerate_device: checking whether descriptors changed");
@@ -3005,6 +3071,11 @@ static int darwin_detach_kernel_driver_locked (struct libusb_device_handle *dev_
   if (get_interface_interface_version() < 700) {
     return LIBUSB_ERROR_NOT_SUPPORTED;
   }
+
+  /* adopt any replacement left over from a re-enumeration that timed out:
+     IOServiceAuthorize and darwin_reload_device below must operate on the
+     live service */
+  darwin_adopt_pending_device (dpriv);
 
   if (dpriv->capture_count == 0) {
     usbi_dbg (ctx, "attempting to detach kernel driver from device");

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2897,11 +2897,15 @@ static bool darwin_has_capture_entitlements (void) {
 
 static int darwin_reload_device (struct libusb_device_handle *dev_handle) EXCLUDES(darwin_cached_devices_mutex) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  usb_device_t new_device;
   enum libusb_error err;
 
   usbi_mutex_lock(&darwin_cached_devices_mutex);
-  (*dpriv->device)->Release(dpriv->device);
-  err = darwin_device_from_service (HANDLE_CTX (dev_handle), dpriv->service, &dpriv->device);
+  err = darwin_device_from_service (HANDLE_CTX (dev_handle), dpriv->service, &new_device);
+  if (err == LIBUSB_SUCCESS) {
+    (*dpriv->device)->Release(dpriv->device);
+    dpriv->device = new_device;
+  }
   usbi_mutex_unlock(&darwin_cached_devices_mutex);
 
   return err;

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1712,18 +1712,29 @@ static void darwin_close_locked (struct libusb_device_handle *dev_handle) {
   }
 }
 
-static void darwin_close (struct libusb_device_handle *dev_handle) REQUIRES(dev_handle->lock) {
+static void darwin_close (struct libusb_device_handle *dev_handle) EXCLUDES(dev_handle->lock) {
   struct darwin_cached_device *dpriv = DARWIN_CACHED_DEVICE(dev_handle->dev);
+  unsigned long claimed_interfaces;
   int i;
 
-  /* make sure all interfaces are released before taking the device lock.
-     releasing an interface may reattach the kernel driver
-     (auto_detach_kernel_driver) via darwin_capture_release_interface, which
-     acquires dpriv->lock itself. this is safe even if the device is gone:
-     the interface plug-ins are per-handle objects and every path below
-     checks dpriv->device before using it. */
+  /* snapshot the claimed interfaces under dev_handle->lock, which guards
+     claimed_interfaces. the interfaces must be released before taking the
+     device lock and without holding dev_handle->lock:
+     libusb_release_interface takes dev_handle->lock itself, and releasing
+     an interface may reattach the kernel driver
+     (auto_detach_kernel_driver) via darwin_capture_release_interface,
+     which acquires dpriv->lock. a stale snapshot is harmless because
+     libusb_release_interface rechecks the bit under the lock, and using
+     the handle concurrently with libusb_close is undefined anyway.
+     releasing is safe even if the device is gone: the interface plug-ins
+     are per-handle objects and every path below checks dpriv->device
+     before using it. */
+  usbi_mutex_lock(&dev_handle->lock);
+  claimed_interfaces = dev_handle->claimed_interfaces;
+  usbi_mutex_unlock(&dev_handle->lock);
+
   for (i = 0 ; i < USB_MAXINTERFACES ; i++)
-    if (dev_handle->claimed_interfaces & (1U << i))
+    if (claimed_interfaces & (1U << i))
       libusb_release_interface (dev_handle, i);
 
   usbi_mutex_lock(&dpriv->lock);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -697,12 +697,6 @@ static void darwin_devices_detached (void *ptr, io_iterator_t rem_devices) EXCLU
           usbi_dbg (NULL, "detected device detached due to re-enumeration. sessionID: 0x%" PRIx64
                           ", locationID: 0x%" PRIx32, session, locationID);
 
-          /* the device object is no longer usable so go ahead and release it */
-          if (old_device->device) {
-            (*old_device->device)->Release(old_device->device);
-            old_device->device = NULL;
-          }
-
           is_reenumerating = true;
         } else {
           darwin_deref_cached_device (old_device);
@@ -1377,7 +1371,8 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
   UInt64 sessionID = 0, parent_sessionID = 0;
   UInt32 locationID = 0;
   enum libusb_error ret = LIBUSB_SUCCESS;
-  usb_device_t device;
+  usb_device_t device, old_device = NULL;
+  io_service_t old_service = IO_OBJECT_NULL;
   UInt8 port = 0;
 
   /* assuming sessionID != 0 normally (never seen it be 0) */
@@ -1405,6 +1400,8 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
       if (new_device->location == locationID && atomic_load(&new_device->in_reenumerate)) {
         usbi_dbg (ctx, "found cached device with matching location that is being re-enumerated");
         *old_session_id = new_device->session;
+        old_device = new_device->device;
+        old_service = new_device->service;
         break;
       }
 
@@ -1445,9 +1442,6 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
       new_device->parent_session = parent_sessionID;
 
       usbi_mutex_init(&new_device->lock);
-    } else {
-      /* release the ref to old device's service */
-      IOObjectRelease (new_device->service);
     }
 
     /* keep track of devices regardless of if we successfully enumerate them to
@@ -1460,6 +1454,17 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
 
     /* retain the service */
     IOObjectRetain (service);
+
+    /* release the old device */
+    if (old_device) {
+      (*old_device)->Release (old_device);
+      old_device = NULL;
+    }
+
+    /* release the ref to old device's service */
+    if (old_service) {
+      IOObjectRelease (old_service);
+    }
 
     /* cache the device descriptor */
     ret = darwin_cache_device_descriptor(ctx, new_device);

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -116,12 +116,13 @@ struct darwin_cached_device {
   char                  sys_path[21];
   usb_device_t          device;
   io_service_t          service;
-  int                   open_count;
+  usbi_mutex_t          lock;          /* protects open_count and capture_count */
+  int                   open_count;    /* GUARDED_BY(lock) */
+  int                   capture_count; /* GUARDED_BY(lock) */
   UInt8                 first_config, active_config, port;
   int                   can_enumerate;
   int                   refcount;
   atomic_bool           in_reenumerate;
-  int                   capture_count;
 };
 
 struct darwin_device_priv {

--- a/libusb/os/darwin_usb.h
+++ b/libusb/os/darwin_usb.h
@@ -116,6 +116,13 @@ struct darwin_cached_device {
   char                  sys_path[21];
   usb_device_t          device;
   io_service_t          service;
+  /* replacement interface and service discovered by the hotplug thread while
+     the device is re-enumerating. adopted (and the old ones released) by the
+     re-enumerating thread once the re-enumeration completes, so device and
+     service themselves are never written by the hotplug thread.
+     GUARDED_BY(darwin_cached_devices_mutex) */
+  usb_device_t          pending_device;
+  io_service_t          pending_service;
   usbi_mutex_t          lock;          /* protects open_count and capture_count */
   int                   open_count;    /* GUARDED_BY(lock) */
   int                   capture_count; /* GUARDED_BY(lock) */


### PR DESCRIPTION
Draft PR to verify whether the `stress_mt` macOS CI hang (#1869) is actually fixed by the open/capture-state race fixes, using the reproduction watchdog from #1870.

**Not meant to merge as-is** — this is a combination branch for testing, opened so CI runs on the combined tree. If the fixes are confirmed, the real merges should go through #1864 and #1865 individually.

## What's on this branch

Cherry-picked on top of current `master`:

1. `23f83226` / `f6e538df` / `74c78a5a` — the three commits from #1864 (`darwin: serialize open/capture state`): fixes the unsynchronized `open_count`/`capture_count` race (#1798 item 1) that the captured CI stack trace in #1869 points to, plus the `darwin_reload_device` UAF and a `claimed_interfaces` snapshot fix.
2. `c246d126` / `b6770f01` — the two commits unique to #1865 (`darwin: fix use after free during reenumeration`) not already covered by #1864. (#1865's own branch is stale against current `master` — its first two commits duplicate an older revision of #1864's — so these two were cherry-picked directly rather than merging #1865 wholesale.)
3. `2723c487` — the CI watchdog from #1870: caps the macOS job at 60min and fails fast with captured `sample` stack traces if `stress_mt` is still alive after 40min, instead of silently burning the 6h GitHub timeout.

All five fix commits cherry-picked cleanly (one auto-merge, no conflicts) onto current master, which already includes the recent Thread Safety Analysis annotations.

## Why

The stack trace captured via #1870 ([run 29169932932](https://github.com/libusb/libusb/actions/runs/29169932932/job/86615466593), see [#1869](https://github.com/libusb/libusb/issues/1869#issuecomment-4950063680)) shows all 8 `stress_mt` worker threads wedged waiting on a lost `libusb_control_transfer` completion after opening the same shared, refcounted `darwin_cached_device` — matching @mcuee's TSan-confirmed `open_count`/`capture_count` race. This branch tests whether #1864 (+ #1865) actually closes that race on real CI infrastructure, using the same watchdog to either confirm a clean run streak or capture a fresh stack trace if it still hangs.

Assisted-by: claude-code:claude-fable-5
