### PR TITLE
core: keep event fd declaration C++ compatible

### DIFF
--- a/libusb/os/events_posix.c
+++ b/libusb/os/events_posix.c
@@ -259,6 +259,7 @@ int usbi_wait_for_events(struct libusb_context *ctx,
 {
 	struct pollfd *fds = (struct pollfd *)ctx->event_data;
 	usbi_nfds_t nfds = (usbi_nfds_t)ctx->event_data_cnt;
+	unsigned int internal_fds;
 
 	usbi_dbg(ctx, "poll() %u fds with timeout in %dms", (unsigned int)nfds, timeout_ms);
 #ifdef __EMSCRIPTEN__
@@ -309,7 +310,7 @@ int usbi_wait_for_events(struct libusb_context *ctx,
 	 * library's internal file descriptors, so we determine how many are
 	 * in use internally for this context and skip these when passing any
 	 * remaining pollfds to the backend. */
-	unsigned int internal_fds = usbi_using_timer(ctx) ? 2 : 1;
+	internal_fds = usbi_using_timer(ctx) ? 2 : 1;
 	fds += internal_fds;
 	nfds -= internal_fds;
 


### PR DESCRIPTION
## Summary

Move the `internal_fds` declaration ahead of the existing `goto done` paths while preserving its unsigned type and original assignment point.

## Root cause

PR #1730 changed `internal_fds` from a function-scope declaration to an initialized local declaration. The existing jumps to `done` then crossed that initialization, which is invalid in C++. The cross-platform C++ build coverage added by PR #1845 exposed the regression after the latest merge from `master`.

This is a declaration-placement fix only; it does not change runtime behavior.

## Verification

- The exact Linux C++20 build command from #1845 passes with g++ 11 under WSL.
- `git diff --check` passes.

Related to #1730
Related to #1845

Assisted-by: codex:GPT-5.6-Sol
