### PR TITLE
haiku: enumerate existing devices into every new context

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -47,6 +47,9 @@ jobs:
             ../configure --enable-examples-build --enable-tests-build \
               || { cat config.log; exit 1; }
             make -j4
-            # stress_mt is skipped on Haiku via an OS_HAIKU branch in
-            # tests/Makefile.am; see libusb/libusb#1907.
+            # stress_mt only compares the per-thread device counts against
+            # each other, so it passes vacuously when the guest publishes no
+            # USB device at all. Fail loudly instead of testing nothing.
+            ./examples/listdevs | tee listdevs.out
+            test -s listdevs.out || { echo "no USB devices in the guest"; exit 1; }
             make check || { cat tests/test-suite.log; exit 1; }

--- a/libusb/os/haiku_pollfs.cpp
+++ b/libusb/os/haiku_pollfs.cpp
@@ -18,6 +18,29 @@
 #include <Path.h>
 #include <cstring>
 
+class WatchedEntry;
+
+/* Guards gDeviceRegistry and, with it, the transitions that add a device to a
+   context or take it away again. Held by the roster looper thread (device
+   arrival and removal) and by USBRoster::EnumerateInto() (a context being
+   created), so that those two paths cannot interleave for the same device.
+
+   Lock order is gInitLock -> gRosterLock -> active_contexts_lock ->
+   ctx->usb_devs_lock. The looper thread never takes gInitLock, which is what
+   makes it safe to hold gInitLock across the blocking RosterLooper::Stop(). */
+static usbi_mutex_static_t gRosterLock = USBI_MUTEX_INITIALIZER;
+
+/* Every device the roster currently knows about, in discovery order, so that
+   a context populated from the registry ends up with the same device order as
+   one populated by the constructor loop below. */
+static WatchedEntry *gDeviceRegistry GUARDED_BY(gRosterLock) = NULL;
+
+/* Guards the roster reference count and USBRoster::fLooper. Never taken by
+   the looper thread; see the lock order above. */
+static usbi_mutex_static_t gInitLock = USBI_MUTEX_INITIALIZER;
+static int gInitCount GUARDED_BY(gInitLock) = 0;
+
+
 class WatchedEntry {
 public:
 			WatchedEntry(BMessenger *, entry_ref *);
@@ -26,13 +49,25 @@ public:
 	bool		EntryRemoved(ino_t node);
 	bool		InitCheck();
 
+	/* Called for a single context, with gRosterLock held. */
+	void		AddToContext(struct libusb_context *ctx);
+	void		RemoveFromContext(struct libusb_context *ctx);
+	WatchedEntry*	RegistryLink() const { return fRegistryLink; }
+
 private:
+	void		Register() REQUIRES(gRosterLock);
+	void		Unregister() REQUIRES(gRosterLock);
+
 	BMessenger*	fMessenger;
 	node_ref	fNode;
 	bool		fIsDirectory;
 	USBDevice*	fDevice;
+	unsigned long	fSessionID;
+	uint8		fBusNumber;
+	uint8		fDeviceAddress;
 	WatchedEntry*	fEntries;
 	WatchedEntry*	fLink;
+	WatchedEntry*	fRegistryLink;
 	bool		fInitCheck;
 };
 
@@ -52,12 +87,102 @@ private:
 };
 
 
