### PR TITLE
DO NOT MERGE: baseline for the Haiku stress_mt failure

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -52,4 +52,16 @@ jobs:
             # USB device at all. Fail loudly instead of testing nothing.
             ./examples/listdevs | tee listdevs.out
             test -s listdevs.out || { echo "no USB devices in the guest"; exit 1; }
+            # TEMPORARY (drop before merge): the failure is scheduling
+            # dependent, so a single run proves little either way. Repeat it
+            # inside the guest that is already booted and report the rate;
+            # 25 repeats cost about 25 seconds, far less than extra runs.
+            fails=0
+            i=1
+            while [ $i -le 25 ]; do
+              ./tests/stress_mt > /dev/null 2>&1 || fails=$((fails + 1))
+              i=$((i + 1))
+            done
+            echo "stress_mt: $fails failure(s) in 25 runs"
             make check || { cat tests/test-suite.log; exit 1; }
+            [ $fails -eq 0 ] || exit 1

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -47,6 +47,9 @@ jobs:
             ../configure --enable-examples-build --enable-tests-build \
               || { cat config.log; exit 1; }
             make -j4
-            # stress_mt is skipped on Haiku via an OS_HAIKU branch in
-            # tests/Makefile.am; see libusb/libusb#1907.
+            # stress_mt only compares the per-thread device counts against
+            # each other, so it passes vacuously when the guest publishes no
+            # USB device at all. Fail loudly instead of testing nothing.
+            ./examples/listdevs | tee listdevs.out
+            test -s listdevs.out || { echo "no USB devices in the guest"; exit 1; }
             make check || { cat tests/test-suite.log; exit 1; }

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -261,15 +261,6 @@ int main(void)
 {
 	int errs = 0;
 
-#if defined(__HAIKU__)
-	/* The enumeration phase reports per-thread device counts that disagree
-	   with each other on Haiku; see libusb/libusb#1907. Report an Automake
-	   skip rather than a failure until the backend is fixed. Remove this
-	   once #1907 is closed. */
-	printf("Skipping on Haiku: per-thread device counts disagree (libusb/libusb#1907)\n");
-	return 77;
-#endif
-
 	printf("Running multithreaded init/exit test...\n");
 	errs += test_multi_init(0);
 	printf("Running multithreaded init/exit test with enumeration...\n");


### PR DESCRIPTION
Throwaway branch, opened only to record the "before" half of the evidence for the Haiku enumeration fix, on libusb's own runner rather than a fork's.

No backend change. It removes the `__HAIKU__` skip that #1906 added to `tests/stress_mt.c`, so the Haiku job runs the test against the current backend, and adds a `listdevs` check first so a green run could not be mistaken for a vacuous one.

Expected result: red, with `Device count mismatch: Thread N discovered 0 devices instead of 1`.

Will be closed as soon as the run finishes.

Assisted-by: claude-code:claude-opus-5