### PR TITLE
ci: reduce redundant Windows CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,26 +4,74 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: >-
+      ${{ matrix.compiler.runner }} |
+      ${{ matrix.compiler.host }} |
+      MSVC ${{ matrix.compiler.toolset }} (${{ matrix.compiler.toolset_visual_studio }} toolset) |
+      ${{ matrix.architecture }} |
+      ${{ matrix.configuration_family.label }}
     strategy:
+      fail-fast: false
+      # Leave runner capacity for the Linux, macOS, and MSYS2 workflows.
+      max-parallel: 12
       matrix:
-        os:
-          - 'windows-2022'
-          - 'windows-2025'
-        configuration:
-          - 'Debug'
-          - 'Release'
-          - 'Debug-MT'
-          - 'Release-MT'
-          - 'Debug-Hotplug'
-          - 'Release-Hotplug'
-          - 'Debug-Hotplug-MT'
-          - 'Release-Hotplug-MT'
+        compiler:
+          - runner: windows-2022
+            host: Visual Studio 2022/MSBuild 17 host
+            toolset: v143
+            toolset_visual_studio: Visual Studio 2022
+            artifact_prefix: build-windows-2022
+          - runner: windows-2025-vs2026
+            host: Visual Studio 2026/MSBuild 18 host
+            toolset: v145
+            toolset_visual_studio: Visual Studio 2026
+            # Retain the established artifact names despite using the explicit
+            # VS 2026 runner label.
+            artifact_prefix: build-windows-2025
+        configuration_family:
+          - label: Debug + Release
+            first: Debug
+            second: Release
+          - label: Debug-MT + Release-MT
+            first: Debug-MT
+            second: Release-MT
+          - label: Debug-Hotplug + Release-Hotplug
+            first: Debug-Hotplug
+            second: Release-Hotplug
+          - label: Debug-Hotplug-MT + Release-Hotplug-MT
+            first: Debug-Hotplug-MT
+            second: Release-Hotplug-MT
         architecture:
-          - 'Win32'
-          - 'x64'
-          - 'ARM64'
+          - Win32
+          - x64
+          - ARM64
+        include:
+          # VS 2022 hosts the VS 2019-era v142 toolset. Pairing Debug and
+          # Release keeps the four v142 builds in two clearly named jobs.
+          - compiler:
+              runner: windows-2022
+              host: Visual Studio 2022/MSBuild 17 host
+              toolset: v142
+              toolset_visual_studio: Visual Studio 2019
+              artifact_prefix: build-windows-2022-v142
+            configuration_family:
+              label: Debug + Release
+              first: Debug
+              second: Release
+            architecture: Win32
+          - compiler:
+              runner: windows-2022
+              host: Visual Studio 2022/MSBuild 17 host
+              toolset: v142
+              toolset_visual_studio: Visual Studio 2019
+              artifact_prefix: build-windows-2022-v142
+            configuration_family:
+              label: Debug + Release
+              first: Debug
+              second: Release
+            architecture: x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.compiler.runner }}
     timeout-minutes: 60
 
     steps:
@@ -38,61 +86,64 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v3
 
-      - name: Build solution
-        run: |
-          msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }}
+      - name: Build ${{ matrix.configuration_family.first }}
+        id: first_build
+        continue-on-error: true
+        run: >-
+          msbuild msvc/libusb.sln /m
+          -property:Configuration=${{ matrix.configuration_family.first }}
+          -property:Platform=${{ matrix.architecture }}
+          -property:PlatformToolset=${{ matrix.compiler.toolset }}
 
-      - name: Upload artifacts
+      - name: Build ${{ matrix.configuration_family.second }}
+        id: second_build
+        if: ${{ !cancelled() && steps.first_build.outcome != 'skipped' }}
+        continue-on-error: true
+        run: >-
+          msbuild msvc/libusb.sln /m
+          -property:Configuration=${{ matrix.configuration_family.second }}
+          -property:Platform=${{ matrix.architecture }}
+          -property:PlatformToolset=${{ matrix.compiler.toolset }}
+
+      - name: Upload ${{ matrix.configuration_family.first }} artifacts
+        if: ${{ !cancelled() && steps.first_build.outcome == 'success' }}
         uses: actions/upload-artifact@v7
         with:
