### PR TITLE
linux: read a wrapped device's active configuration from the kernel

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1410,11 +1410,11 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
  * available to you through libusb_get_device(). This device is destroyed
  * during libusb_close(). The device shall not be opened through libusb_open().
  *
- * No requests are sent over the bus and the function does not block, with
- * one exception: on Linux, if the active configuration of the wrapped
- * device cannot be read from the kernel, it is asked of the device itself
- * with a single GET_CONFIGURATION control request, sent with a 1000
- * millisecond timeout.
+ * This function does not block and sends no requests over the bus. On Linux
+ * one exception is possible: a single GET_CONFIGURATION control request to
+ * the wrapped device, with a 1000 millisecond timeout. The kernel usually
+ * supplies the active configuration of that device. This request is sent
+ * only when the kernel cannot supply it.
  *
  * Since version 1.0.23, \ref LIBUSB_API_VERSION >= 0x01000107
  *

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1410,7 +1410,11 @@ void API_EXPORTED libusb_unref_device(libusb_device *dev)
  * available to you through libusb_get_device(). This device is destroyed
  * during libusb_close(). The device shall not be opened through libusb_open().
  *
- * This is a non-blocking function; no requests are sent over the bus.
+ * No requests are sent over the bus and the function does not block, with
+ * one exception: on Linux, if the active configuration of the wrapped
+ * device cannot be read from the kernel, it is asked of the device itself
+ * with a single GET_CONFIGURATION control request, sent with a 1000
+ * millisecond timeout.
  *
  * Since version 1.0.23, \ref LIBUSB_API_VERSION >= 0x01000107
  *

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -714,8 +714,7 @@ static int open_sysfs_attr(struct libusb_context *ctx,
 	return fd;
 }
 
