### PR TITLE
ci: drop obsolete AppVeyor toolsets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 version: 1.0.{build}
 image:
-  - Visual Studio 2013
-  - Visual Studio 2015
   - Visual Studio 2017
   - Visual Studio 2019
   - Visual Studio 2022
@@ -20,30 +18,11 @@ for:
   -
     matrix:
       only:
-        - image: Visual Studio 2013
-    environment:
-      toolset: v120
-    build:
-      project: msvc\libusb.sln
-
-  -
-    matrix:
-      only:
-        - image: Visual Studio 2015
-          configuration: Debug
-    environment:
-      toolset: v140
-    build:
-      project: msvc\libusb.sln
-
-  -
-    matrix:
-      only:
-        - image: Visual Studio 2015
+        - image: Visual Studio 2017
           platform: Win32
           configuration: Release
     environment:
-      toolset: v140
+      toolset: v141
     install:
       - cmd: xcopy /S /I "%APPVEYOR_BUILD_FOLDER%" C:\msys64\home\appveyor\libusb
       - cmd: xcopy /S /I "%APPVEYOR_BUILD_FOLDER%" C:\cygwin\home\appveyor\libusb
@@ -57,11 +36,11 @@ for:
   -
     matrix:
       only:
-        - image: Visual Studio 2015
+        - image: Visual Studio 2017
           platform: x64
           configuration: Release
     environment:
-      toolset: v140
+      toolset: v141
     install:
       - cmd: xcopy /S /I "%APPVEYOR_BUILD_FOLDER%" C:\msys64\home\appveyor\libusb
       - cmd: xcopy /S /I "%APPVEYOR_BUILD_FOLDER%" C:\cygwin64\home\appveyor\libusb
@@ -76,6 +55,7 @@ for:
     matrix:
       only:
         - image: Visual Studio 2017
+          configuration: Debug
     environment:
       toolset: v141
     build:


### PR DESCRIPTION
Update the AppVeyor matrix after support for VS2013/v120 and VS2015/v140 was removed.

The matrix still scheduled those obsolete toolsets, so all eight VS2013/VS2015 jobs failed. In the same run, every VS2017/v141, VS2019/v142, and VS2022/v143 job passed.

This change:
- removes the VS2013 and VS2015 images and their v120/v140 mappings;
- moves the existing MinGW/Cygwin release coverage to the VS2017/v141 release jobs; and
- limits the generic VS2017 rule to Debug, so each of the 12 remaining matrix jobs has exactly one configuration.

Validation:
- Inspected AppVeyor build 1.0.2637: only obsolete-toolset jobs failed.
- Parsed `appveyor.yml` with PyYAML.
- Verified every remaining matrix job matches exactly one `for` rule.
- Ran `git diff --check`.

Related to [b25a51479ce03da078fb4f5bb0576561bfe2538e](https://github.com/libusb/libusb/commit/b25a51479ce03da078fb4f5bb0576561bfe2538e).

Assisted-by: Codex:GPT-5