### PR TITLE
core: honor documented atomic ordering in MSVC usbi_atomic_load/store

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -103,8 +103,8 @@
  */
 #ifdef _MSC_VER
 typedef volatile LONG usbi_atomic_t;
-#define usbi_atomic_load(a)	(*(a))
-#define usbi_atomic_store(a, v)	(*(a)) = (v)
+#define usbi_atomic_load(a)	InterlockedCompareExchange((a), 0, 0)
+#define usbi_atomic_store(a, v)	((void)InterlockedExchange((a), (v)))
 #define usbi_atomic_inc(a)	InterlockedIncrement((a))
 #define usbi_atomic_dec(a)	InterlockedDecrement((a))
 #else


### PR DESCRIPTION
On MSVC, usbi_atomic_load()/usbi_atomic_store() are plain volatile accesses. The documented contract in libusbi.h says all usbi_atomic operations are ordered with each other, and the GCC-builtin and C11 implementations deliver seq-cst, but volatile only provides ordering on x86/x64 as a side effect of /volatile:ms. 

On MSVC ARM64 (default /volatile:iso) these accesses carry no hardware ordering at all, so the contract is not met.

Implement the load and store with Interlocked operations so the contract holds on every architecture MSVC targets. usbi_atomic_inc()/usbi_atomic_dec() were already Interlocked. 

The load becomes a locked RMW, which is heavier than a plain read, but no current call site is hot enough to matter.

Verified with MSVC Release x64 and Release ARM64 builds.

Related: #1871