### PR TITLE
ci: avoid duplicate feature-branch workflow runs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,16 @@
 name: Android
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,11 @@
 name: CIFuzz
-on: [pull_request]
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,16 @@
 name: linux
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,8 +1,18 @@
 name: macOS
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
-on: [push, pull_request]
+# Run branch pushes only on master; pull requests continue to run against all
+# branches.
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # A workflow run is made up of one or more jobs that can run
 # sequentially or in parallel

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,5 +1,15 @@
 name: MSYS2 build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -1,5 +1,15 @@
 name: MSYS2 aarch64 clang64
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -1,5 +1,15 @@
 name: MSYS2 clang64 build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,16 @@
 name: Windows build and Package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- run push-triggered workflows only for `master` and tags;
- retain pull-request builds for feature branches; and
- cancel superseded runs within the same workflow/PR, while preserving direct branch and tag runs.

## Why

Feature-branch pushes already receive equivalent validation through `pull_request`; limiting pushes avoids duplicate runner use. The concurrency group keeps one current pull-request run per workflow without cancelling `master` or tag builds.

## Validation

- ran actionlint 1.7.12 across all workflows;
- verified each modified workflow has the intended `push` / `pull_request` triggers and concurrency policy; and
- ran `git diff --check`.

Related to #1879.

Assisted-by: Codex:GPT-5