### PR TITLE
ci: add GCC 16 C23 build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,36 @@ name: linux
 on: [push, pull_request]
 
 jobs:
+  c23:
+    name: GCC 15 / C23
+    runs-on: ubuntu-latest
+    container: gcc:15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags for build-aux/gen-describe.sh.
+          fetch-depth: 0
+
+      - name: setup prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends autoconf automake libtool pkg-config
+
+      - name: bootstrap
+        run: ./bootstrap.sh
+
+      - name: build libusb with C23
+        env:
+          CC: gcc
+          CFLAGS: -std=c23
+        run: |
+          gcc --version
+          mkdir build-c23
+          cd build-c23 || exit 1
+          ../configure --disable-udev
+          make -j"$(nproc)"
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -55,7 +85,7 @@ jobs:
       - name: emscripten
         run: emconfigure .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten
 
-      - name: Ubuntu rolling / GCC C23 / umockdev
+      - name: umockdev test
         run: .private/ci-container-build.sh docker.io/amd64/ubuntu:rolling
 
       # --- Sanitizers + BOS fuzzer smoke, inside linux job (PRs only) ---

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,7 +55,7 @@ jobs:
       - name: emscripten
         run: emconfigure .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten
 
-      - name: umockdev test
+      - name: Ubuntu rolling / GCC C23 / umockdev
         run: .private/ci-container-build.sh docker.io/amd64/ubuntu:rolling
 
       # --- Sanitizers + BOS fuzzer smoke, inside linux job (PRs only) ---

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 jobs:
   c23:
-    name: GCC 15 / C23
+    name: GCC 16 / C23
     runs-on: ubuntu-latest
-    container: gcc:15
+    container: gcc:16
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.private/ci-container-build.sh
+++ b/.private/ci-container-build.sh
@@ -38,7 +38,7 @@ eatmydata apt-get install -y make libtool libudev-dev pkg-config umockdev libumo
 
 # run build as user
 useradd build
-su -s /bin/bash - build << EOG
+su -s /bin/bash - build << 'EOG'
 set -ex
 
 mkdir "/tmp/builddir"
@@ -53,13 +53,33 @@ CFLAGS+=" -Wnested-externs"
 CFLAGS+=" -Wpointer-arith"
 CFLAGS+=" -Wredundant-decls"
 CFLAGS+=" -Wswitch-enum"
-export CFLAGS
 
 export CXXFLAGS="\${CFLAGS}"
+CFLAGS+=" -std=c23"
+export CFLAGS
 
 echo ""
 echo "Configuring ..."
 /source/configure --enable-examples-build --enable-tests-build
+
+echo ""
+echo "Checking C23 headers ..."
+printf '%s\n' \
+	'#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L' \
+	'#error compiler does not report final C23 mode' \
+	'#endif' \
+	'#include <assert.h>' \
+	'#ifdef static_assert' \
+	'#define SYSTEM_STATIC_ASSERT_IS_MACRO 1' \
+	'#endif' \
+	'#include "libusbi.h"' \
+	'#if !defined(SYSTEM_STATIC_ASSERT_IS_MACRO) && defined(static_assert)' \
+	'#error libusbi.h must not define static_assert in C23' \
+	'#endif' | \
+	gcc -std=c23 -I. -I/source/libusb -E -x c -o /dev/null -
+
+gcc -std=c23 -I/source/libusb -dM -E -include libusb.h -x c /dev/null | \
+	grep -F '#define LIBUSB_DEPRECATED_FOR(f) [[deprecated("Use " #f " instead")]]'
 
 echo ""
 echo "Building ..."

--- a/.private/ci-container-build.sh
+++ b/.private/ci-container-build.sh
@@ -38,7 +38,7 @@ eatmydata apt-get install -y make libtool libudev-dev pkg-config umockdev libumo
 
 # run build as user
 useradd build
-su -s /bin/bash - build << 'EOG'
+su -s /bin/bash - build << EOG
 set -ex
 
 mkdir "/tmp/builddir"
@@ -53,33 +53,13 @@ CFLAGS+=" -Wnested-externs"
 CFLAGS+=" -Wpointer-arith"
 CFLAGS+=" -Wredundant-decls"
 CFLAGS+=" -Wswitch-enum"
+export CFLAGS
 
 export CXXFLAGS="\${CFLAGS}"
-CFLAGS+=" -std=c23"
-export CFLAGS
 
 echo ""
 echo "Configuring ..."
 /source/configure --enable-examples-build --enable-tests-build
-
-echo ""
-echo "Checking C23 headers ..."
-printf '%s\n' \
-	'#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L' \
-	'#error compiler does not report final C23 mode' \
-	'#endif' \
-	'#include <assert.h>' \
-	'#ifdef static_assert' \
-	'#define SYSTEM_STATIC_ASSERT_IS_MACRO 1' \
-	'#endif' \
-	'#include "libusbi.h"' \
-	'#if !defined(SYSTEM_STATIC_ASSERT_IS_MACRO) && defined(static_assert)' \
-	'#error libusbi.h must not define static_assert in C23' \
-	'#endif' | \
-	gcc -std=c23 -I. -I/source/libusb -E -x c -o /dev/null -
-
-gcc -std=c23 -I/source/libusb -dM -E -include libusb.h -x c /dev/null | \
-	grep -F '#define LIBUSB_DEPRECATED_FOR(f) [[deprecated("Use " #f " instead")]]'
 
 echo ""
 echo "Building ..."


### PR DESCRIPTION
## Summary

- add a separate `GCC 16 / C23` job to the Linux workflow;
- run the job on `ubuntu-latest` with the official GCC 16 container;
- configure and build libusb with `CFLAGS=-std=c23` and udev disabled; and
- leave the existing Linux, Ubuntu rolling, and umockdev builds unchanged.

## Why

PR #1878 added final-C23 handling for `static_assert` and deprecation attributes, while the normal Linux builds continue to compile in C11 mode. The new isolated job makes C23 compilation an explicit CI check without changing the behavior or responsibilities of any existing build.

## Validation

- verified by parsed workflow comparison that the existing Linux `build` job is unchanged;
- verified `.private/ci-container-build.sh` is unchanged in the final PR diff;
- parsed the workflow and ran actionlint 1.7.12;
- ran ShellCheck 0.10.0 over the new shell commands; and
- ran `git diff --check`.

Related to #1878.

Assisted-by: Codex:GPT-5
