### PR TITLE
Darwin hotplug attach robustness

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -691,16 +691,20 @@ static void darwin_devices_attached (void *ptr, io_iterator_t add_devices) EXCLU
 
   while ((service = IOIteratorNext(add_devices))) {
     ret = darwin_get_cached_device (NULL, service, &cached_device, &old_session_id);
-    if (ret < 0 || !cached_device->can_enumerate) {
-      continue;
+
+    if (ret >= 0 && cached_device->can_enumerate) {
+      /* add this device to each active context's device list */
+      for_each_context(ctx) {
+        process_new_device (ctx, cached_device, old_session_id);
+      }
     }
 
-    /* add this device to each active context's device list */
-    for_each_context(ctx) {
-      process_new_device (ctx, cached_device, old_session_id);
-    }
-
-    if (atomic_exchange(&cached_device->in_reenumerate, false)) {
+    /* clear the re-enumeration flag even if the device could not be
+       enumerated: the device did come back, and the thread waiting in
+       darwin_reenumerate_device must not sit out the full timeout. if
+       enumeration failed before a cached device was matched the flag
+       cannot be cleared here and the waiter will still time out. */
+    if (cached_device && atomic_exchange(&cached_device->in_reenumerate, false)) {
       usbi_dbg (NULL, "cached device in reset state. reset complete...");
     }
 
@@ -1663,11 +1667,9 @@ static enum libusb_error darwin_scan_devices(struct libusb_context *ctx) {
   while ((service = IOIteratorNext (deviceIterator))) {
     ret = darwin_get_cached_device (ctx, service, &cached_device, &old_session_id);
     assert((ret >= 0) ? (cached_device != NULL) : true);
-    if (ret < 0 || !cached_device->can_enumerate) {
-      continue;
+    if (ret >= 0 && cached_device->can_enumerate) {
+      (void) process_new_device (ctx, cached_device, old_session_id);
     }
-
-    (void) process_new_device (ctx, cached_device, old_session_id);
 
     IOObjectRelease(service);
   }

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1559,6 +1559,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
   struct libusb_device *dev = NULL;
   UInt8 devSpeed;
   enum libusb_error ret = LIBUSB_SUCCESS;
+  bool reused = false;
 
   do {
     /* check current active configuration (and cache the first configuration value--
@@ -1596,6 +1597,7 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
       assert(cached_device->address <= UINT8_MAX);
       dev->device_address = (uint8_t)cached_device->address;
     } else {
+      reused = true;
       priv = (struct darwin_device_priv *)usbi_get_device_priv(dev);
     }
 
@@ -1643,7 +1645,11 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
 
   } while (0);
 
-  if (!atomic_load(&cached_device->in_reenumerate) && 0 == ret) {
+  /* a device found by its old session id is already in this context's device
+     list; connecting it again would corrupt the list (list_add of an
+     already-listed node). New devices (including a re-enumerated device
+     this context has never seen) are connected.*/
+  if (!reused && 0 == ret) {
     usbi_connect_device (dev);
   } else {
     libusb_unref_device (dev);


### PR DESCRIPTION
# darwin: harden the hotplug attach path

Items 9 and 10 of the #1798 addendum, as two commits:

**Commit 1 : always release the service and clear `in_reenumerate` in the attach loops.** 
When `darwin_get_cached_device` failed or the device was not enumerable, the loops in `darwin_devices_attached` and `darwin_scan_devices` skipped the rest of the body with `continue`, leaking the `io_service_t` from `IOIteratorNext` on every failed attempt, and, in the attach handler, skipping the `in_reenumerate` exchange, so a thread waiting in `darwin_reenumerate_device` sat out the full 10 s timeout whenever the re-attached device's descriptor read failed. 

Both now run on all paths: a waiter woken this way exits promptly via the descriptor comparison with the live pending interface already stashed.

**Commit 2 :  decide device connection from lookup state, not `in_reenumerate`.**
`process_new_device` re-sampled `in_reenumerate` at its tail to decide between `usbi_connect_device` and unref. That races the re-enumeration timeout path: if the waiter timed out and cleared the flag between the device match and the tail check,
a device found by its old session id (never disconnected, since the detach event was consumed by the re-enumeration branch) was connected a second time: `list_add` of an already-listed node. The decision now derives from how the device was obtained
(found-by-old-session -> already connected -> update only). This also connects a re-enumerated device in a context that never saw it, matching a fresh attach, instead of silently dropping it.

Reference: #1798 (addendum items 9 and 10)