### PR TITLE
core: bound the fill loop in libusb_get_port_numbers

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1013,9 +1013,13 @@ int API_EXPORTED libusb_get_port_numbers(libusb_device *dev,
 		return LIBUSB_ERROR_OVERFLOW;
 	}
 
-	/* fill port numbers directly into the correct positions */
+	/* Fill port numbers directly into the correct positions. The parent
+	 * chain is walked without holding a lock, so a backend updating a
+	 * published device can make it longer between the two passes; bound the
+	 * index so a chain that grew cannot write before the start of the
+	 * caller's array. */
 	i = depth;
-	while (dev && dev->port_number != 0) {
+	while (dev && dev->port_number != 0 && i > 0) {
 		port_numbers[--i] = dev->port_number;
 		dev = dev->parent_dev;
 	}


### PR DESCRIPTION
libusb_get_port_numbers walks the parent chain twice without holding a lock: once to count the depth, and again to fill the caller's array from the end backwards. A backend that updates a published device can change the chain between the two passes: the darwin backend does exactly that when it reuses a libusb_device for a re-enumerated device.

If the chain is longer during the second pass than it was during the first, the fill index runs past the start of the array and writes before port_numbers[0], corrupting the caller's memory.

Solution: Stop the loop when the index reaches zero, so a chain that grew is reported as the shorter depth that was actually validated against the caller's buffer size rather than overflowing it.

A chain that shrank between the passes already fails safe: the leading entries are left untouched and the returned depth simply exceeds what was written.