### PR TITLE
Removed unneed uintptr_t cast, which -fbounds-safety does not like

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -60,7 +60,7 @@
 #endif
 
 #define container_of(ptr, type, member) \
-	((type *)((uintptr_t)(ptr) - (uintptr_t)offsetof(type, member)))
+	((type *)((char*)(ptr) - offsetof(type, member)))
 
 #ifndef ARRAYSIZE
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))


### PR DESCRIPTION
Use cast to char* instead. char* aliases everything.