-/* Note only suitable for attributes which always read >= 0, < 0 is error.
- * Takes ownership of fd and closes it. */
+/* fd stays open: the caller that opened it also closes it. */
 static int parse_sysfs_attr_fd(struct libusb_context *ctx, int fd,
 	const char *attr, int max_value, int *value_p)
 {
@@ -728,13 +727,11 @@ static int parse_sysfs_attr_fd(struct libusb_context *ctx, int fd,
 	r = read(fd, buf, sizeof(buf) - 1);
 	if (r < 0) {
 		r = errno;
-		close(fd);
 		if (r == ENODEV)
 			return LIBUSB_ERROR_NO_DEVICE;
 		usbi_err(ctx, "attribute %s read failed, errno=%zd", attr, r);
 		return LIBUSB_ERROR_IO;
 	}
-	close(fd);
 
 	if (r == 0) {
 		/* Certain attributes (e.g. bConfigurationValue) are not
@@ -789,13 +786,16 @@ static int parse_sysfs_attr_fd(struct libusb_context *ctx, int fd,
 static int read_sysfs_attr(struct libusb_context *ctx,
 	const char *sysfs_dir, const char *attr, int max_value, int *value_p)
 {
-	int fd;
+	int fd, r;
 
 	fd = open_sysfs_attr(ctx, sysfs_dir, attr);
 	if (fd < 0)
 		return fd;
 
-	return parse_sysfs_attr_fd(ctx, fd, attr, max_value, value_p);
+	r = parse_sysfs_attr_fd(ctx, fd, attr, max_value, value_p);
+	close(fd);
+
+	return r;
 }
 
 static int sysfs_scan_device(struct libusb_context *ctx, const char *devname)
@@ -819,33 +819,26 @@ static int sysfs_get_active_config(struct libusb_device *dev, int *config)
 			UINT8_MAX, config);
 }
 
-/* read the bConfigurationValue for a device we only have a usbfs file
- * descriptor for, i.e. one that came in through libusb_wrap_sys_device().
+/* Read the sysfs bConfigurationValue of a device that came in through
+ * libusb_wrap_sys_device(). Such a device has no priv->sysfs_dir. A usbfs
+ * node is a character device, so /sys/dev/char/<major>:<minor> links to the
+ * owning device's sysfs directory. Open the attribute through that link,
+ * never through a copy of the directory name: the kernel can give a name
+ * like "1-4" to a new device as soon as this one disconnects.
  *
- * Such a device has no priv->sysfs_dir, so the active configuration is
- * normally asked of the device itself with a GET_CONFIGURATION request. The
- * kernel already knows the answer and publishes the mapping needed to find
- * it: a usbfs node is a character device, and /sys/dev/char/<major>:<minor>
- * is a symlink to the owning device's sysfs directory. The attribute is
- * opened through that link, never through a copy of the directory name: the
- * kernel can give the "1-4" style name to a new device the moment this one
- * disconnects, so the link must be resolved at open time.
+ * Trust the value only if IOCTL_USBFS_GET_CAPABILITIES on the wrapped fd
+ * then answers 0, or ENOTTY, which initialize_handle() already treats as a
+ * kernel without the ioctl; no such kernel was tested here. The ioctl is
+ * issued for that answer, not for the capabilities. Observed here: a live fd
+ * answered 0 with no bus traffic in usbmon, and an fd held open across a
+ * disconnect answered ENODEV, as did every other usbfs ioctl tried on it.
+ * "Anything but ENODEV" would not do: an fd opened without write access
+ * answered EPERM both while the device was attached and after it was gone.
+ * The probe runs after the read, so a value from a recycled link is rejected.
  *
- * The value read is trusted only if USBDEVFS_GET_CAPABILITIES on the
- * wrapped fd then proves the device is still connected. The kernel answers
- * that ioctl from memory, without bus traffic. usbfs checks the connection
- * before it decodes the command, so success is proof, and so is ENOTTY
- * from a kernel that predates the ioctl. Any other result is not: ENODEV
- * means the device is gone, and EPERM means the fd was opened without
- * write access and can prove nothing. A usbfs fd never comes back once its
- * device disconnects, so an fd that is connected after the read was
- * connected throughout it, and the value is its own.
- *
- * Any failure at any step is not an error: the caller falls back to asking
- * the device, which is what it did before, and for a disconnected fd that
- * request path is what reports LIBUSB_ERROR_NO_DEVICE. All failures collapse
- * to LIBUSB_ERROR_NOT_SUPPORTED so no caller is tempted to report one.
- */
+ * Every failure returns LIBUSB_ERROR_NOT_SUPPORTED, never a device error. The
+ * caller then asks the device, and that path reports LIBUSB_ERROR_NO_DEVICE
+ * for a disconnected fd. */
 static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 	int *config)
 {
@@ -861,6 +854,8 @@ static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 	if (fstat(fd, &st) < 0 || !S_ISCHR(st.st_mode))
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
+	/* No truncation check: the longest path this can build is 55
+	 * characters, two 10-digit numbers included, and path holds 64. */
 	snprintf(path, sizeof(path),
 		SYSFS_MOUNT_PATH "/dev/char/%u:%u/bConfigurationValue",
 		major(st.st_rdev), minor(st.st_rdev));
@@ -871,6 +866,7 @@ static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 
 	r = parse_sysfs_attr_fd(ctx, attr_fd, "bConfigurationValue", UINT8_MAX,
 		&active);
+	close(attr_fd);
 	if (r < 0)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
@@ -879,9 +875,8 @@ static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
 	/* An unconfigured device leaves the attribute empty, which
-	 * parse_sysfs_attr_fd() already reports as -1. Reaching this line with
-	 * a 0 means the kernel named configuration 0, so decide it the way the
-	 * request path decides the same answer. */
+	 * parse_sysfs_attr_fd() reports as -1. Map a real 0 as
+	 * usbfs_get_active_config() maps it. */
 	if (active == 0 && !dev_has_config0(dev))
 		active = -1;
 
@@ -1311,20 +1306,20 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 
 	/* cache active config */
 	if (wrapped_fd >= 0) {
-		/* The device came in through libusb_wrap_sys_device(), which
-		 * is documented not to send requests over the bus when the
-		 * kernel can describe the wrapped device. Ask the kernel, and
-		 * only fall back to asking the device if it cannot be. */
+		/* libusb_wrap_sys_device() is documented not to send bus
+		 * requests when the kernel can describe the device. Read the
+		 * sysfs bConfigurationValue first; ask the device only if that
+		 * read fails. */
 		int active_config;
 
 		if (wrapped_fd_get_active_config(dev, wrapped_fd,
 				&active_config) == LIBUSB_SUCCESS) {
-			usbi_dbg(ctx, "active configuration %d for wrapped device from sysfs",
+			usbi_dbg(ctx, "active configuration %d for wrapped device from sysfs bConfigurationValue",
 				 active_config);
 			priv->active_config = active_config;
 			return LIBUSB_SUCCESS;
 		}
-		usbi_dbg(ctx, "no sysfs answer for wrapped device, asking the device");
+		usbi_dbg(ctx, "no sysfs bConfigurationValue for wrapped device, asking the device");
 	}
 
 	if (wrapped_fd < 0)
@@ -1789,19 +1784,26 @@ static int op_get_configuration(struct libusb_device_handle *handle,
 
 			active_config = priv->active_config;
 
-			/* The request stays: it is what reports a disconnect,
-			 * and this function is documented to do that. For a
-			 * wrapped descriptor its answer is not the one to keep
-			 * though -- initialize_device() already preferred the
-			 * kernel's, and this call would otherwise write the
-			 * device's answer back over it, which is the cache
-			 * op_get_active_config_descriptor() goes on to use. */
+			/* usbfs_get_active_config() has already written
+			 * priv->active_config: the device's answer, or a
+			 * config_descriptors[0] guess when the request fails
+			 * with anything but ENODEV. This arm overwrites it
+			 * with the sysfs bConfigurationValue; it does not
+			 * prevent the write. priv->active_config is the cache
+			 * op_get_active_config_descriptor() reads.
+			 *
+			 * The request itself stays. It is what reports a
+			 * disconnect, and libusb_get_configuration() is
+			 * documented to return LIBUSB_ERROR_NO_DEVICE when the
+			 * device has been disconnected. */
 			if (hpriv->fd_keep &&
 			    wrapped_fd_get_active_config(handle->dev, hpriv->fd,
 					&kernel_config) == LIBUSB_SUCCESS) {
 				if (kernel_config != active_config)
 					usbi_dbg(usbi_handle_ctx(handle),
-						 "device reports configuration %d but the kernel reports %d, keeping the kernel's",
+						 "device reports active configuration %d, "
+						 "sysfs bConfigurationValue reports %d, "
+						 "keeping the sysfs value",
 						 active_config, kernel_config);
 				priv->active_config = kernel_config;
 				active_config = kernel_config;

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -710,18 +710,16 @@ static int open_sysfs_attr(struct libusb_context *ctx,
 	return fd;
 }
 
-/* Note only suitable for attributes which always read >= 0, < 0 is error */
-static int read_sysfs_attr(struct libusb_context *ctx,
-	const char *sysfs_dir, const char *attr, int max_value, int *value_p)
+/* Note only suitable for attributes which always read >= 0, < 0 is error.
+ * Takes ownership of fd and closes it. */
+static int parse_sysfs_attr_fd(struct libusb_context *ctx, int fd,
+	const char *attr, int max_value, int *value_p)
 {
 	char buf[20], *endptr;
 	long value;
 	ssize_t r;
-	int fd;
 
-	fd = open_sysfs_attr(ctx, sysfs_dir, attr);
-	if (fd < 0)
-		return fd;
+	UNUSED(attr);  /* only referenced by usbi_err(), a no-op without logging */
 
 	r = read(fd, buf, sizeof(buf) - 1);
 	if (r < 0) {
@@ -783,6 +781,19 @@ static int read_sysfs_attr(struct libusb_context *ctx,
 	return 0;
 }
 
+/* Note only suitable for attributes which always read >= 0, < 0 is error */
+static int read_sysfs_attr(struct libusb_context *ctx,
+	const char *sysfs_dir, const char *attr, int max_value, int *value_p)
+{
+	int fd;
+
+	fd = open_sysfs_attr(ctx, sysfs_dir, attr);
+	if (fd < 0)
+		return fd;
+
+	return parse_sysfs_attr_fd(ctx, fd, attr, max_value, value_p);
+}
+
 static int sysfs_scan_device(struct libusb_context *ctx, const char *devname)
 {
 	uint8_t busnum, devaddr;
@@ -811,26 +822,34 @@ static int sysfs_get_active_config(struct libusb_device *dev, int *config)
  * normally asked of the device itself with a GET_CONFIGURATION request. The
  * kernel already knows the answer and publishes the mapping needed to find
  * it: a usbfs node is a character device, and /sys/dev/char/<major>:<minor>
- * is a symlink to the owning device's sysfs directory, whose basename is the
- * same "1-4" form priv->sysfs_dir holds. The node's device numbers come from
- * the sysfs "dev" attribute udev read when it created the node, and
- * linux_get_device_address() already trusts this file descriptor's identity
- * when it reads the bus number and address out of the node's name, so
- * resolving the same file descriptor's device numbers through the kernel's
- * own mapping introduces no new source of trust.
+ * is a symlink to the owning device's sysfs directory. The attribute is
+ * opened through that link, never through a copy of the directory name: the
+ * kernel can give the "1-4" style name to a new device the moment this one
+ * disconnects, so the link must be resolved at open time.
+ *
+ * The value read is trusted only if USBDEVFS_GET_CAPABILITIES on the
+ * wrapped fd then proves the device is still connected. The kernel answers
+ * that ioctl from memory, without bus traffic. usbfs checks the connection
+ * before it decodes the command, so success is proof, and so is ENOTTY
+ * from a kernel that predates the ioctl. Any other result is not: ENODEV
+ * means the device is gone, and EPERM means the fd was opened without
+ * write access and can prove nothing. A usbfs fd never comes back once its
+ * device disconnects, so an fd that is connected after the read was
+ * connected throughout it, and the value is its own.
  *
  * Any failure at any step is not an error: the caller falls back to asking
- * the device, which is what it did before. All failures collapse to
- * LIBUSB_ERROR_NOT_SUPPORTED so no caller is tempted to report one.
+ * the device, which is what it did before, and for a disconnected fd that
+ * request path is what reports LIBUSB_ERROR_NO_DEVICE. All failures collapse
+ * to LIBUSB_ERROR_NOT_SUPPORTED so no caller is tempted to report one.
  */
 static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 	int *config)
 {
-	struct libusb_context *ctx = DEVICE_CTX(dev);
-	char link[64], target[PATH_MAX], *name;
+	struct libusb_context *ctx = usbi_device_ctx(dev);
+	char path[64];
 	struct stat st;
-	ssize_t len;
-	int active, r;
+	uint32_t caps;
+	int active, attr_fd, r;
 
 	if (!sysfs_available)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
@@ -838,26 +857,26 @@ static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
 	if (fstat(fd, &st) < 0 || !S_ISCHR(st.st_mode))
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
-	snprintf(link, sizeof(link), "/sys/dev/char/%u:%u",
+	snprintf(path, sizeof(path),
+		SYSFS_MOUNT_PATH "/dev/char/%u:%u/bConfigurationValue",
 		major(st.st_rdev), minor(st.st_rdev));
 
-	len = readlink(link, target, sizeof(target) - 1);
-	if (len < 0)
-		return LIBUSB_ERROR_NOT_SUPPORTED;
-	target[len] = '\0';
-
-	name = strrchr(target, '/');
-	name = name ? name + 1 : target;
-	if (*name == '\0')
+	attr_fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (attr_fd < 0)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
-	r = read_sysfs_attr(ctx, name, "bConfigurationValue", UINT8_MAX, &active);
+	r = parse_sysfs_attr_fd(ctx, attr_fd, "bConfigurationValue", UINT8_MAX,
+		&active);
 	if (r < 0)
 		return LIBUSB_ERROR_NOT_SUPPORTED;
 
+	r = ioctl(fd, IOCTL_USBFS_GET_CAPABILITIES, &caps);
+	if (r < 0 && errno != ENOTTY)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
 	/* An unconfigured device leaves the attribute empty, which
-	 * read_sysfs_attr() already reports as -1. Reaching this line with a 0
-	 * means the kernel named configuration 0, so decide it the way the
+	 * parse_sysfs_attr_fd() already reports as -1. Reaching this line with
+	 * a 0 means the kernel named configuration 0, so decide it the way the
 	 * request path decides the same answer. */
 	if (active == 0 && !dev_has_config0(dev))
 		active = -1;
@@ -1777,7 +1796,7 @@ static int op_get_configuration(struct libusb_device_handle *handle,
 			    wrapped_fd_get_active_config(handle->dev, hpriv->fd,
 					&kernel_config) == LIBUSB_SUCCESS) {
 				if (kernel_config != active_config)
-					usbi_dbg(HANDLE_CTX(handle),
+					usbi_dbg(usbi_handle_ctx(handle),
 						 "device reports configuration %d but the kernel reports %d, keeping the kernel's",
 						 active_config, kernel_config);
 				priv->active_config = kernel_config;

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -693,9 +693,13 @@ static int open_sysfs_attr(struct libusb_context *ctx,
 	const char *sysfs_dir, const char *attr)
 {
 	char filename[256];
-	int fd;
+	int fd, r;
 
-	snprintf(filename, sizeof(filename), SYSFS_DEVICE_PATH "/%s/%s", sysfs_dir, attr);
+	r = snprintf(filename, sizeof(filename), SYSFS_DEVICE_PATH "/%s/%s", sysfs_dir, attr);
+	if (r < 0 || r >= (int)sizeof(filename)) {
+		usbi_err(ctx, "sysfs attribute path %s/%s too long", sysfs_dir, attr);
+		return LIBUSB_ERROR_OTHER;
+	}
 	fd = open(filename, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		if (errno == ENOENT) {

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -36,6 +36,8 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/utsname.h>
 #include <sys/vfs.h>
 #include <unistd.h>
@@ -798,6 +800,69 @@ static int sysfs_get_active_config(struct libusb_device *dev, int *config)
 			UINT8_MAX, config);
 }
 
+/* read the bConfigurationValue for a device we only have a usbfs file
+ * descriptor for, i.e. one that came in through libusb_wrap_sys_device().
+ *
+ * Such a device has no priv->sysfs_dir, so the active configuration is
+ * normally asked of the device itself with a GET_CONFIGURATION request. The
+ * kernel already knows the answer and publishes the mapping needed to find
+ * it: a usbfs node is a character device, and /sys/dev/char/<major>:<minor>
+ * is a symlink to the owning device's sysfs directory, whose basename is the
+ * same "1-4" form priv->sysfs_dir holds. The node's device numbers come from
+ * the sysfs "dev" attribute udev read when it created the node, and
+ * linux_get_device_address() already trusts this file descriptor's identity
+ * when it reads the bus number and address out of the node's name, so
+ * resolving the same file descriptor's device numbers through the kernel's
+ * own mapping introduces no new source of trust.
+ *
+ * Any failure at any step is not an error: the caller falls back to asking
+ * the device, which is what it did before. All failures collapse to
+ * LIBUSB_ERROR_NOT_SUPPORTED so no caller is tempted to report one.
+ */
+static int wrapped_fd_get_active_config(struct libusb_device *dev, int fd,
+	int *config)
+{
+	struct libusb_context *ctx = DEVICE_CTX(dev);
+	char link[64], target[PATH_MAX], *name;
+	struct stat st;
+	ssize_t len;
+	int active, r;
+
+	if (!sysfs_available)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	if (fstat(fd, &st) < 0 || !S_ISCHR(st.st_mode))
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	snprintf(link, sizeof(link), "/sys/dev/char/%u:%u",
+		major(st.st_rdev), minor(st.st_rdev));
+
+	len = readlink(link, target, sizeof(target) - 1);
+	if (len < 0)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+	target[len] = '\0';
+
+	name = strrchr(target, '/');
+	name = name ? name + 1 : target;
+	if (*name == '\0')
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	r = read_sysfs_attr(ctx, name, "bConfigurationValue", UINT8_MAX, &active);
+	if (r < 0)
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+
+	/* An unconfigured device leaves the attribute empty, which
+	 * read_sysfs_attr() already reports as -1. Reaching this line with a 0
+	 * means the kernel named configuration 0, so decide it the way the
+	 * request path decides the same answer. */
+	if (active == 0 && !dev_has_config0(dev))
+		active = -1;
+
+	*config = active;
+
+	return LIBUSB_SUCCESS;
+}
+
 int linux_get_device_address(struct libusb_context *ctx, int detached,
 	uint8_t *busnum, uint8_t *devaddr, const char *dev_node,
 	const char *sys_name, int fd)
@@ -1218,6 +1283,23 @@ static int initialize_device(struct libusb_device *dev, uint8_t busnum,
 	}
 
 	/* cache active config */
+	if (wrapped_fd >= 0) {
+		/* The device came in through libusb_wrap_sys_device(), which
+		 * is documented not to send requests over the bus when the
+		 * kernel can describe the wrapped device. Ask the kernel, and
+		 * only fall back to asking the device if it cannot be. */
+		int active_config;
+
+		if (wrapped_fd_get_active_config(dev, wrapped_fd,
+				&active_config) == LIBUSB_SUCCESS) {
+			usbi_dbg(ctx, "active configuration %d for wrapped device from sysfs",
+				 active_config);
+			priv->active_config = active_config;
+			return LIBUSB_SUCCESS;
+		}
+		usbi_dbg(ctx, "no sysfs answer for wrapped device, asking the device");
+	}
+
 	if (wrapped_fd < 0)
 		fd = get_usbfs_fd(dev, O_RDWR, 1);
 	else
@@ -1675,8 +1757,29 @@ static int op_get_configuration(struct libusb_device_handle *handle,
 		struct linux_device_handle_priv *hpriv = (struct linux_device_handle_priv *)usbi_get_device_handle_priv(handle);
 
 		r = usbfs_get_active_config(handle->dev, hpriv->fd);
-		if (r == LIBUSB_SUCCESS)
+		if (r == LIBUSB_SUCCESS) {
+			int kernel_config;
+
 			active_config = priv->active_config;
+
+			/* The request stays: it is what reports a disconnect,
+			 * and this function is documented to do that. For a
+			 * wrapped descriptor its answer is not the one to keep
+			 * though -- initialize_device() already preferred the
+			 * kernel's, and this call would otherwise write the
+			 * device's answer back over it, which is the cache
+			 * op_get_active_config_descriptor() goes on to use. */
+			if (hpriv->fd_keep &&
+			    wrapped_fd_get_active_config(handle->dev, hpriv->fd,
+					&kernel_config) == LIBUSB_SUCCESS) {
+				if (kernel_config != active_config)
+					usbi_dbg(HANDLE_CTX(handle),
+						 "device reports configuration %d but the kernel reports %d, keeping the kernel's",
+						 active_config, kernel_config);
+				priv->active_config = kernel_config;
+				active_config = kernel_config;
+			}
+		}
 	}
 	if (r < 0)
 		return r;


### PR DESCRIPTION
Read a wrapped device's active configuration from the sysfs bConfigurationValue instead of asking the device. Against master
`c75357cd`: two files, 144 insertions / 13 deletions — `libusb/os/linux_usbfs.c` and one Doxygen note in `libusb/core.c`.

## The defect

`libusb_wrap_sys_device()` passes `sysfs_dir = NULL` to `initialize_device()`, so the sysfs path is skipped and the active
configuration is asked of the device with a `GET_CONFIGURATION` request. An Intel 8087:0032 Bluetooth radio answers **0** to
that request while its sysfs bConfigurationValue is **1** and `bNumConfigurations` is 1; the device declares no configuration 0,
so `priv->active_config` becomes `-1` and stays there. Measured on an ASUS G513RM, radio at `/dev/bus/usb/001/003` (sysfs
`1-4`), always with `LIBUSB_OPTION_NO_DEVICE_DISCOVERY` — which is what `libusb_wrap_sys_device()` exists for and what silences
the init-time sysfs scan, so every sysfs access is the code under test:

| | baseline | with this patch |
|---|---|---|
| `libusb_get_configuration()` | **0** (wrong) | **1** |
| `libusb_get_active_config_descriptor()` | **-5 NOT_FOUND** (wrong) | 0, `bConfigurationValue = 1`, `bNumInterfaces = 2` |
| control transfers on the wire, per run | 2 | **1** |
| ASUS N-KEY keyboard `1-3`, regression control | 1 / OK | 1 / OK, unchanged |

Correct in both call orders and under a descriptor re-check after `get_configuration()`. Two transfers become one, not zero: the
wrap-time transfer is gone, the one inside `libusb_get_configuration()` stays on purpose.

## What the patch does

`wrapped_fd_get_active_config()`, gated on `sysfs_available`, `fstat()`s the wrapped descriptor and requires `S_ISCHR`; opens
`/sys/dev/char/<major>:<minor>/bConfigurationValue` **through the symlink**; reads it with `parse_sysfs_attr_fd()`, the numeric
parser `read_sysfs_attr()` now shares; and accepts the value only if `IOCTL_USBFS_GET_CAPABILITIES` on the wrapped fd then
answers 0, or `ENOTTY` from a kernel older than the ioctl. The directory name is never copied and never resolved to a name
first: the kernel can give a name like `1-4` to a new device as soon as this one disconnects, so the link must resolve at open
time.

On a live fd the ioctl returned 0 and usbmon
captured zero URBs from it; on a staged disconnect it returned `ENODEV`, as did `CONNECTINFO`, `GET_SPEED`, `GETDRIVER` and
`CONTROL` on the same kept fd; on an fd opened `O_RDONLY` every usbfs ioctl tried returned `EPERM`, with the device attached and
again after it was gone, so `EPERM` separates nothing.

An empty attribute means an unconfigured device and arrives as `-1`. A real `0` is resolved the way the request path resolves
it, `if (active == 0 && !dev_has_config0(dev)) active = -1;`. Every failure at every step returns `LIBUSB_ERROR_NOT_SUPPORTED`,
and both call sites test `== LIBUSB_SUCCESS` only, so none reaches a user.

Also in this branch: `read_sysfs_attr()` splits into `open_sysfs_attr()` plus `parse_sysfs_attr_fd()` so the wrapped path can
read an attribute from a descriptor it opened itself, and the side that opens the fd closes it; `open_sysfs_attr()` fails
instead of truncating a path that does not fit, as a separate commit; `priv->sysfs_dir` is never set, no field is added, and
`op_get_active_config_descriptor()` is untouched, so its zero-I/O property holds; the `libusb_wrap_sys_device()` Doxygen note
names the one exception to "sends no requests over the bus"; and `<sys/sysmacros.h>` is a first use in the tree —
bionic ships `major()`/`minor()` as plain macros, read from its source.

## Scope: why `op_get_configuration()` is also touched

The arm in `op_get_configuration()` is the second place this branch touches. The narrower scope — seed the cache in
`initialize_device()` only, leave that arm out — was built and measured on the same radio. In the default call order it is
byte-identical to the unpatched baseline:

| call | unpatched | seed only | seed + the arm |
|---|---|---|---|
| `libusb_get_active_config_descriptor()` | NOT_FOUND | OK | OK |
| `libusb_get_configuration()` | 0 | 0 | 1 |
| the same descriptor call again | NOT_FOUND | **NOT_FOUND** | OK |

`usbfs_get_active_config()` writes the device's answer into `priv->active_config`, the cache `op_get_active_config_descriptor()`
reads; a correct seed that the first `libusb_get_configuration()` erases is not a fix. So the arm is cache protection,
not a fix to that function. The control request stays where it is: it is what reports `LIBUSB_ERROR_NO_DEVICE` on disconnect.
The sysfs bConfigurationValue replaces the device's answer only after that request returns `LIBUSB_SUCCESS` and only when
`hpriv->fd_keep` says the handle came through `libusb_wrap_sys_device()` — set at exactly one place, `op_wrap_sys_device()`.

## The minor-recycle race, realized on hardware

Staged with a `dummy_hcd` configfs gadget: device A (configuration 1, char device 189:1153) is wrapped, then unbind +
`dummy_hcd` reload + rebind enumerate device B as `10-1` with **A's minor** and configuration 2. Open-by-name on A's dead fd
reads **2**, B's value; this design opens through the link, reads 2, probes, gets `ENODEV`, and rejects it. Name-only reuse
(rebind, no reload) also reads B's value, which open-by-name survives only because the minor dangles.

## Limitation: an unprivileged wrap gets no saving

On an `O_RDONLY` wrapped fd the sysfs bConfigurationValue is read correctly and then discarded: every usbfs ioctl on such an fd
returned `EPERM`, measured with the device attached and again after it was gone, so the accept rule can never be met. The
`GET_CONFIGURATION` that follows returns `EPERM` too, and libusb answers from `config_descriptors[0]`. Probe tool
(`disctest`), fd opened `O_RDONLY` on the live `dummy_hcd` gadget used for the staged run above:

```
ioctl GET_CAPABILITIES rc=-1 errno=1 (Operation not permitted)
ioctl CONTROL(GET_CFG) rc=-1 errno=1 (Operation not permitted)
```

The answer is right there only because the radio has one configuration; the saving applies to a writable wrapped fd.

## Degradation, unconfigured, and multi-configuration

Faults injected into unmodified binaries with a user + mount namespace: tmpfs over `/sys` and over `/sys/dev/char` are
byte-identical to the unpatched baseline, and tmpfs over `/sys/bus/usb/devices` still answers from the sysfs bConfigurationValue
in 1 transfer, because the link resolves under `/sys/devices`. `echo 0 > .../1-4/bConfigurationValue` left the radio really
unconfigured — attribute empty, `hci0` gone — and both call orders gave `config = 0` and `NOT_FOUND` before and after, in 1
transfer instead of 2. A two-configuration `dummy_hcd` gadget (`1d6b:0104`, minor `1153 = (10-1)*128 + (2-1)`) matches the
baseline's values in 1 transfer at active = 1, active = 2 and unconfigured; active = 2 is decisive, since a guess answers 1.

## Build and test

16 gcc 16.2.1 `-Werror` configurations per tree, cell by cell: four logging modes × udev and no-udev at `-O2`; default and
`--disable-log` at `-O3`; `-O0`, `-O1` and `-Os` with default and disabled logging. Master `c75357cd` and this branch are clean
in all 16; `3649cc72`, the head before the truncation fix, fails 4 — `-O2 --disable-log` with and without udev, both `-O3`.

`make check` with `--enable-tests-build`: 5/5 PASS on master and on this branch. Under `.private/ci-build.sh --werror --
--enable-udev` the `umockdev` case fails on **both** trees with a byte-identical ASan exit-time leak summary, 115933 bytes in
8213 allocations; with `ASAN_OPTIONS=detect_leaks=0` it is 5/5 on both. `make -C doc` exits 0 on both trees, with the same
pre-existing doxygen warnings and none at a changed line.

## Intentional behaviour changes

1. A device whose `GET_CONFIGURATION` request fails no longer keeps the `config_descriptors[0]` guess when the sysfs
   bConfigurationValue is available. Reasoned from the code; no such device was observed.
2. A device that is unconfigured **and** declares a configuration 0 now reports unconfigured, per the documented contract.

## Not measured

A device with a real configuration 0: the `active == 0 && !dev_has_config0(dev)` arm has never executed, because configfs refuses
`configs/c.0` on this kernel. A stalling device whose request fails while the sysfs read succeeds — change 1 above. Android and
SELinux end to end (waived), an NDK compile of the two new includes, big-endian, and the non-Linux backends this does not touch.
32-bit is compile-tested only.

Fixes: #1925

Assisted-by: claude-code:claude-opus-5
