### PR TITLE
windows: propagate the auto-claim status on control transfers

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -644,20 +644,36 @@ static int auto_claim(struct libusb_transfer *transfer, int *interface_number, i
 
 	usbi_mutex_lock(&autoclaim_lock);
 	if (current_interface < 0) { // No serviceable interface was found
+		// Status of the last claim attempt, returned to the caller when the scan
+		// comes up empty: LIBUSB_ERROR_NO_DEVICE for a device that has been
+		// unplugged or re-enumerated, LIBUSB_ERROR_NOT_FOUND when the device
+		// exposes no interface of this API type.
+		int claim_status = LIBUSB_ERROR_NOT_FOUND;
+
 		for (current_interface = 0; current_interface < USB_MAXINTERFACES; current_interface++) {
 			// Must claim an interface of the same API type
-			if ((priv->usb_interface[current_interface].apib->id == api_type)
-					&& (libusb_claim_interface(transfer->dev_handle, current_interface) == LIBUSB_SUCCESS)) {
+			if (priv->usb_interface[current_interface].apib->id != api_type)
+				continue;
+
+			claim_status = libusb_claim_interface(transfer->dev_handle, current_interface);
+			if (claim_status == LIBUSB_SUCCESS) {
 				usbi_dbg(TRANSFER_CTX(transfer), "auto-claimed interface %d for control request", current_interface);
 				if (handle_priv->autoclaim_count[current_interface] != 0)
 					usbi_err(TRANSFER_CTX(transfer), "program assertion failed - autoclaim_count was nonzero");
 				handle_priv->autoclaim_count[current_interface]++;
 				break;
 			}
+
+			// The device is gone, no other interface is going to fare better
+			if (claim_status == LIBUSB_ERROR_NO_DEVICE) {
+				current_interface = USB_MAXINTERFACES;
+				break;
+			}
 		}
 		if (current_interface == USB_MAXINTERFACES) {
-			usbi_err(TRANSFER_CTX(transfer), "could not auto-claim any interface");
-			r = LIBUSB_ERROR_NOT_FOUND;
+			r = claim_status;
+			usbi_err(TRANSFER_CTX(transfer), "could not auto-claim any interface: %s",
+				libusb_error_name(r));
 		}
 	} else {
 		// If we have a valid interface that was autoclaimed, we must increment
@@ -3497,6 +3513,7 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 	HANDLE winusb_handle;
 	OVERLAPPED *overlapped;
 	int current_interface;
+	int r;
 
 	CHECK_WINUSBX_AVAILABLE(sub_api);
 
@@ -3512,8 +3529,9 @@ static int winusbx_submit_control_transfer(int sub_api, struct usbi_transfer *it
 	else
 		current_interface = get_valid_interface(transfer->dev_handle, USB_API_WINUSBX);
 	if (current_interface < 0) {
-		if (auto_claim(transfer, &current_interface, USB_API_WINUSBX) != LIBUSB_SUCCESS)
-			return LIBUSB_ERROR_NOT_FOUND;
+		r = auto_claim(transfer, &current_interface, USB_API_WINUSBX);
+		if (r != LIBUSB_SUCCESS)
+			return r;
 	}
 
 	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);
@@ -4943,8 +4961,9 @@ static int hid_submit_control_transfer(int sub_api, struct usbi_transfer *itrans
 
 	current_interface = get_valid_interface(dev_handle, USB_API_HID);
 	if (current_interface < 0) {
-		if (auto_claim(transfer, &current_interface, USB_API_HID) != LIBUSB_SUCCESS)
-			return LIBUSB_ERROR_NOT_FOUND;
+		r = auto_claim(transfer, &current_interface, USB_API_HID);
+		if (r != LIBUSB_SUCCESS)
+			return r;
 	}
 
 	usbi_dbg(ITRANSFER_CTX(itransfer), "will use interface %d", current_interface);


### PR DESCRIPTION
On Windows, a control transfer that isn't already bound to a claimed interface goes through auto_claim(), which walks the device's interfaces and tries libusb_claim_interface() on each one of the matching API type. Whatever the reason a claim failed, the result reported to the application was LIBUSB_ERROR_NOT_FOUND.

That matters because libusb_claim_interface() returns LIBUSB_ERROR_NO_DEVICE once the libusb_device is no longer attached, which is exactly what happens when a device is unplugged or re-enumerates (firmware renumeration, driver reload): the enumeration pass detaches the old libusb_device while the application still holds a handle on it. From that point on every control
transfer on that handle failed with NOT_FOUND, indistinguishable from a device that simply exposes no interface of the requested API type. 

The only hint was the "could not auto-claim any interface" log line, so applications were left guessing whether to reopen the device or give up.

auto_claim() now keeps the status of the last claim attempt and returns it, and both winusbx_submit_control_transfer() and hid_submit_control_transfer() forward it instead of overwriting it with NOT_FOUND. 

A disconnected or re-enumerated device surfaces LIBUSB_ERROR_NO_DEVICE, the documented signal to close and reopen the handle, while NOT_FOUND keeps its narrower meaning. The scan also stops at the first NO_DEVICE rather than making 31 further attempts that cannot succeed, and the log line names the status being returned.