-          name: build-${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.architecture }}
+          name: ${{ matrix.compiler.artifact_prefix }}-${{ matrix.configuration_family.first }}-${{ matrix.architecture }}
+          if-no-files-found: error
           path: |
-            build/**/*.exe
-            build/**/dll/libusb-1.0.dll
-            build/**/dll/libusb-1.0.lib
-            build/**/dll/libusb-1.0.exp
-            build/**/dll/libusb-1.0.pdb
-            build/**/lib/libusb-1.0.lib
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/**/*.exe
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/dll/libusb-1.0.dll
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/dll/libusb-1.0.lib
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/dll/libusb-1.0.exp
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/dll/libusb-1.0.pdb
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/lib/libusb-1.0.lib
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.first }}/lib/libusb-1.0.pdb
 
-  build-v142:
-    name: MSVC v142 (${{ matrix.configuration }}, ${{ matrix.architecture }})
-    strategy:
-      matrix:
-        configuration:
-          - 'Debug'
-          - 'Release'
-        architecture:
-          - 'Win32'
-          - 'x64'
-
-    runs-on: windows-2022
-    timeout-minutes: 60
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          # Full history + tags so the MSVC PreBuildEvent's call to
-          # build-aux/gen-describe.ps1 can produce a tag-prefixed
-          # `git describe` string.
-          fetch-depth: 0
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v3
-
-      - name: Build solution
-        run: |
-          msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }} -property:PlatformToolset=v142
-
-      - name: Upload artifacts
+      - name: Upload ${{ matrix.configuration_family.second }} artifacts
+        if: ${{ !cancelled() && steps.second_build.outcome == 'success' }}
         uses: actions/upload-artifact@v7
         with:
-          name: build-windows-2022-v142-${{ matrix.configuration }}-${{ matrix.architecture }}
+          name: ${{ matrix.compiler.artifact_prefix }}-${{ matrix.configuration_family.second }}-${{ matrix.architecture }}
+          if-no-files-found: error
           path: |
-            build/**/*.exe
-            build/**/dll/libusb-1.0.dll
-            build/**/dll/libusb-1.0.lib
-            build/**/dll/libusb-1.0.exp
-            build/**/dll/libusb-1.0.pdb
-            build/**/lib/libusb-1.0.lib
-            build/**/lib/libusb-1.0.pdb
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/**/*.exe
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/dll/libusb-1.0.dll
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/dll/libusb-1.0.lib
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/dll/libusb-1.0.exp
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/dll/libusb-1.0.pdb
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/lib/libusb-1.0.lib
+            build/${{ matrix.compiler.toolset }}/${{ matrix.architecture }}/${{ matrix.configuration_family.second }}/lib/libusb-1.0.pdb
+
+      - name: Check build results
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          FIRST_CONFIGURATION: ${{ matrix.configuration_family.first }}
+          FIRST_OUTCOME: ${{ steps.first_build.outcome }}
+          SECOND_CONFIGURATION: ${{ matrix.configuration_family.second }}
+          SECOND_OUTCOME: ${{ steps.second_build.outcome }}
+        run: |
+          if ($env:FIRST_OUTCOME -ne 'success' -or $env:SECOND_OUTCOME -ne 'success') {
+            throw "Build results: $env:FIRST_CONFIGURATION=$env:FIRST_OUTCOME, $env:SECOND_CONFIGURATION=$env:SECOND_OUTCOME"
+          }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       # Leave runner capacity for the Linux, macOS, and MSYS2 workflows.
-      max-parallel: 16
+      max-parallel: 18
       matrix:
         compiler:
           - runner: windows-2022

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,3 +53,46 @@ jobs:
             build/**/dll/libusb-1.0.exp
             build/**/dll/libusb-1.0.pdb
             build/**/lib/libusb-1.0.lib
