### PR TITLE
darwin: fix Apple SDK enum conversion warnings

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1155,7 +1155,8 @@ static int darwin_fetch_string_descriptor (struct libusb_context *ctx,
   langid = dpriv->langid;
   if (0 == langid) {
     memset (desc, 0, sizeof(desc));
-    req.bmRequestType = USBmakebmRequestType (kUSBIn, kUSBStandard, kUSBDevice);
+    req.bmRequestType = USBmakebmRequestType ((UInt8)kUSBIn,
+      (UInt8)kUSBStandard, (UInt8)kUSBDevice);
     req.bRequest      = kUSBRqGetDescriptor;
     req.wValue        = (UInt16)(LIBUSB_DT_STRING << 8);
     req.wIndex        = 0;
@@ -1172,7 +1173,8 @@ static int darwin_fetch_string_descriptor (struct libusb_context *ctx,
 
   /* Fetch the requested string descriptor. */
   memset (desc, 0, sizeof(desc));
-  req.bmRequestType = USBmakebmRequestType (kUSBIn, kUSBStandard, kUSBDevice);
+  req.bmRequestType = USBmakebmRequestType ((UInt8)kUSBIn,
+    (UInt8)kUSBStandard, (UInt8)kUSBDevice);
   req.bRequest      = kUSBRqGetDescriptor;
   req.wValue        = (UInt16)((LIBUSB_DT_STRING << 8) | string_index);
   req.wIndex        = langid;
@@ -1394,7 +1396,8 @@ static IOReturn darwin_request_descriptor (usb_device_t device, UInt8 desc, UInt
   memset (buffer, 0, buffer_size);
 
   /* Set up request for descriptor/ */
-  req.bmRequestType = USBmakebmRequestType(kUSBIn, kUSBStandard, kUSBDevice);
+  req.bmRequestType = USBmakebmRequestType((UInt8)kUSBIn,
+    (UInt8)kUSBStandard, (UInt8)kUSBDevice);
   req.bRequest      = kUSBRqGetDescriptor;
   req.wValue        = (UInt16)(desc << 8);
   req.wIndex        = desc_index;


### PR DESCRIPTION
## Summary

Cast the three Apple request-type inputs to `UInt8` before `USBmakebmRequestType` combines them.

This is the remaining `libusb/os/darwin_usb.c` portion extracted from #1904. The language-ID conversion that was also present there has already landed through #1903, so it is not duplicated here.

## Root cause

Xcode 26's SDK defines the request values and masks used by `USBmakebmRequestType` in different anonymous enums. Clang therefore diagnoses the macro's cross-enum bitwise operations at the Darwin string-descriptor call sites added by #1860.

The inputs are byte-sized USB request fields. Casting each input to `UInt8` before the macro combines them makes the intended representation explicit without changing request values or runtime behavior.

## Impact

This removes the Apple SDK anonymous-enum warnings exposed by the macOS C++ build in #1845. The change is confined to `libusb/os/darwin_usb.c` and does not alter the public API or ABI.

## Verification

- The macOS workflow passes on the current head.
- `git diff --check` passes.
- The branch is based on current `origin/master`.
- The diff changes only three `USBmakebmRequestType` call sites in `libusb/os/darwin_usb.c`.

Related to #1845
Related to #1860
Related to #1903
Related to #1904

Assisted-by: Codex:GPT-5.6 Sol
