### PR TITLE
darwin: propagate QueryInterface failure in darwin_device_from_service

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -660,10 +660,21 @@ static enum libusb_error darwin_device_from_service (struct libusb_context *ctx,
     return LIBUSB_ERROR_OTHER;
   }
 
-  (void)(*plugInInterface)->QueryInterface(plugInInterface, CFUUIDGetUUIDBytes(get_device_interface_id()),
-                                           (LPVOID *)device);
+  /* do not trust QueryInterface to set the out parameter on failure */
+  *device = NULL;
+
+  kresult = (*plugInInterface)->QueryInterface(plugInInterface, CFUUIDGetUUIDBytes(get_device_interface_id()),
+                                               (LPVOID *)device);
   /* Use release instead of IODestroyPlugInInterface to avoid stopping IOServices associated with this device */
   (*plugInInterface)->Release (plugInInterface);
+  if (kresult != kIOReturnSuccess) {
+    usbi_dbg (ctx, "QueryInterface: %s", darwin_error_str(kresult));
+    return darwin_to_libusb (kresult);
+  }
+  if (!(*device)) {
+    usbi_dbg (ctx, "QueryInterface: returned null device interface");
+    return LIBUSB_ERROR_OTHER;
+  }
 
   return LIBUSB_SUCCESS;
 }


### PR DESCRIPTION
The QueryInterface result was explicitly discarded, so on failure the function returned LIBUSB_SUCCESS with a NULL device interface. In the fresh-device path of darwin_get_cached_device the very next use is GetDeviceAddress on that NULL interface: a crash on the hotplug thread. Check the result and the returned pointer and propagate an error, matching the existing pattern in darwin_claim_interface.

Item 11 of the #1798 addendum.

Reference: #1798