### PR TITLE
docs: clarify AI attribution trailers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ Assisted-by: AGENT_NAME:MODEL_VERSION
 For example: `Assisted-by: claude-code:claude-opus-4-7` or
 `Assisted-by: github-copilot:MODEL_VERSION`.
 
+Always use the most specific model variant available, not a shorter model-family name.
+When combining or preserving trailers, including during squash merges, deduplicate
+attributions for the same agent and keep only its most specific model variant. For
+example, if `Assisted-by: Codex:GPT-5.6 Sol` applies, do not also add the less-specific
+`Assisted-by: Codex:GPT-5` trailer. Multiple `Assisted-by` trailers are appropriate for
+different agents, but not merely for different specificity levels of the same agent.
+
 This applies to all commits, including those created via automation or agent workflows.
 
 ## Commit generation


### PR DESCRIPTION
## Summary

- require the most specific available model variant in `Assisted-by` trailers
- deduplicate same-agent attributions when combining histories or squash-merging
- document that `Codex:GPT-5.6 Sol` supersedes the less-specific `Codex:GPT-5` trailer

## Why

Preserving both a specific model variant and its broader family name produces redundant attribution. The repository guidance should make squash-merge behavior deterministic while continuing to preserve trailers for genuinely different assisting agents.

## Impact

This changes contributor and agent guidance only; no library or build behavior is affected.

## Verification

- `git diff --check`

Related to #1871

Assisted-by: Codex:GPT-5.6 Sol