+void
+WatchedEntry::Register()
+{
+	WatchedEntry **tail = &gDeviceRegistry;
+	while (*tail != NULL)
+		tail = &(*tail)->fRegistryLink;
+	*tail = this;
+}
+
+
+void
+WatchedEntry::Unregister()
+{
+	WatchedEntry **link = &gDeviceRegistry;
+	while (*link != NULL && *link != this)
+		link = &(*link)->fRegistryLink;
+	if (*link == this)
+		*link = fRegistryLink;
+	fRegistryLink = NULL;
+}
+
+
+void
+WatchedEntry::AddToContext(struct libusb_context *ctx)
+{
+	struct libusb_device *dev = usbi_get_device_by_session_id(ctx, fSessionID);
+	if (dev != NULL) {
+		usbi_dbg(ctx, "using previously allocated device with location %lu", fSessionID);
+		libusb_unref_device(dev);
+		return;
+	}
+
+	usbi_dbg(ctx, "allocating new device with location %lu", fSessionID);
+	dev = usbi_alloc_device(ctx, fSessionID);
+	if (dev == NULL) {
+		/* Logged as an error rather than debug: a context that silently
+		   ends up with fewer devices than its siblings is exactly the
+		   symptom this backend used to have. */
+		usbi_err(ctx, "device allocation failed");
+		return;
+	}
+
+	*((USBDevice **)usbi_get_device_priv(dev)) = fDevice;
+	dev->bus_number = fBusNumber;
+	dev->device_address = fDeviceAddress;
+
+	static_assert(sizeof(dev->device_descriptor) == sizeof(usb_device_descriptor),
+		      "mismatch between libusb and OS device descriptor sizes");
+	memcpy(&dev->device_descriptor, fDevice->Descriptor(), LIBUSB_DT_DEVICE_SIZE);
+	usbi_localize_device_descriptor(&dev->device_descriptor);
+
+	if (usbi_sanitize_device(dev) < 0) {
+		usbi_err(ctx, "device sanitization failed");
+		libusb_unref_device(dev);
+		return;
+	}
+
+	usbi_connect_device(dev);
+}
+
+
+void
+WatchedEntry::RemoveFromContext(struct libusb_context *ctx)
+{
+	struct libusb_device *dev = usbi_get_device_by_session_id(ctx, fSessionID);
+	if (dev == NULL) {
+		usbi_dbg(ctx, "device with location %lu not found", fSessionID);
+		return;
+	}
+
+	if (usbi_atomic_load(&ctx->hotplug_ready)) {
+		/* The device-left message takes over the reference held by the
+		   context's device list. */
+		usbi_disconnect_device(dev);
+	} else {
+		/* A context is only enumerated but not yet hotplug-ready while
+		   it is inside libusb_init_context(); no message is posted
+		   there, so nothing would inherit that reference. */
+		usbi_detach_device(dev);
+		libusb_unref_device(dev);
+	}
+
+	libusb_unref_device(dev);
+}
+
+
 WatchedEntry::WatchedEntry(BMessenger *messenger, entry_ref *ref)
 	:	fMessenger(messenger),
 		fIsDirectory(false),
 		fDevice(NULL),
+		fSessionID(0),
+		fBusNumber(0),
+		fDeviceAddress(0),
 		fEntries(NULL),
 		fLink(NULL),
