### PR TITLE
Updates to account for C23 changes

### DIFF
--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -71,7 +71,9 @@ typedef SSIZE_T ssize_t;
 #endif
 #endif /* _WIN32 || __CYGWIN__ */
 
-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
+#define LIBUSB_DEPRECATED_FOR(f) [[deprecated("Use " #f " instead")]]
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
 #define LIBUSB_DEPRECATED_FOR(f) __attribute__ ((deprecated ("Use " #f " instead")))
 #elif defined(__GNUC__) && (__GNUC__ >= 3)
 #define LIBUSB_DEPRECATED_FOR(f) __attribute__ ((deprecated))

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -42,8 +42,10 @@
 
 /* Not all C standard library headers define static_assert in assert.h
  * Additionally, Visual Studio treats static_assert as a keyword.
+ * Additionally, starting with C23, static_assert must always be present.
  */
-#if !defined(__cplusplus) && !defined(static_assert) && !defined(_MSC_VER)
+#if !(defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)) && \
+    !defined(__cplusplus) && !defined(static_assert) && !defined(_MSC_VER)
 #define static_assert(cond, msg) _Static_assert(cond, msg)
 #endif
 


### PR DESCRIPTION
- use standard [[deprecated]] to indicate deprecation
- never #define static_assert if C23