### PR TITLE
Allow leading whitespace in read_sysfs_attr

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -106,6 +106,7 @@ static int read_sysfs_attr(struct libusb_context *ctx,
 	const char *sysfs_dir, const char *attr, int max_value, int *value_p);
 static int linux_scan_devices(struct libusb_context *ctx);
 static int detach_kernel_driver_and_claim(struct libusb_device_handle *, uint8_t);
+static int sysfs_get_active_config(struct libusb_device *dev, int *config);
 
 #if !defined(HAVE_LIBUDEV)
 static int linux_default_scan_devices(struct libusb_context *ctx);
@@ -576,8 +577,7 @@ static int op_get_config_string(struct libusb_device *dev,
 	 * anything else cannot be read without opening the device. */
 	if (config_value != 0) {
 		int active = 0;
-		r = read_sysfs_attr(ctx, priv->sysfs_dir, "bConfigurationValue",
-			UINT8_MAX, &active);
+		r = sysfs_get_active_config(dev, &active);
 		if (r < 0)
 			return r;
 		if (active != (int)config_value) {
@@ -620,7 +620,7 @@ static int op_get_interface_string(struct libusb_device *dev,
 		return LIBUSB_ERROR_NOT_FOUND;
 
 	/* sysfs exposes interfaces only for the active configuration */
-	r = read_sysfs_attr(ctx, priv->sysfs_dir, "bConfigurationValue", UINT8_MAX, &active);
+	r = sysfs_get_active_config(dev, &active);
 	if (r < 0)
 		return r;
 	if (active <= 0)

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -741,10 +741,7 @@ static int read_sysfs_attr(struct libusb_context *ctx,
 
 	/* The kernel does *not* NUL-terminate the string, but every attribute
 	 * should be terminated with a newline character. */
-	if (!isdigit(buf[0])) {
-		usbi_err(ctx, "attribute %s doesn't have numeric value?", attr);
-		return LIBUSB_ERROR_IO;
-	} else if (buf[r - 1] != '\n') {
+	if (buf[r - 1] != '\n') {
 		usbi_warn(ctx, "attribute %s doesn't end with newline?", attr);
 	} else {
 		/* Remove the terminating newline character */
@@ -754,7 +751,14 @@ static int read_sysfs_attr(struct libusb_context *ctx,
 
 	errno = 0;
 	value = strtol(buf, &endptr, 10);
-	if (buf == endptr || value < 0 || value > (long)max_value || errno) {
+	if (buf == endptr) {
+		/* strtol() returns buf == endptr when a error occurs and
+		 * value == 0 for a non-numeric value, first check if the
+		 * error was because of a non-numeric value,
+		 * before general errors */
+		usbi_err(ctx, "attribute %s doesn't have numeric value?", attr);
+		return LIBUSB_ERROR_IO;
+	} else if (value < 0 || value > (long)max_value || errno) {
 		usbi_err(ctx, "attribute %s contains an invalid value: '%s'", attr, buf);
 		return LIBUSB_ERROR_INVALID_PARAM;
 	} else if (*endptr != '\0') {


### PR DESCRIPTION
This PR is to fix a missed bug in #1860 which is caused by a leading white space in `/sys/bus/usb/devices/*/bAlternateSetting`. Change read_sysfs_attr to allow leading white space, while still detecting non numeric values.

The other patch is a minor simplification of the code-flow in the same PR by calling `sysfs_get_active_config` insead of calling `read_sysfs_attr` directly.


The `strtol` docs are a bit hard to understand so here is an example of `ret == 0` when the value is non numeric.
```c
#include <stdio.h>
#include <stdlib.h>

int main() {
	char str1[] = " ";
	char str2[] = " 42";
	char str3[] = "a";
	char str4[] = "a1";
	char str5[] = " a1";
	char str6[] = "42";
	char *endptr;
	long ret;

	ret = strtol(str1, &endptr, 10);
	printf("strtol result for str1: %ld, endptr == str1: %d\n", ret, endptr == str1);

	ret = strtol(str2, &endptr, 10);
	printf("strtol result for str2: %ld, endptr == str2: %d\n", ret, endptr == str2);

	ret = strtol(str3, &endptr, 10);
	printf("strtol result for str3: %ld, endptr == str3: %d\n", ret, endptr == str3);

	ret = strtol(str4, &endptr, 10);
	printf("strtol result for str4: %ld, endptr == str4: %d\n", ret, endptr == str4);

	ret = strtol(str5, &endptr, 10);
	printf("strtol result for str5: %ld, endptr == str5: %d\n", ret, endptr == str5);

	ret = strtol(str6, &endptr, 10);
	printf("strtol result for str6: %ld, endptr == str6: %d\n", ret, endptr == str6);

	return 0;
}
```