### PR TITLE
fix: support C++ build of Linux usbfs backend

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2571,9 +2571,11 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		struct usbfs_iso_packet_desc *urb_desc = &urb->iso_frame_desc[i];
 		struct libusb_iso_packet_descriptor *lib_desc =
 			&transfer->iso_packet_desc[tpriv->iso_packet_offset++];
+		/* usbfs writes negative errno values to this unsigned UAPI field. */
+		int packet_status = (int)urb_desc->status;
 
 		lib_desc->status = LIBUSB_TRANSFER_COMPLETED;
-		switch (urb_desc->status) {
+		switch (packet_status) {
 		case 0:
 			break;
 		case -ENOENT: /* cancelled */
@@ -2598,12 +2600,12 @@ static int handle_iso_completion(struct usbi_transfer *itransfer,
 		case -ECOMM:
 		case -ENOSR:
 		case -EXDEV:
-			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - low-level USB error %d", i, urb_desc->status);
+			usbi_dbg(TRANSFER_CTX(transfer), "packet %d - low-level USB error %d", i, packet_status);
 			lib_desc->status = LIBUSB_TRANSFER_ERROR;
 			break;
 		default:
 			usbi_warn(TRANSFER_CTX(transfer), "packet %d - unrecognised urb status %d",
-				  i, urb_desc->status);
+				  i, packet_status);
 			lib_desc->status = LIBUSB_TRANSFER_ERROR;
 			break;
 		}


### PR DESCRIPTION
## Summary

- cast Linux usbfs isochronous packet-status values to signed errno values before classifying them; and
- use that signed status in diagnostics.

## Why

The usbfs UAPI declares the per-packet status field as unsigned even though the kernel writes negative errno values into it. Casting the ABI value to `int` before the switch gives the comparisons and diagnostics their intended signed type; without it, a C++ compiler rejects the negative `case` labels as narrowing conversions.

## Validation

- inspected the failed Ubuntu `build-cxx` job introduced by #1845;
- rebuilt and linked the Linux backend as C++20 with g++ using #1845's configure/build settings, explicitly compiling `linux_usbfs.c`; and
- ran `git diff --check`.

Related to #1845.

Assisted-by: Codex:GPT-5