+		fRegistryLink(NULL),
 		fInitCheck(false)
 {
 	BEntry entry(ref);
@@ -92,62 +217,52 @@ WatchedEntry::WatchedEntry(BMessenger *messenger, entry_ref *ref)
 		BPath path, parent_path;
 		entry.GetPath(&path);
 		fDevice = new(std::nothrow) USBDevice(path.Path());
-		if (fDevice != NULL && fDevice->InitCheck() == true) {
-			// Add this new device to each active context's device list
-			struct libusb_context *ctx;
-			unsigned long session_id = (unsigned long)&fDevice;
-
-			usbi_mutex_lock(&active_contexts_lock);
-			for_each_context(ctx) {
-				struct libusb_device *dev = usbi_get_device_by_session_id(ctx, session_id);
-				if (dev) {
-					usbi_dbg(NULL, "using previously allocated device with location %lu", session_id);
-					libusb_unref_device(dev);
-					continue;
-				}
-				usbi_dbg(NULL, "allocating new device with location %lu", session_id);
-				dev = usbi_alloc_device(ctx, session_id);
-				if (!dev) {
-					usbi_dbg(NULL, "device allocation failed");
-					continue;
-				}
-				*((USBDevice **)usbi_get_device_priv(dev)) = fDevice;
-
-				// Calculate pseudo-device-address
-				int addr, tmp;
-				if (strcmp(path.Leaf(), "hub") == 0)
-					tmp = 100;	//Random Number
-				else
-					sscanf(path.Leaf(), "%d", &tmp);
-				addr = tmp + 1;
-				path.GetParent(&parent_path);
-				while (strcmp(parent_path.Leaf(), "usb") != 0) {
-					sscanf(parent_path.Leaf(), "%d", &tmp);
-					addr += tmp + 1;
-					parent_path.GetParent(&parent_path);
-				}
-				sscanf(path.Path(), "/dev/bus/usb/%hhu", &dev->bus_number);
-				dev->device_address = addr - (dev->bus_number + 1);
-
-				static_assert(sizeof(dev->device_descriptor) == sizeof(usb_device_descriptor),
-					      "mismatch between libusb and OS device descriptor sizes");
-				memcpy(&dev->device_descriptor, fDevice->Descriptor(), LIBUSB_DT_DEVICE_SIZE);
-				usbi_localize_device_descriptor(&dev->device_descriptor);
-
-				if (usbi_sanitize_device(dev) < 0) {
-					usbi_dbg(NULL, "device sanitization failed");
-					libusb_unref_device(dev);
-					continue;
-				}
-				usbi_connect_device(dev);
-			}
-			usbi_mutex_unlock(&active_contexts_lock);
-		}
-		else if (fDevice) {
+		if (fDevice == NULL)
+			return;
+		if (fDevice->InitCheck() == false) {
+			/* Loud, because a device dropped here is invisible to
+			   every context for as long as the roster lives. */
+			usbi_err(NULL, "failed to read descriptors of %s", path.Path());
 			delete fDevice;
 			fDevice = NULL;
 			return;
 		}
+
+		/* The session id only has to be unique among the devices that
+		   exist at the same time and stable for as long as this entry
+		   does; the USBDevice this entry owns is both. */
+		fSessionID = (unsigned long)fDevice;
+
+		// Calculate pseudo-device-address
+		int addr, tmp;
+		if (strcmp(path.Leaf(), "hub") == 0)
+			tmp = 100;	//Random Number
+		else
+			sscanf(path.Leaf(), "%d", &tmp);
+		addr = tmp + 1;
+		path.GetParent(&parent_path);
+		while (strcmp(parent_path.Leaf(), "usb") != 0) {
+			sscanf(parent_path.Leaf(), "%d", &tmp);
+			addr += tmp + 1;
+			parent_path.GetParent(&parent_path);
+		}
+		sscanf(path.Path(), "/dev/bus/usb/%hhu", &fBusNumber);
+		fDeviceAddress = (uint8)(addr - (fBusNumber + 1));
+
+		/* Publish the device to the contexts that exist right now. A
+		   context created later picks it up from the registry, in
+		   USBRoster::EnumerateInto(). active_contexts_lock is held
+		   across the whole loop so that a context cannot be unlinked
+		   half way through it. */
+		struct libusb_context *ctx;
+
+		usbi_mutex_static_lock(&gRosterLock);
+		Register();
+		usbi_mutex_static_lock(&active_contexts_lock);
+		for_each_context(ctx)
+			AddToContext(ctx);
+		usbi_mutex_static_unlock(&active_contexts_lock);
+		usbi_mutex_static_unlock(&gRosterLock);
 	}
 	fInitCheck = true;
 }
