### PR TITLE
docs: eliminate Doxygen warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,7 @@ jobs:
         run: .private/ci-build.sh --werror --build-dir build-netlink --no-test -- --disable-udev
 
       - name: udev
-        run: .private/ci-build.sh --werror --build-dir build-udev -- --enable-udev
+        run: .private/ci-build.sh --werror --build-dir build-udev --build-docs -- --enable-udev
 
       - name: Release build
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           brew update
-          brew install autoconf automake libtool m4
+          brew install autoconf automake libtool m4 doxygen
 
       - name: bootstrap
         shell: bash
@@ -43,7 +43,7 @@ jobs:
 
       - name: compile
         shell: bash
-        run: .private/ci-build.sh --build-dir build
+        run: .private/ci-build.sh --build-dir build --build-docs
 
       - name: Xcode
         shell: bash

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -7,6 +7,7 @@ scriptdir=$(dirname $(readlink -f "$0"))
 install=no
 test=yes
 asan=yes
+docs=no
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -32,6 +33,10 @@ while [ $# -gt 0 ]; do
 		;;
 	--werror)
 		cflags+=" -Werror"
+		shift
+		;;
+	--build-docs)
+		docs=yes
 		shift
 		;;
 	--)
@@ -79,6 +84,10 @@ CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure --enable-examples-build --e
 echo ""
 echo "Building ..."
 make -j4 -k
+
+if [ "${docs}" = "yes" ]; then
+	make -C doc
+fi
 
 if [ "${test}" = "yes" ]; then
 	# Load custom shim for WebUSB tests that simulates Web environment.

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -99,7 +99,7 @@ OUTPUT_LANGUAGE        = English
 # Possible values are: None, LTR, RTL and Context.
 # The default value is: None.
 
-OUTPUT_TEXT_DIRECTION  = None
+#OUTPUT_TEXT_DIRECTION  = None
 
 # If the BRIEF_MEMBER_DESC tag is set to YES, doxygen will include brief member
 # descriptions after the members that are listed in the file and class
@@ -826,7 +826,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -1244,7 +1244,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+#HTML_TIMESTAMP         = YES
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
@@ -1549,7 +1549,7 @@ FORMULA_FONTSIZE       = 10
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-FORMULA_TRANSPARENT    = YES
+#FORMULA_TRANSPARENT    = YES
 
 # The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
 # to create new LaTeX commands to be used in formulas as building blocks. See
@@ -1862,7 +1862,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+#LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1878,7 +1878,7 @@ LATEX_BIB_STYLE        = plain
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_TIMESTAMP        = NO
+#LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,
@@ -1952,7 +1952,7 @@ RTF_EXTENSIONS_FILE    =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_SOURCE_CODE        = NO
+#RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -2057,7 +2057,7 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
+#DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2166,10 +2166,19 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
+# Hide Clang thread-safety annotations that Doxygen otherwise misinterprets as
+# trailing return types.
 PREDEFINED             = API_EXPORTED= \
                          DEFAULT_VISIBILITY= \
                          LIBUSB_CALL= \
-                         LIBUSB_PACKED=
+                         LIBUSB_PACKED= \
+                         "ACQUIRE(x)=" \
+                         "EXCLUDES(x)=" \
+                         "GUARDED_BY(x)=" \
+                         NO_THREAD_SAFETY_ANALYSIS= \
+                         "RELEASE(x)=" \
+                         "REQUIRES(x)=" \
+                         "TRY_ACQUIRE(x,y)="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2247,7 +2256,7 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = YES
+#CLASS_DIAGRAMS         = YES
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
@@ -2289,14 +2298,14 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
+#DOT_FONTNAME           = Helvetica
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.
 # Minimum value: 4, maximum value: 24, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTSIZE           = 10
+#DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2542,7 +2551,7 @@ MAX_DOT_GRAPH_DEPTH    = 0
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_TRANSPARENT        = NO
+#DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This
@@ -2551,7 +2560,7 @@ DOT_TRANSPARENT        = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_MULTI_TARGETS      = NO
+#DOT_MULTI_TARGETS      = NO
 
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated


### PR DESCRIPTION
## Summary

- disable obsolete Doxygen configuration assignments without introducing newer options that older supported releases reject
- hide Clang thread-safety annotations from Doxygen so they are not parsed as C++ trailing return types
- fail documentation generation on warnings and exercise it in both Linux and macOS CI

## Why

Doxygen 1.9.8 through 1.17.0 warns about obsolete configuration keys, while newer parsers can misinterpret libusb's function-suffix thread-safety annotations. Keeping obsolete assignments commented preserves compatibility with Doxygen 1.9.8 without the large generated-configuration update in the reference PR. Running documentation generation in CI prevents future source-documentation warnings from being merged unnoticed.

## Verification

- official Doxygen 1.9.8: HTML and man-page generation with warnings treated as errors
- official Doxygen 1.15.0: HTML and man-page generation with warnings treated as errors
- official Doxygen 1.17.0: HTML and man-page generation with warnings treated as errors
- `.private/ci-build.sh --build-dir build-ci-docs --build-docs --no-test --no-asan -- --disable-udev`
- `bash -n .private/ci-build.sh`
- `git diff --check`

Closes: #1895

Related to #1549

Assisted-by: Codex:GPT-5