### PR TITLE
ci: gate testcore stress test

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -27,8 +27,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -19,13 +19,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -9,6 +9,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,6 +25,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -45,6 +58,7 @@ jobs:
             gcc --version | head -1
             mkdir build && cd build
             ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             make -j4
             # stress_mt is skipped on Haiku via an OS_HAIKU branch in

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -21,14 +21,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/illumos.yml
+++ b/.github/workflows/illumos.yml
@@ -29,14 +29,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   omnios:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -79,8 +83,8 @@ jobs:
   openindiana:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -119,8 +123,8 @@ jobs:
   solaris:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/illumos.yml
+++ b/.github/workflows/illumos.yml
@@ -35,8 +35,8 @@ jobs:
   omnios:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -79,8 +79,8 @@ jobs:
   openindiana:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -119,8 +119,8 @@ jobs:
   solaris:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/illumos.yml
+++ b/.github/workflows/illumos.yml
@@ -17,6 +17,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -24,6 +33,10 @@ concurrency:
 
 jobs:
   omnios:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -58,11 +71,16 @@ jobs:
             gcc --version | head -1
             mkdir build && cd build
             CC=gcc ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             gmake -j4
             gmake check || { cat tests/test-suite.log; exit 1; }
 
   openindiana:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -93,11 +111,16 @@ jobs:
             gcc --version | head -1
             mkdir build && cd build
             CC=gcc ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             gmake -j4
             gmake check || { cat tests/test-suite.log; exit 1; }
 
   solaris:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -126,6 +149,7 @@ jobs:
             gcc --version | head -1
             mkdir build && cd build
             CC=gcc ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             gmake -j4
             gmake check || { cat tests/test-suite.log; exit 1; }

--- a/.github/workflows/illumos.yml
+++ b/.github/workflows/illumos.yml
@@ -27,13 +27,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   omnios:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,14 +19,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   c23:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     name: GCC 16 / C23
     runs-on: ubuntu-latest
     container: gcc:16
@@ -59,8 +63,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,6 +23,10 @@ concurrency:
 
 jobs:
   c23:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     name: GCC 16 / C23
     runs-on: ubuntu-latest
     container: gcc:16
@@ -44,6 +57,10 @@ jobs:
           make -j"$(nproc)"
 
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,8 +25,8 @@ jobs:
   c23:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     name: GCC 16 / C23
     runs-on: ubuntu-latest
     container: gcc:16
@@ -59,8 +59,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,13 +17,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   c23:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,8 +30,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: macos-latest
     timeout-minutes: 60
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,11 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 # A workflow run is made up of one or more jobs that can run
 # sequentially or in parallel
@@ -30,8 +34,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: macos-latest
     timeout-minutes: 60
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,13 +19,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # A workflow run is made up of one or more jobs that can run
 # sequentially or in parallel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +28,10 @@ concurrency:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: macos-latest
     timeout-minutes: 60
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -16,13 +16,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -6,6 +6,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,6 +22,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -24,8 +24,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -18,14 +18,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -18,14 +18,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-11-arm
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -6,6 +6,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,6 +22,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-11-arm
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -16,13 +16,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -24,8 +24,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: windows-11-arm
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -16,13 +16,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -6,6 +6,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,6 +22,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -24,8 +24,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -18,14 +18,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -27,8 +27,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -19,13 +19,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -9,6 +9,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,6 +25,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -47,6 +60,7 @@ jobs:
             cc --version | head -1
             mkdir build && cd build
             ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             gmake -j4
             gmake check || { cat tests/test-suite.log; exit 1; }

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -21,14 +21,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -27,8 +27,8 @@ jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
+      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -19,13 +19,15 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
+# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' ||
-         github.event.label.name == 'force_testcore' ||
-         github.event.label.name == 'force_long_tests') }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'force_testcore' &&
+      github.event.label.name != 'force_long_tests' &&
+      github.run_id || 'ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -9,6 +9,15 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# Keep the long-running stress test on master unless a PR explicitly opts in.
+env:
+  TESTCORE_CONFIGURE_FLAG: >-
+    ${{ (github.ref == 'refs/heads/master' ||
+         contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
+         contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
+        && '--enable-testcore' || '' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,6 +25,10 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -47,6 +60,7 @@ jobs:
             cc --version | head -1
             mkdir build && cd build
             ../configure --enable-examples-build --enable-tests-build \
+              ${{ env.TESTCORE_CONFIGURE_FLAG }} \
               || { cat config.log; exit 1; }
             gmake -j4
             gmake check || { cat tests/test-suite.log; exit 1; }

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -21,14 +21,18 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' &&
+        (github.event.action != 'labeled' ||
+         github.event.label.name == 'force_testcore' ||
+         github.event.label.name == 'force_long_tests') }}
 
 jobs:
   build:
     if: >-
       github.event.action != 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'force_testcore') ||