@@ -167,22 +282,18 @@ WatchedEntry::~WatchedEntry()
 	}
 
 	if (fDevice) {
-		// Remove this device from each active context's device list
+		// Remove this device from the registry and from each active
+		// context's device list
 		struct libusb_context *ctx;
-		struct libusb_device *dev;
-		unsigned long session_id = (unsigned long)&fDevice;
 
-		usbi_mutex_lock(&active_contexts_lock);
-		for_each_context(ctx) {
-			dev = usbi_get_device_by_session_id(ctx, session_id);
-			if (dev != NULL) {
-				usbi_disconnect_device(dev);
-				libusb_unref_device(dev);
-			} else {
-				usbi_dbg(ctx, "device with location %lu not found", session_id);
-			}
-		}
+		usbi_mutex_static_lock(&gRosterLock);
+		Unregister();
+		usbi_mutex_static_lock(&active_contexts_lock);
+		for_each_context(ctx)
+			RemoveFromContext(ctx);
 		usbi_mutex_static_unlock(&active_contexts_lock);
+		usbi_mutex_static_unlock(&gRosterLock);
+
 		delete fDevice;
 	}
 }
@@ -207,6 +318,10 @@ WatchedEntry::EntryCreated(entry_ref *ref)
 	WatchedEntry *child = new(std::nothrow) WatchedEntry(fMessenger, ref);
 	if (child == NULL)
 		return false;
+	if (child->InitCheck() == false) {
+		delete child;
+		return false;
+	}
 	child->fLink = fEntries;
 	fEntries = child;
 	return true;
@@ -280,18 +395,32 @@ RosterLooper::RosterLooper(USBRoster *roster)
 			fRoot = NULL;
 			return;
 		}
+		fInitCheck = true;
 	}
-	fInitCheck = true;
 }
 
 
 void
 RosterLooper::Stop()
 {
-	Lock();
-	delete fRoot;
-	delete fMessenger;
+	if (!Lock()) {
+		usbi_err(NULL, "failed to lock the roster looper");
+		return;
+	}
+
+	/* Tear the tree down while this looper is still alive: ~WatchedEntry
+	   deregisters its node monitors through fMessenger, whose target is
+	   this looper. Clearing fRoot first keeps the messages that Quit()
+	   still dispatches away from a partially destroyed tree. */
+	WatchedEntry *root = fRoot;
+	fRoot = NULL;
+	delete root;
+
+	/* Quit() deletes this looper, so nothing may touch a member after it. */
+	BMessenger *messenger = fMessenger;
+	fMessenger = NULL;
 	Quit();
+	delete messenger;
 }
 
 
