### PR TITLE
darwin: remove code related to obsolete Obj-C garbage collection

### DIFF
--- a/Xcode/libusb.xcodeproj/project.pbxproj
+++ b/Xcode/libusb.xcodeproj/project.pbxproj
@@ -49,7 +49,6 @@
 		008FBFA51628B84200BC5BE2 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 008FBFA41628B84200BC5BE2 /* config.h */; };
 		008FBFA71628B87000BC5BE2 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 008FBFA61628B87000BC5BE2 /* CoreFoundation.framework */; };
 		008FBFA91628B88000BC5BE2 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 008FBFA81628B88000BC5BE2 /* IOKit.framework */; };
-		008FBFAB1628B8CB00BC5BE2 /* libobjc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 008FBFAA1628B8CB00BC5BE2 /* libobjc.dylib */; };
 		008FBFEF1628BA3500BC5BE2 /* xusb.c in Sources */ = {isa = PBXBuildFile; fileRef = 008FBFED1628BA0E00BC5BE2 /* xusb.c */; };
 		008FBFFF1628BB9600BC5BE2 /* dpfp.c in Sources */ = {isa = PBXBuildFile; fileRef = 008FBFD71628BA0E00BC5BE2 /* dpfp.c */; };
 		008FC01F1628BC1500BC5BE2 /* fxload.c in Sources */ = {isa = PBXBuildFile; fileRef = 008FBFE11628BA0E00BC5BE2 /* fxload.c */; };
@@ -345,7 +344,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				008FBFAB1628B8CB00BC5BE2 /* libobjc.dylib in Frameworks */,
 				008FBFA91628B88000BC5BE2 /* IOKit.framework in Frameworks */,
 				CEA45DFB2634CDFA002FA97D /* Security.framework in Frameworks */,
 				008FBFA71628B87000BC5BE2 /* CoreFoundation.framework in Frameworks */,

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -36,18 +36,11 @@
 
 #include <mach/mach_time.h>
 
-/* Suppress warnings about the use of the deprecated objc_registerThreadWithCollector
- * function. Its use is also conditionalized to only older deployment targets. */
-#define OBJC_SILENCE_GC_DEPRECATIONS 1
-
 /* Default timeout to 10s for reenumerate. This is needed because USBDeviceReEnumerate
  * does not return error status on macOS. */
 #define DARWIN_REENUMERATE_TIMEOUT_US (10ULL * USEC_PER_SEC)
 
 #include <AvailabilityMacros.h>
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && MAC_OS_X_VERSION_MIN_REQUIRED < 101200
-  #include <objc/objc-auto.h>
-#endif
 
 #include "darwin_usb.h"
 
@@ -827,16 +820,6 @@ static void *darwin_event_thread_main (void *arg0) EXCLUDES(libusb_darwin_at_mut
   /* Set this thread's name, so it can be seen in the debugger
      and crash reports. */
   pthread_setname_np ("org.libusb.device-hotplug");
-#endif
-
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && MAC_OS_X_VERSION_MIN_REQUIRED < 101200
-  /* Tell the Objective-C garbage collector about this thread.
-     This is required because, unlike NSThreads, pthreads are
-     not automatically registered. Although we don't use
-     Objective-C, we use CoreFoundation, which does.
-     Garbage collection support was entirely removed in 10.12,
-     so don't bother there. */
-  objc_registerThreadWithCollector();
 #endif
 
   /* hotplug (device arrival/removal) sources */


### PR DESCRIPTION
Obj-C was deprecated years ago, and totally removed in Mac OS X 10.12.

This eliminates to need to link with libobjc.dylib and redcues complexity.