-      contains(github.event.pull_request.labels.*.name, 'force_long_tests')
+      github.event.label.name == 'force_testcore' ||
+      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.private/ci-build.sh
+++ b/.private/ci-build.sh
@@ -74,7 +74,11 @@ fi
 
 echo ""
 echo "Configuring ..."
-CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure --enable-examples-build --enable-tests-build "$@"
+configure_args=(--enable-examples-build --enable-tests-build)
+if [ -n "${TESTCORE_CONFIGURE_FLAG:-}" ]; then
+	configure_args+=("${TESTCORE_CONFIGURE_FLAG}")
+fi
+CFLAGS="${cflags}" CXXFLAGS="${cflags}" ../configure "${configure_args[@]}" "$@"
 
 echo ""
 echo "Building ..."

--- a/configure.ac
+++ b/configure.ac
@@ -425,8 +425,15 @@ AC_ARG_ENABLE([tests-build],
 	[build_tests=$enableval],
 	[build_tests=no])
 
+dnl Long-running testcore stress test
+AC_ARG_ENABLE([testcore],
+	[AS_HELP_STRING([--enable-testcore], [include the testcore stress test in make check [default=no]])],
+	[run_testcore=$enableval],
+	[run_testcore=no])
+
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$build_examples" != xno])
 AM_CONDITIONAL([BUILD_TESTS], [test "x$build_tests" != xno])
+AM_CONDITIONAL([RUN_TESTCORE], [test "x$run_testcore" = xyes])
 AM_CONDITIONAL([BUILD_MAN_PAGES], [test "x$build_man_pages" = xyes])
 AM_CONDITIONAL([BUILD_UMOCKDEV_TEST], [test "x$ac_have_umockdev" = xyes -a "x$log_enabled" != xno -a "x$debug_log_enabled" != xyes])
 AM_CONDITIONAL([CREATE_IMPORT_LIB], [test "x$create_import_lib" = xyes])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,8 +37,17 @@ endif
 
 noinst_HEADERS = libusb_testlib.h
 noinst_PROGRAMS = stress stress_mt set_option init_context testcore
+
+# testcore is an intentionally long-running stress test. CI sets
+# --enable-testcore on master and for explicitly labelled pull requests.
+TESTS = stress stress_mt set_option init_context
+if RUN_TESTCORE
+TESTS += testcore
+endif
+
 if OS_DARWIN
 noinst_PROGRAMS += macos
+TESTS += macos
 endif
 
 if BUILD_UMOCKDEV_TEST
@@ -50,6 +59,5 @@ umockdev_LDFLAGS = -Wl,--push-state,--no-as-needed -Wl,-lumockdev-preload -Wl,--
 umockdev_SOURCES = umockdev.c
 
 noinst_PROGRAMS += umockdev
+TESTS += umockdev
 endif
-
-TESTS=$(noinst_PROGRAMS)


### PR DESCRIPTION
## Summary

- Keep building `testcore`, but exclude it from the default `make check` test list.
- Add `--enable-testcore` to include the stress test explicitly.
- Enable `testcore` automatically for `master` builds and for pull requests carrying either the `force_testcore` or `force_long_tests` label.
- Trigger on PR label additions while skipping unrelated label-triggered workflow runs.

## Rationale

`testcore` performs 10,000 concurrent enumeration loops and adds roughly 70–110 seconds to each MSYS2 test configuration. Running it on every pull request substantially increases CI time without removing coverage from `master`; the labels preserve an immediate opt-in path for relevant PRs.

## Validation

- `actionlint` 1.7.12 on all workflow files
- `bash -n .private/ci-build.sh`
- Autotools bootstrap and default/forced out-of-tree configurations
- Default configuration generated four tests without `testcore`
- `--enable-testcore` generated the fifth test and `testcore` passed
- `.private/ci-build.sh` forwarded `TESTCORE_CONFIGURE_FLAG=--enable-testcore`

Related to #1809

Assisted-by: codex:gpt-5.6-sol