+
+  build-v142:
+    name: MSVC v142 (${{ matrix.configuration }}, ${{ matrix.architecture }})
+    strategy:
+      matrix:
+        configuration:
+          - 'Debug'
+          - 'Release'
+        architecture:
+          - 'Win32'
+          - 'x64'
+
+    runs-on: windows-2022
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # Full history + tags so the MSVC PreBuildEvent's call to
+          # build-aux/gen-describe.ps1 can produce a tag-prefixed
+          # `git describe` string.
+          fetch-depth: 0
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v3
+
+      - name: Build solution
+        run: |
+          msbuild msvc/libusb.sln /m -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.architecture }} -property:PlatformToolset=v142
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-windows-2022-v142-${{ matrix.configuration }}-${{ matrix.architecture }}
+          path: |
+            build/**/*.exe
+            build/**/dll/libusb-1.0.dll
+            build/**/dll/libusb-1.0.lib
+            build/**/dll/libusb-1.0.exp
+            build/**/dll/libusb-1.0.pdb
+            build/**/lib/libusb-1.0.lib
+            build/**/lib/libusb-1.0.pdb

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       # Leave runner capacity for the Linux, macOS, and MSYS2 workflows.
-      max-parallel: 12
+      max-parallel: 16
       matrix:
         compiler:
           - runner: windows-2022

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,13 +1,11 @@
-name: Windows build and Package
+name: Windows
 
 on: [push, pull_request]
 
 jobs:
   build:
     name: >-
-      ${{ matrix.compiler.runner }} |
-      ${{ matrix.compiler.host }} |
-      MSVC ${{ matrix.compiler.toolset }} (${{ matrix.compiler.toolset_visual_studio }} toolset) |
+      ${{ matrix.compiler.job_label }} |
       ${{ matrix.architecture }} |
       ${{ matrix.configuration_family.label }}
     strategy:
@@ -17,14 +15,12 @@ jobs:
       matrix:
         compiler:
           - runner: windows-2022
-            host: Visual Studio 2022/MSBuild 17 host
+            job_label: W-2022 | VS 2022 | v143
             toolset: v143
-            toolset_visual_studio: Visual Studio 2022
             artifact_prefix: build-windows-2022
           - runner: windows-2025-vs2026
-            host: Visual Studio 2026/MSBuild 18 host
+            job_label: W-2025 | VS 2026 | v145
             toolset: v145
-            toolset_visual_studio: Visual Studio 2026
             # Retain the established artifact names despite using the explicit
             # VS 2026 runner label.
             artifact_prefix: build-windows-2025
@@ -50,9 +46,8 @@ jobs:
           # Release keeps the four v142 builds in two clearly named jobs.
           - compiler:
               runner: windows-2022
-              host: Visual Studio 2022/MSBuild 17 host
+              job_label: W-2022 | VS 2022 | v142 (VS 2019)
               toolset: v142
-              toolset_visual_studio: Visual Studio 2019
               artifact_prefix: build-windows-2022-v142
             configuration_family:
               label: Debug + Release
@@ -61,9 +56,8 @@ jobs:
             architecture: Win32
           - compiler:
               runner: windows-2022
-              host: Visual Studio 2022/MSBuild 17 host
+              job_label: W-2022 | VS 2022 | v142 (VS 2019)
               toolset: v142
-              toolset_visual_studio: Visual Studio 2019
               artifact_prefix: build-windows-2022-v142
             configuration_family:
               label: Debug + Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ matrix:
 environment:
   toolset: UNK
 clone_depth: 1
+skip_branch_with_pr: true
 build:
   parallel: true
 for:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.0.{build}
 image:
   - Visual Studio 2017
-  - Visual Studio 2019
   - Visual Studio 2022
 platform:
   - Win32
