### PR TITLE
darwin: order transfer submission against the async completion callback

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -618,6 +618,22 @@ struct usbi_transfer {
 	struct libusb_device *dev;
 
 	void *priv;
+
+	/* Publication fence for backends whose completion callback is invoked
+	 * directly by the OS on another thread (e.g. the darwin CFRunLoop event
+	 * thread). The kernel guarantees the callback only runs after the async
+	 * submission call that registered it, but that ordering is invisible to
+	 * the C11 memory model and to ThreadSanitizer. The backend stores 1 here
+	 * (usbi_atomic_store) after the last submit-side write to any transfer
+	 * state the callback reads and immediately before the async
+	 * registration; the callback loads it (usbi_atomic_load) before
+	 * touching any transfer state. Allocation-time state (priv above, the
+	 * lock) is covered transitively: handing the transfer from the
+	 * allocating thread to the submitting thread already requires
+	 * synchronization under the documented threading rules, so those writes
+	 * happen-before the store. Zeroed by the transfer allocation; the
+	 * loaded value is unused, only the ordering matters. */
+	usbi_atomic_t submit_fence;
 };
 
 enum usbi_transfer_state_flags {

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -2779,8 +2779,15 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
 
   usbi_mutex_unlock(&transfer->dev_handle->lock);
 
-  /* submit the request */
   /* timeouts are unavailable on interrupt endpoints */
+  if (pipe_properties.transfer_type != kUSBInterrupt)
+    itransfer->timeout_flags |= USBI_TRANSFER_OS_HANDLES_TIMEOUT;
+
+  /* publish the submit-side transfer state to darwin_async_io_callback
+     (see submit_fence in struct usbi_transfer) */
+  usbi_atomic_store(&itransfer->submit_fence, 1);
+
+  /* submit the request */
   if (pipe_properties.transfer_type == kUSBInterrupt) {
     if (IS_XFERIN(transfer))
       ret = (*IOINTERFACE(cInterface))->ReadPipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
@@ -2789,8 +2796,6 @@ static int submit_bulk_transfer(struct usbi_transfer *itransfer) REQUIRES(itrans
       ret = (*IOINTERFACE(cInterface))->WritePipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
                                                                (UInt32)transfer->length, darwin_async_io_callback, itransfer);
   } else {
-    itransfer->timeout_flags |= USBI_TRANSFER_OS_HANDLES_TIMEOUT;
-
     if (IS_XFERIN(transfer))
       ret = (*IOINTERFACE(cInterface))->ReadPipeAsyncTO(IOINTERFACE(cInterface), pipeRef, transfer->buffer,
                                                                 (UInt32)transfer->length, transfer->timeout, transfer->timeout,
@@ -2844,6 +2849,10 @@ static int submit_stream_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
   }
 
   itransfer->timeout_flags |= USBI_TRANSFER_OS_HANDLES_TIMEOUT;
+
+  /* publish the submit-side transfer state to darwin_async_io_callback
+     (see submit_fence in struct usbi_transfer) */
+  usbi_atomic_store(&itransfer->submit_fence, 1);
 
   if (IS_XFERIN(transfer))
     ret = (*IOINTERFACE_V(cInterface, 550))->ReadStreamsPipeAsyncTO(IOINTERFACE(cInterface), pipeRef, itransfer->stream_id,
@@ -2927,6 +2936,10 @@ static int submit_iso_transfer(struct usbi_transfer *itransfer) REQUIRES(itransf
   if (cInterface->frames[transfer->endpoint] && frame < cInterface->frames[transfer->endpoint])
     frame = cInterface->frames[transfer->endpoint];
 
+  /* publish the submit-side transfer state to darwin_async_io_callback
+     (see submit_fence in struct usbi_transfer) */
+  usbi_atomic_store(&itransfer->submit_fence, 1);
+
   /* submit the request */
   if (IS_XFERIN(transfer))
     kresult = (*IOINTERFACE(cInterface))->ReadIsochPipeAsync(IOINTERFACE(cInterface), pipeRef, transfer->buffer, frame,
@@ -2977,6 +2990,10 @@ static int submit_control_transfer(struct usbi_transfer *itransfer) REQUIRES(itr
   tpriv->req.noDataTimeout     = transfer->timeout;
 
   itransfer->timeout_flags |= USBI_TRANSFER_OS_HANDLES_TIMEOUT;
+
+  /* publish the submit-side transfer state to darwin_async_io_callback
+     (see submit_fence in struct usbi_transfer) */
+  usbi_atomic_store(&itransfer->submit_fence, 1);
 
   /* all transfers in libusb-1.0 are async */
 
@@ -3107,6 +3124,13 @@ static int darwin_cancel_transfer(struct usbi_transfer *itransfer) REQUIRES(itra
 
 static void darwin_async_io_callback (void *refcon, IOReturn result, void *arg0) {
   struct usbi_transfer *itransfer = (struct usbi_transfer *)refcon;
+
+  /* acquire the submitting thread's writes to the transfer before reading
+     any of its state, including itransfer->priv below. pairs with the
+     usbi_atomic_store in the submit paths; see submit_fence in
+     struct usbi_transfer. */
+  (void)usbi_atomic_load(&itransfer->submit_fence);
+
   struct libusb_transfer *transfer = USBI_TRANSFER_TO_LIBUSB_TRANSFER(itransfer);
   struct darwin_transfer_priv *tpriv = (struct darwin_transfer_priv *)usbi_get_transfer_priv(itransfer);
 


### PR DESCRIPTION
Add a submit_fence field to struct usbi_transfer and use it as a release/acquire fence between transfer submission and the OS-invoked completion callback. Each of the four darwin submit paths (submit_bulk/stream/iso/control_transfer) stores to it with usbi_atomic_store, after its last submit-side write to any transfer state the callback reads and immediately before the async IOKit registration; darwin_async_io_callback loads it with usbi_atomic_load as its first access, before touching any transfer state. The stored value is unused, only the synchronizes-with edge matters.

Put the fence in struct usbi_transfer rather than in the darwin private data: the callback reaches the private data through itransfer->priv, so that read is itself one of the accesses to order.

Hoist the bulk path's timeout_flags update above the store as well, so it falls inside the release set, the events thread reads it lock-free in darwin_transfer_status, matching the control and stream paths.

This expresses an ordering the kernel already provides (the completion callback runs only after the async call that registers it) but which, passing through the kernel, is invisible to the C11 memory model and to ThreadSanitizer; without the fence stress_mt reports formal data races on itransfer->priv and the submit-side transfer fields. The field is zeroed by the calloc in libusb_alloc_transfer.

Reference: #1869
Reference: #1798