### PR TITLE
darwin: #ifdef kUSBVendorString, kUSBProductString, and kUSBSerialNumberString

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1053,13 +1053,19 @@ static int darwin_get_device_string(struct libusb_device *dev,
 
   switch (string_type) {
     case LIBUSB_DEVICE_STRING_MANUFACTURER:
-      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
+      #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
+      #endif
       break;
     case LIBUSB_DEVICE_STRING_PRODUCT:
-      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
+      #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
+      #endif
       break;
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
-      cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
+      #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
+      #endif
       break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1055,18 +1055,18 @@ static int darwin_get_device_string(struct libusb_device *dev,
     case LIBUSB_DEVICE_STRING_MANUFACTURER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
+        break;
       #endif
-      break;
     case LIBUSB_DEVICE_STRING_PRODUCT:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
+        break;
       #endif
-      break;
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
+        break;
       #endif
-      break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:
       IOObjectRelease(service);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1055,18 +1055,24 @@ static int darwin_get_device_string(struct libusb_device *dev,
     case LIBUSB_DEVICE_STRING_MANUFACTURER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBVendorString), kCFAllocatorDefault, 0);
-        break;
+      #else
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR("USB Vendor Name"), kCFAllocatorDefault, 0);
       #endif
+      break;
     case LIBUSB_DEVICE_STRING_PRODUCT:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBProductString), kCFAllocatorDefault, 0);
-        break;
+      #else
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR("USB Product Name"), kCFAllocatorDefault, 0);
       #endif
+      break;
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
-        break;
+      #else
+        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR("USB Serial Number"), kCFAllocatorDefault, 0);
       #endif
+      break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:
       IOObjectRelease(service);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1070,7 +1070,7 @@ static int darwin_get_device_string(struct libusb_device *dev,
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
       #else
-        cf = "";
+        cf = NULL;
       #endif
       break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1069,8 +1069,10 @@ static int darwin_get_device_string(struct libusb_device *dev,
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
-        break;
+      #else
+        cf = "";
       #endif
+      break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:
       IOObjectRelease(service);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1069,10 +1069,8 @@ static int darwin_get_device_string(struct libusb_device *dev,
     case LIBUSB_DEVICE_STRING_SERIAL_NUMBER:
       #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
         cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kUSBSerialNumberString), kCFAllocatorDefault, 0);
-      #else
-        cf = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR("USB Serial Number"), kCFAllocatorDefault, 0);
+        break;
       #endif
-      break;
     case LIBUSB_DEVICE_STRING_COUNT: /* intentional fall-through, avoid -Wswitch-enum */
     default:
       IOObjectRelease(service);


### PR DESCRIPTION
All three of these were added for Mac OS 10.6, and must be #ifdef around to avoid breaking the build on earlier OS versions. Closes #1888 .
This is my first time contributing to the code base, so please let me know if any changes are requested.