### PR TITLE
darwin: keep the parent device link correct across re-enumeration

### DIFF
--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1786,13 +1786,24 @@ static enum libusb_error process_new_device (struct libusb_context *ctx, struct 
     usbi_localize_device_descriptor(&dev->device_descriptor);
     dev->session_data = cached_device->session;
 
-    if (NULL != dev->parent_dev) {
-      libusb_unref_device(dev->parent_dev);
-      dev->parent_dev = NULL;
-    }
+    /* store the new parent before releasing the old one, so the field always
+       holds either NULL or a device we own a reference to. this device is
+       already visible to the application and libusb_get_port_numbers walks
+       the parent chain without a lock, so a concurrent walk sees one parent
+       or the other and never a gap. a walk that already loaded the old
+       pointer can still race; closing that needs a core-level fix. */
+    {
+      struct libusb_device *old_parent = dev->parent_dev;
 
-    if (cached_device->parent_session > 0) {
-      dev->parent_dev = usbi_get_device_by_session_id (ctx, (unsigned long) cached_device->parent_session);
+      if (cached_device->parent_session > 0) {
+        dev->parent_dev = usbi_get_device_by_session_id (ctx, (unsigned long) cached_device->parent_session);
+      } else {
+        dev->parent_dev = NULL;
+      }
+
+      if (NULL != old_parent) {
+        libusb_unref_device(old_parent);
+      }
     }
 
     usb_device_t darwin_device = darwin_active_device_interface (priv->dev);

--- a/libusb/os/darwin_usb.c
+++ b/libusb/os/darwin_usb.c
@@ -1668,10 +1668,14 @@ static enum libusb_error darwin_get_cached_device(struct libusb_context *ctx, io
 
       (*device)->GetLocationID (device, &new_device->location);
       new_device->port = port;
-      new_device->parent_session = parent_sessionID;
 
       usbi_mutex_init(&new_device->lock);
     }
+
+    /* refresh on every path, not just for a freshly allocated cached device:
+       a parent re-enumerated while this device was away has a new session id,
+       and process_new_device needs the current one to resolve the parent. */
+    new_device->parent_session = parent_sessionID;
 
     /* keep track of devices regardless of if we successfully enumerate them to
        prevent them from being enumerated multiple times */


### PR DESCRIPTION
Two fixes in the darwin re-enumeration path, found while investigating the
`libusb_get_port_numbers` / `process_new_device` report on #1798. They are different
kinds of fix in the same code, so they are separate commits. A companion fix bounding
the reader's fill loop is in PR#1915.

**`darwin: refresh the cached parent session on re-enumeration`** (functional, no
concurrency involved)

`darwin_get_cached_device` assigns `parent_session` on every path, not only when it
allocates a cached device, so a device returning from a re-enumeration carries the
session id of the parent it currently sits behind. When a parent hub is re-enumerated
and receives a new session id, its children resolve that new id the next time they are
re-enumerated, and `libusb_get_parent` and `libusb_get_port_numbers` keep reporting the
real topology.

**`darwin: publish the new parent device before releasing the old one`** (addendum item
12 of #1798)

`process_new_device` resolves the new parent and stores it before releasing the previous
one, so `dev->parent_dev` always holds either NULL or a device this device owns a
reference to. A concurrent `libusb_get_port_numbers` walk sees one parent or the other,
with no NULL gap while the lookup runs. Reference counting stays balanced:
`usbi_get_device_by_session_id` returns a referenced device, so this is the same +1/-1
pair in the opposite order.

It narrows the reader race rather than closing it. A walk that already loaded the old
pointer can still dereference it after the release, and closing that needs the reader to
hold a reference, which is a core-level change.

Reference: #1798 (addendum item 12)

Regarding testing:
The first commit has a visible symptom and is the one worth exercising: with a device
behind a hub, replug or re-enumerate the hub, then reset the child, and check that
`libusb_get_parent` and the port path still resolve. `hotplugtest` plus `testlibusb`
covers it. 

The second has no targeted reproducer, so the usual suite for no-regression
is enough.

If somebody re-runs the item-9/10 tester (its scan thread calls `libusb_get_port_numbers`),
the TSan report on `parent_dev` still appears. It flags the unlocked read of the field,
which neither commit changes; the recent clean runs used tests that never walk the
parent chain, so they did not exercise it. Silencing it needs the field made atomic, or
both the reader and the backend writer holding a common lock, with `ctx->usb_devs_lock`
the natural candidate since `usbi_hotplug_exit` already walks parent chains under it.
Both are core changes, and separate from the use-after-free question above.