@@ -300,6 +429,11 @@ RosterLooper::MessageReceived(BMessage *message)
 {
 	int32 opcode;
 	if (message->FindInt32("opcode", &opcode) < B_OK)
+		return;
+
+	/* Stop() clears fRoot under the looper lock, but Quit() still
+	   dispatches whatever was already queued. */
+	if (fRoot == NULL)
 		return;
 
 	switch (opcode) {
@@ -344,21 +478,81 @@ USBRoster::USBRoster()
 
 USBRoster::~USBRoster()
 {
+	usbi_mutex_static_lock(&gInitLock);
+	if (gInitCount > 0)
+		usbi_warn(NULL, "%d context(s) not deinitialized at exit", gInitCount);
+	gInitCount = 0;
 	Stop();
+	usbi_mutex_static_unlock(&gInitLock);
+}
+
+
+int
+USBRoster::Init(struct libusb_context *ctx)
+{
+	int status = LIBUSB_SUCCESS;
+
+	usbi_mutex_static_lock(&gInitLock);
+	if (gInitCount == 0)
+		status = Start();
+	if (status == LIBUSB_SUCCESS) {
+		/* Counted only on success, so that a roster that failed to
+		   start is retried by the next context instead of leaving
+		   every later context permanently empty. */
+		gInitCount++;
+
+		/* Every context has to be given the devices that are already
+		   present, not just the one that happened to start the roster.
+		   Devices showing up later are added by the roster itself. */
+		EnumerateInto(ctx);
+	}
+	usbi_mutex_static_unlock(&gInitLock);
+
+	return status;
+}
+
+
+void
+USBRoster::Exit(struct libusb_context *ctx)
+{
+	UNUSED(ctx);
+
+	usbi_mutex_static_lock(&gInitLock);
+	if (gInitCount > 0 && --gInitCount == 0)
+		Stop();
+	usbi_mutex_static_unlock(&gInitLock);
+}
+
+
+void
+USBRoster::EnumerateInto(struct libusb_context *ctx)
+{
+	usbi_mutex_static_lock(&gRosterLock);
+	for (WatchedEntry *entry = gDeviceRegistry; entry != NULL;
+	     entry = entry->RegistryLink())
+		entry->AddToContext(ctx);
+	usbi_mutex_static_unlock(&gRosterLock);
 }
 
 
 int
 USBRoster::Start()
 {
-	if (fLooper == NULL) {
-		fLooper = new(std::nothrow) RosterLooper(this);
-		if (fLooper == NULL || ((RosterLooper *)fLooper)->InitCheck() == false) {
-			if (fLooper)
-				fLooper = NULL;
-			return LIBUSB_ERROR_OTHER;
-		}
+	if (fLooper != NULL)
+		return LIBUSB_SUCCESS;
+
+	RosterLooper *looper = new(std::nothrow) RosterLooper(this);
+	if (looper == NULL)
+		return LIBUSB_ERROR_NO_MEM;
+	if (looper->InitCheck() == false) {
+		/* Run() is called early in the constructor, so the looper
+		   thread may already be alive; it has to be taken down through
+		   Stop() rather than simply dropped. */
+		looper->Stop();
+		return LIBUSB_ERROR_OTHER;
 	}
+
+	fLooper = looper;
 	return LIBUSB_SUCCESS;
 }
 
@@ -366,8 +560,10 @@ USBRoster::Start()
 void
 USBRoster::Stop()
 {
-	if (fLooper) {
-		((RosterLooper *)fLooper)->Stop();
-		fLooper = NULL;
-	}
+	if (fLooper == NULL)
+		return;
+
+	RosterLooper *looper = (RosterLooper *)fLooper;
+	fLooper = NULL;
+	looper->Stop();
 }

--- a/libusb/os/haiku_pollfs.cpp
+++ b/libusb/os/haiku_pollfs.cpp
@@ -25,9 +25,15 @@ class WatchedEntry;
    arrival and removal) and by USBRoster::EnumerateInto() (a context being
    created), so that those two paths cannot interleave for the same device.
 
-   Lock order is gInitLock -> gRosterLock -> active_contexts_lock ->
-   ctx->usb_devs_lock. The looper thread never takes gInitLock, which is what
-   makes it safe to hold gInitLock across the blocking RosterLooper::Stop(). */
+   Lock order is gInitLock -> RosterLooper's BLooper lock -> gRosterLock ->
+   active_contexts_lock -> ctx->usb_devs_lock. The BLooper lock sits between
+   the first two on every path that takes both: the looper thread holds it
+   while dispatching device arrival and removal, the initial tree build in the
+   RosterLooper constructor holds it around the WatchedEntry walk, and
+   RosterLooper::Stop() takes it before deleting the tree. Nothing may lock the
+   looper while holding gRosterLock. The looper thread never takes gInitLock,
+   which is what makes it safe to hold gInitLock across the blocking
+   RosterLooper::Stop(). */
 static usbi_mutex_static_t gRosterLock = USBI_MUTEX_INITIALIZER;
 
 /* Every device the roster currently knows about, in discovery order, so that
@@ -49,9 +55,9 @@ public:
 	bool		EntryRemoved(ino_t node);
 	bool		InitCheck();
 
-	/* Called for a single context, with gRosterLock held. */
-	void		AddToContext(struct libusb_context *ctx);
-	void		RemoveFromContext(struct libusb_context *ctx);
+	/* Called for a single context. */
+	void		AddToContext(struct libusb_context *ctx) REQUIRES(gRosterLock);
+	void		RemoveFromContext(struct libusb_context *ctx) REQUIRES(gRosterLock);
 	WatchedEntry*	RegistryLink() const { return fRegistryLink; }
 
 private:
@@ -376,7 +382,18 @@ RosterLooper::RosterLooper(USBRoster *roster)
 		return;
 	}
 
-	Run();
+	/* A failing Run() returns without unlocking the looper and without
+	   setting its fRunCalled, so the constructor's own lock is still held.
+	   Lock() would then nest rather than block and the rest of this would
+	   look like it worked, leaving a roster with no thread behind it and a
+	   looper that only this thread can ever unlock. Give up instead: Start()
+	   takes the object down through Stop(), where Quit() sees fRunCalled
+	   unset and simply deletes it. */
+	if (Run() < B_OK) {
+		usbi_err(NULL, "failed to start the roster looper thread");
+		return;
+	}
+
 	fMessenger = new(std::nothrow) BMessenger(this);
 	if (fMessenger == NULL) {
 		usbi_err(NULL, "error creating BMessenger object");

--- a/libusb/os/haiku_usb.h
+++ b/libusb/os/haiku_usb.h
@@ -109,8 +109,11 @@ class USBRoster {
 public:
 			USBRoster();
 	virtual		~USBRoster();
+	int		Init(struct libusb_context *ctx);
+	void		Exit(struct libusb_context *ctx);
+private:
 	int		Start();
 	void		Stop();
-private:
+	void		EnumerateInto(struct libusb_context *ctx);
 	void*		fLooper;
 };

--- a/libusb/os/haiku_usb_raw.cpp
+++ b/libusb/os/haiku_usb_raw.cpp
@@ -30,7 +30,6 @@
 #include "haiku_usb.h"
 
 USBRoster gUsbRoster;
-int32 gInitCount = 0;
 
 static int haiku_get_config_descriptor(struct libusb_device *, uint8_t,
     void *, size_t);
@@ -38,18 +37,13 @@ static int haiku_get_config_descriptor(struct libusb_device *, uint8_t,
 static int
 haiku_init(struct libusb_context *ctx)
 {
-	UNUSED(ctx);
-	if (atomic_add(&gInitCount, 1) == 0)
-		return gUsbRoster.Start();
-	return LIBUSB_SUCCESS;
+	return gUsbRoster.Init(ctx);
 }
 
 static void
 haiku_exit(struct libusb_context *ctx)
 {
-	UNUSED(ctx);
-	if (atomic_add(&gInitCount, -1) == 1)
-		gUsbRoster.Stop();
+	gUsbRoster.Exit(ctx);
 }
 
 static int

--- a/tests/stress_mt.c
+++ b/tests/stress_mt.c
@@ -261,15 +261,6 @@ int main(void)
 {
 	int errs = 0;
 
-#if defined(__HAIKU__)
-	/* The enumeration phase reports per-thread device counts that disagree
-	   with each other on Haiku; see libusb/libusb#1907. Report an Automake
-	   skip rather than a failure until the backend is fixed. Remove this
-	   once #1907 is closed. */
-	printf("Skipping on Haiku: per-thread device counts disagree (libusb/libusb#1907)\n");
-	return 77;
-#endif
-
 	printf("Running multithreaded init/exit test...\n");
 	errs += test_multi_init(0);
 	printf("Running multithreaded init/exit test with enumeration...\n");


### PR DESCRIPTION
`stress_mt` fails on Haiku because contexts disagree about how many devices
exist:

```
Device count mismatch: Thread 2 discovered 1 devices instead of 0
Device count mismatch: Thread 3 discovered 0 devices instead of 1
```

### Why

`haiku_init()` starts the roster on the `gInitCount` 0->1 transition and does
nothing else. The only code that ever puts a device into a context is the
`WatchedEntry` constructor, which walks `for_each_context()` once — while the
roster is building its tree. The backend has no `get_device_list` and no
`hotplug_poll`, so `libusb_get_device_list()` only walks `ctx->usb_devs`.

A context created while the roster is already running therefore never receives
the devices that are already there, and nothing ever refills its list. It sees
zero, permanently. `stress_mt` keeps up to eight contexts alive at once, so
whichever one happened to start the roster sees the devices and the rest see
none — which is also why its first, non-enumerating phase passes.

The other hotplug backends all split "start the global monitor once" from
"scan into this context, every time": `linux_usbfs.c` (`op_init` ->
`linux_scan_devices`), `windows_common.c` (`windows_init` ->
`windows_initial_scan_devices`), `darwin_usb.c` (`darwin_init_context` ->
`darwin_scan_devices`). Haiku only had the first half.

### Fix

The roster keeps a registry of the devices it knows about, and
`USBRoster::Init()` replays that registry into each new context. Device
arrival, device removal and this initial scan all go through the same
per-(device, context) helpers, under one lock, so the two paths cannot
disagree or add a device twice.

`get_device_list` and `hotplug_poll` stay `NULL`, so
`libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)` is unchanged and there is no
API or ABI change. Hotplug still works: `ctx->hotplug_ready` is still 0 while
`backend.init` runs, so the initial scan produces no spurious ARRIVED events,
exactly as on the other backends.

A handful of smaller defects in the functions this touches are fixed in the
same commit — roster start/stop serialization, a use-after-free in
`RosterLooper::Stop()` (the entry tree was deleted before `Quit()`, which
still dispatches queued messages that walk it), a leaked looper on the
`Start()` failure path, and the device-list reference that nothing inherits
when a context is not yet hotplug-ready. They are listed in the commit
message.

### Testing

`tests/stress_mt.c` loses the `__HAIKU__` skip added in #1906.

The test only compares the per-thread counts against each other, so it also
passes when every thread sees nothing — the workflow now runs `listdevs`
first and fails if the guest publishes no USB device, so a green run cannot be
vacuous.

A caveat that shaped how this was measured: on the CI guest, which publishes
a single root hub, the failure is scheduling dependent rather than
deterministic. [The first baseline run](https://github.com/libusb/libusb/actions/runs/30532892243)
removed the skip with no backend change and *passed*, so one green run would
have proved nothing. Both sides therefore run `stress_mt` 25 times inside the
already-booted guest and report the failure rate. (mcuee's four-device
hardware in #1781 is a considerably stronger reproducer than CI.)

Before and after, same runner, same measurement:

| | `stress_mt`, 25 in-guest runs | `make check` | run |
|---|---|---|---|
| before, no backend change | **10 failures** | FAIL, `Thread 1 discovered 0 devices instead of 1` | [30533153444](https://github.com/libusb/libusb/actions/runs/30533153444) |
| after, run 1 | **0 failures** | PASS | [30533222480 attempt 1](https://github.com/libusb/libusb/actions/runs/30533222480/attempts/1) |
| after, run 2 | **0 failures** | PASS | [attempt 2](https://github.com/libusb/libusb/actions/runs/30533222480/attempts/2) |
| after, run 3 | **0 failures** | PASS | [attempt 3](https://github.com/libusb/libusb/actions/runs/30533222480/attempts/3) |

75 consecutive passes against a measured 40% per-run failure rate. The commit
carrying that loop has been dropped again, so what is proposed here runs
`stress_mt` once, as every other platform does.

Off Haiku, all three backend sources were checked with
`g++ -fsyntax-only -Wall -Wextra` against hand-written Be API stubs; WSL
cannot run Haiku binaries, so that only covers the build.

### Not fixed here

`USBDevice` ownership. A raw `USBDevice*` is stored in every context's device
priv, `.destroy_device` is `NULL`, and `~WatchedEntry` deletes it — so
unplugging a device while an application still holds a reference or an open
handle reads freed memory. That is a design change rather than a bug fix, it
is not made worse by this commit, and it wants its own pull request. Same for
the per-device state (`fClaimedInterfaces`, `fActiveConfiguration`) that is
shared process-wide instead of per context, and for the transfer path in
`haiku_usb_backend.cpp`. I will open an issue with the details.

Fixes: #1781
Closes: #1907

Assisted-by: claude-code:claude-opus-5