@@ -9,6 +8,16 @@ platform:
 configuration:
   - Debug
   - Release
+matrix:
+  exclude:
+    # GitHub Actions already checks these v143 configurations. Keep only the
+    # AppVeyor Release jobs whose artifacts are used to assemble releases.
+    - image: Visual Studio 2022
+      platform: Win32
+      configuration: Debug
+    - image: Visual Studio 2022
+      platform: x64
+      configuration: Debug
 environment:
   toolset: UNK
 clone_depth: 1
@@ -64,16 +73,8 @@ for:
   -
     matrix:
       only:
-        - image: Visual Studio 2019
-    environment:
-      toolset: v142
-    build:
-      project: msvc\libusb.sln
-
-  -
-    matrix:
-      only:
         - image: Visual Studio 2022
+          configuration: Release
     environment:
       toolset: v143
     build:


### PR DESCRIPTION
## Summary

- reduce AppVeyor from 12 jobs to 6 and skip its duplicate branch build when an open pull request exists;
- keep all four Visual Studio 2017/v141 jobs because they retain unique compiler coverage and the Release jobs also run the legacy MinGW and Cygwin builds;
- keep the Visual Studio 2022/v143 Release Win32 and x64 jobs, including their established `.7z` artifacts, because the release process consumes those trusted AppVeyor outputs;
- remove the redundant AppVeyor v143 Debug and v142 jobs;
- unify the GitHub Windows coverage in one matrix whose compact check names identify runner, Visual Studio host, MSVC toolset, architecture, and configuration family;
- pair each related Debug/Release configuration in one job, reducing the Windows matrix from 52 jobs to 26 while preserving all 52 compiler builds and all 52 existing artifact names; and
- cap that matrix at 12 parallel jobs so the other platform workflows retain runner capacity.

## Coverage

| CI host | MSVC toolset | Architectures | Configurations | Jobs |
| --- | --- | --- | --- | ---: |
| AppVeyor Visual Studio 2017 | v141 | Win32, x64 | Debug, Release | 4 |
| AppVeyor Visual Studio 2022 | v143 | Win32, x64 | Release | 2 |
| GitHub `windows-2022`, Visual Studio 2022/MSBuild 17 host | v142 (Visual Studio 2019 toolset) | Win32, x64 | Debug, Release | 2 paired |
| GitHub `windows-2022`, Visual Studio 2022/MSBuild 17 host | v143 (Visual Studio 2022 toolset) | Win32, x64, ARM64 | all 8 existing configurations | 12 paired |
| GitHub `windows-2025-vs2026`, Visual Studio 2026/MSBuild 18 host | v145 (Visual Studio 2026 toolset) | Win32, x64, ARM64 | all 8 existing configurations | 12 paired |

For example, the v142 check is now rendered as:

`Windows / W-2022 | VS 2022 | v142 (VS 2019) | Win32 | Debug + Release`

Each paired job has separate build steps and uploads separate per-configuration artifacts. Both builds are attempted, and the job fails if either build fails.

The AppVeyor Release artifact names used downstream remain unchanged:

- `libusb-build_Visual Studio 2022_Win32_Release.7z`
- `libusb-build_Visual Studio 2022_x64_Release.7z`

## Validation

- built MSVC v142 Debug and Release locally for Win32 and x64 with Visual Studio 2022/MSBuild 17;
- ran actionlint 1.7.12 across all GitHub Actions workflows;
- verified by scripted matrix expansion that GitHub Windows jobs decrease from 52 to 26 while the same 52 compiler/configuration/architecture combinations and the same 52 artifact names remain;
- verified representative full check names are 74, 84, and 96 characters, down from roughly 150 characters;
- verified the AppVeyor matrix has exactly six jobs, every job matches exactly one toolset rule, and both retained v141 Release jobs still run MSBuild, MinGW, and Cygwin; and
- ran `git diff --check`.

Related to #1876.
Related to #1765.
Related to #1786.

Assisted-by: Codex:GPT-5
