### PR TITLE
docs: protect public API compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,23 @@ with their own certificate.
 - Branch names should be explicit and brief about what is being done or asked — e.g. `add-commit-attribution`, `fix-win-hang`, etc.
 - Prefer kebab-case.
 
+## Public API and ABI Compatibility
+
+`libusb/libusb.h` is the installed public API header and must be treated as a
+compatibility contract for existing source and binary users.
+
+- Do not change the type, calling convention, parameters, return value, or
+  linkage of an existing public function to fix an internal implementation
+  issue, compiler warning, or refactor. Even an ABI-equivalent type change can
+  break source users, including code with explicitly typed function pointers.
+- Do not remove or incompatibly change public declarations, constants, enum
+  values, structure layouts, or other ABI-visible definitions.
+- Additive public API changes require explicit task scope and a compatibility
+  review. Documentation-only changes remain permitted.
+- If a fix appears to require a breaking change in `libusb/libusb.h`, preserve
+  the existing interface and ask a maintainer for direction instead of making
+  the API or ABI change.
+
 ## PR description content
 
 The `Assisted-by` attribution should be included in the PR description, but no link to the


### PR DESCRIPTION
## Summary

Document that `libusb/libusb.h` is the installed public API header and must be treated as a compatibility contract for existing source and binary users.

The new guidance prohibits changing existing public function types, calling conventions, parameters, return values, linkage, enum values, structure layouts, and other ABI-visible definitions to resolve internal implementation issues, compiler warnings, or refactors. It also calls out source compatibility for explicitly typed function pointers, even when a proposed type change appears ABI-equivalent.

Additive public API work remains possible when explicitly in scope and reviewed for compatibility. If a fix appears to require a breaking change, agents must preserve the interface and ask a maintainer for direction.

## Motivation

PR #1904 initially changed the public `libusb_set_option()` parameter type while addressing a C++ compiler warning exposed by CI PR #1845. The implementation fix has been revised to preserve the established declaration. This repository guidance makes that compatibility constraint explicit for future work.

## Verification

- `git diff --check` passes.
- The branch is based on current `origin/master`.
- The PR changes only `AGENTS.md`.

Related to #1845
Related to #1904

Assisted-by: codex:GPT-5.6-Sol
