### PR TITLE
examples: include <string.h> in hotplugtest for Solaris FD_ZERO

### DIFF
--- a/examples/hotplugtest.c
+++ b/examples/hotplugtest.c
@@ -25,6 +25,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
+/* Solaris implements FD_ZERO() as a memset() call, so <string.h> is required
+ * even though this file makes no direct use of it. */
+#include <string.h>
 #include <signal.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
`examples/hotplugtest.c` uses `FD_ZERO()`, which Oracle Solaris's `<sys/select.h>` implements as a plain `memset()` call. With no `<string.h>` in scope there is no declaration for it, so the build fails:

```
../../examples/hotplugtest.c:141:9: error: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
  141 |         FD_ZERO(&read_fds);
      |         ^~~~~~~
../../examples/hotplugtest.c:47:1: note: include ‘<string.h>’ or provide a declaration of ‘memset’
```

This has broken the `illumos` workflow's **solaris** job on every master commit since the workflow landed in 8aed2bb0 — the offending code came in earlier (f42efb7d, the interactive quit flow), so that job has never been green.

Only the `solaris` job is affected. `omnios` and `openindiana` build everything and pass `gmake check`, because the illumos headers do not route `FD_ZERO` through `memset`. glibc is likewise unaffected: it expands `FD_ZERO` to an inline loop instead of a `memset()` call.

### Verification

- Full `configure --enable-examples-build --enable-tests-build` + `make` clean on Linux (no regression).
- Confirmed the root cause is header-side, not compiler-version-side: with `hotplugtest.c`'s exact include set minus `<string.h>`, a `memset()` call fails to compile on glibc too — Linux escapes the bug only because its `FD_ZERO` never calls `memset`.
- Verified `FD_ZERO` is the sole such use in the tree; no other file needs this.

The include carries a short comment, since it looks unused at a glance and would otherwise be an easy target for a future cleanup.

Assisted-by: claude-code:claude-opus-5
