### PR TITLE
windows hotplug: only announce devices once a scan proves them usable

### DIFF
--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -247,7 +247,15 @@ struct winusb_device_priv {
 	bool initialized;
 #if defined(LIBUSB_WINDOWS_HOTPLUG)
 	bool seen_during_scan; // set true for each device encountered during windows_get_device_list
-	bool seen_before_scan; // set true for each device encountered before windows_get_device_list
+	// DEVICE_ARRIVED is withheld until a scan proves the device usable, or
+	// proves that nothing usable is coming; the device stays attached so
+	// its child devnodes keep resolving to it (windows_resolve_pending_announcements)
+	bool announce_pending;
+	// Driver stack seen fully settled by an earlier scan: if the next scan
+	// still yields nothing usable, none is coming
+	bool settled_observed;
+	// DEVICE_ARRIVED was fired; DEVICE_LEFT is only fired for announced devices
+	bool announced;
 #endif
 	bool root_hub;
 	uint8_t active_config;

--- a/libusb/os/windows_common.h
+++ b/libusb/os/windows_common.h
@@ -254,6 +254,9 @@ struct winusb_device_priv {
 	// Driver stack seen fully settled by an earlier scan: if the next scan
 	// still yields nothing usable, none is coming
 	bool settled_observed;
+	// When this device's announcement was first withheld: the give-up
+	// ceiling is counted per device, not for the monitor as a whole
+	ULONGLONG pending_since;
 	// DEVICE_ARRIVED was fired; DEVICE_LEFT is only fired for announced devices
 	bool announced;
 #endif

--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -40,8 +40,13 @@
  *    has proven them usable, or proven that they never will be, because
  *    Windows makes devices visible before their driver stack is up (see
  *    windows_resolve_pending_announcements). A retry timer re-examines
- *    still-pending devices, and after HOTPLUG_SETTLE_MAX_WAIT_MS one scan
- *    runs with deferral disabled so nothing stays unannounced forever.
+ *    still-pending devices, and a device withheld for more than
+ *    HOTPLUG_SETTLE_MAX_WAIT_MS is announced as-is, so nothing stays
+ *    unannounced forever.
+ *
+ * All of this bookkeeping lives in struct winusb_device_priv, so it only runs
+ * for contexts served by the WinUSB backend: a context that selected UsbDk
+ * stores a different structure in the same memory (see #1920, item 4).
  */
 
 #define HOTPLUG_DEBOUNCE_TIMER_ID       1
@@ -52,14 +57,14 @@
 #define HOTPLUG_SETTLE_RETRY_MS         500
 #define HOTPLUG_SETTLE_MAX_WAIT_MS      5000
 
-// Posted to the notification window (possibly from another thread) when a
-// device stays announce-pending, so the event thread schedules a retry scan
-#define WM_LIBUSB_SETTLE_KICK           (WM_APP + 0)
+// libusb_init must not return while a device is still withheld: the
+// application enumerates the device list right after, and a device announced
+// later would be reported twice. Devices present at startup are settled long
+// ago, so this only bounds the rare case of one arriving at the same moment.
+#define HOTPLUG_INITIAL_SETTLE_MAX_MS   500
+#define HOTPLUG_INITIAL_SETTLE_POLL_MS  100
 
 static ULONGLONG first_debounce_tick;
-static ULONGLONG settle_wait_start_tick;
-static volatile LONG scan_deferred_count;
-static volatile LONG defer_arrivals = 1;
 static HWND windows_event_hwnd;
 static HANDLE windows_event_thread_handle;
 static DWORD WINAPI windows_event_thread_main(LPVOID lpParam);
@@ -178,11 +183,23 @@ static int windows_get_device_list(struct libusb_context *ctx)
 	return ((struct windows_context_priv *)usbi_get_context_priv(ctx))->backend->get_device_list(ctx, NULL);
 }
 
+// Whether this context is served by the WinUSB backend, i.e. whether its
+// devices carry the struct winusb_device_priv this file reads and writes.
+// A UsbDk context stores struct usbdk_device_priv in the same memory, where
+// these fields would land in the middle of a device ID.
+static bool ctx_uses_winusb(struct libusb_context *ctx)
+{
+	return ((struct windows_context_priv *)usbi_get_context_priv(ctx))->backend == &winusb_backend;
+}
+
 // Resolve withheld announcements once a scan has run all of its passes.
-// kick_if_pending schedules a retry scan for every device left pending: the
-// first of the two initial-scan resolves passes false, since it only exists
-// to record settled_observed for the immediately following second resolve.
-static void windows_resolve_pending_announcements(struct libusb_context *ctx, bool kick_if_pending)
+//
+// A withheld device stays attached, so libusb_get_device_list still lists it:
+// that is what lets its child devnodes resolve to it while the driver stack
+// comes up. libusb_init therefore completes this decision before returning
+// (see windows_initial_scan_devices), so that the enumeration performed by
+// LIBUSB_HOTPLUG_ENUMERATE never races it.
+static void windows_resolve_pending_announcements(struct libusb_context *ctx)
 {
 	struct libusb_device *dev;
 
@@ -195,7 +212,7 @@ static void windows_resolve_pending_announcements(struct libusb_context *ctx, bo
 			continue;
 		}
 
-		if (!windows_hotplug_defer_arrivals() || windows_hotplug_device_usable(dev))
+		if (windows_hotplug_device_usable(dev))
 		{
 			priv->announce_pending = false;
 		}
@@ -204,6 +221,14 @@ static void windows_resolve_pending_announcements(struct libusb_context *ctx, bo
 			// Was already settled before this scan and still yields nothing
 			// usable: nothing is coming, announce the device as-is
 			usbi_dbg(ctx, "device '%s' settled without becoming usable, announcing it as-is", priv->dev_id);
+			priv->announce_pending = false;
+		}
+		else if (GetTickCount64() - priv->pending_since >= HOTPLUG_SETTLE_MAX_WAIT_MS)
+		{
+			// Counted per device: a device that just started waiting must not
+			// inherit the deadline of one that has been waiting for seconds.
+			usbi_warn(ctx, "device '%s' did not become usable within %d ms, announcing it as-is",
+				priv->dev_id, HOTPLUG_SETTLE_MAX_WAIT_MS);
 			priv->announce_pending = false;
 		}
 		else
@@ -215,13 +240,26 @@ static void windows_resolve_pending_announcements(struct libusb_context *ctx, bo
 				// snapshot postdates this observation, decide usability
 				priv->settled_observed = true;
 			}
-			if (kick_if_pending)
-			{
-				usbi_dbg(ctx, "deferring arrival of device '%s' until its driver stack has settled", priv->dev_id);
-				windows_hotplug_arrival_deferred();
-			}
+			usbi_dbg(ctx, "deferring arrival of device '%s' until its driver stack has settled", priv->dev_id);
 		}
 	}
+}
+
+static bool ctx_has_pending_announcement(struct libusb_context *ctx)
+{
+	struct libusb_device *dev;
+
+	for_each_device(ctx, dev)
+	{
+		const struct winusb_device_priv *priv = (const struct winusb_device_priv *)usbi_get_device_priv(dev);
+
+		if (priv->initialized && priv->announce_pending)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void windows_initial_scan_devices(struct libusb_context *ctx)
@@ -230,27 +268,66 @@ void windows_initial_scan_devices(struct libusb_context *ctx)
 
 	usbi_mutex_static_lock(&active_contexts_lock);
 
-	const int ret =  windows_get_device_list(ctx);
+	int ret = windows_get_device_list(ctx);
 	if (ret != LIBUSB_SUCCESS)
 	{
 		usbi_err(ctx, "hotplug failed to retrieve initial list with error: %s", libusb_error_name(ret));
 	}
 
-	// Resolve twice: devices present at initialization have long been stable,
-	// so a settled-without-usable observation can be acted upon immediately.
-	// Only devices genuinely mid-bring-up stay pending.
-	windows_resolve_pending_announcements(ctx, false);
-	windows_resolve_pending_announcements(ctx, true);
-
-	// Devices present at initialization are delivered through
-	// LIBUSB_HOTPLUG_ENUMERATE: mark them announced so the first refresh
-	// does not re-announce them
-	for_each_device(ctx, dev)
+	if (ctx_uses_winusb(ctx))
 	{
-		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
-		if (priv->initialized && !priv->announce_pending)
+		// These devices reach the application through LIBUSB_HOTPLUG_ENUMERATE,
+		// which simply lists what is attached. The announcement decision must
+		// therefore be complete before returning: a device left pending would
+		// be enumerated while still unusable, then announced a second time by
+		// the scan that releases it.
+		const ULONGLONG deadline = GetTickCount64() + HOTPLUG_INITIAL_SETTLE_MAX_MS;
+
+		for (;;)
 		{
-			priv->announced = true;
+			// Devices present at startup settled long ago, so the second pass
+			// releases them at once, acting on what the first observed.
+			windows_resolve_pending_announcements(ctx);
+			windows_resolve_pending_announcements(ctx);
+
+			if (!ctx_has_pending_announcement(ctx))
+			{
+				break;
+			}
+
+			if (GetTickCount64() >= deadline)
+			{
+				usbi_dbg(ctx, "some devices were still coming up after %d ms, listing them as they are",
+					HOTPLUG_INITIAL_SETTLE_MAX_MS);
+				break;
+			}
+
+			// Give the driver stack time to progress, then look again: the
+			// interface paths of a device being brought up appear in a later
+			// scan, not in the snapshot this one has already taken. This is
+			// the only place that waits while holding active_contexts_lock,
+			// and only for a device that is arriving as libusb starts.
+			Sleep(HOTPLUG_INITIAL_SETTLE_POLL_MS);
+
+			ret = windows_get_device_list(ctx);
+			if (ret != LIBUSB_SUCCESS)
+			{
+				usbi_err(ctx, "hotplug failed to refresh the initial list with error: %s", libusb_error_name(ret));
+				break;
+			}
+		}
+
+		for_each_device(ctx, dev)
+		{
+			struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
+
+			if (priv->initialized)
+			{
+				// Part of the list the application enumerates, whether or not
+				// it settled in time: no DEVICE_ARRIVED for it later.
+				priv->announce_pending = false;
+				priv->announced = true;
+			}
 		}
 	}
 
@@ -260,6 +337,22 @@ void windows_initial_scan_devices(struct libusb_context *ctx)
 static void windows_refresh_device_list(struct libusb_context *ctx)
 {
 	struct libusb_device *dev, *next_dev;
+
+	if (!ctx_uses_winusb(ctx))
+	{
+		// Every field used below belongs to struct winusb_device_priv, and a
+		// UsbDk context stores something else there: reading them would
+		// interpret a device ID as flags and pointers, and writing them would
+		// corrupt that ID. Keep the device list current (the UsbDk backend
+		// announces its own arrivals through usbi_connect_device) and leave
+		// hotplug support for that backend to #1920, item 4.
+		const int usbdk_ret = windows_get_device_list(ctx);
+		if (usbdk_ret != LIBUSB_SUCCESS)
+		{
+			usbi_err(ctx, "hotplug failed to retrieve current list with error: %s", libusb_error_name(usbdk_ret));
+		}
+		return;
+	}
 
 	// Step 1: clear seen_during_scan so the scan can mark which devices are
 	// still physically present.
@@ -280,7 +373,7 @@ static void windows_refresh_device_list(struct libusb_context *ctx)
 	}
 
 	// Step 2.5: decide which withheld announcements can be released
-	windows_resolve_pending_announcements(ctx, true);
+	windows_resolve_pending_announcements(ctx);
 
 	// Step 3: diff old vs new.
 	for_each_device_safe(ctx, dev, next_dev)
@@ -310,51 +403,42 @@ static void windows_refresh_device_list(struct libusb_context *ctx)
 	}
 }
 
-static void windows_refresh_device_list_for_all_ctx(void)
+// Returns true when at least one device is still waiting to be announced.
+static bool windows_refresh_device_list_for_all_ctx(void)
 {
+	bool pending = false;
+
 	usbi_mutex_static_lock(&active_contexts_lock);
 
 	struct libusb_context *ctx;
 	for_each_context(ctx)
 	{
 		windows_refresh_device_list(ctx);
+
+		if (ctx_uses_winusb(ctx) && ctx_has_pending_announcement(ctx))
+		{
+			pending = true;
+		}
 	}
 
 	usbi_mutex_static_unlock(&active_contexts_lock);
+
+	return pending;
 }
 
-bool windows_hotplug_defer_arrivals(void)
-{
-	return InterlockedCompareExchange(&defer_arrivals, 0, 0) != 0;
-}
-
-void windows_hotplug_arrival_deferred(void)
-{
-	InterlockedIncrement(&scan_deferred_count);
-
-	// The window exists by the time a scan can run; be defensive during
-	// monitor teardown, a missed kick only delays the re-examination
-	const HWND hwnd = windows_event_hwnd;
-	if (hwnd != NULL)
-	{
-		PostMessage(hwnd, WM_LIBUSB_SETTLE_KICK, 0, 0);
-	}
-}
-
-// Run a scan and maintain the settle-wait state accordingly. Event thread only.
+// Run a scan and keep the retry timer in step with it. Event thread only.
 static void windows_scan_for_hotplug_events(HWND hwnd)
 {
-	InterlockedExchange(&scan_deferred_count, 0);
-
-	windows_refresh_device_list_for_all_ctx();
-
-	if (InterlockedCompareExchange(&scan_deferred_count, 0, 0) == 0)
+	// Whether to retry is decided by the device list itself, not by what this
+	// scan did: a scan that failed leaves its devices pending and therefore
+	// keeps the timer armed, instead of silently dropping the retry.
+	if (windows_refresh_device_list_for_all_ctx())
 	{
-		// Nothing deferred: end the settle-wait window. Otherwise the
-		// posted WM_LIBUSB_SETTLE_KICK messages (re)arm the retry timer,
-		// or give up once the wait ceiling is reached.
+		SetTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID, HOTPLUG_SETTLE_RETRY_MS, NULL);
+	}
+	else
+	{
 		KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
-		settle_wait_start_tick = 0;
 	}
 }
 
@@ -531,41 +615,10 @@ static LRESULT CALLBACK windows_proc_callback(
 		}
 		return DefWindowProc(hwnd, message, wParam, lParam);
 
-	case WM_LIBUSB_SETTLE_KICK:
-	{
-		const ULONGLONG now = GetTickCount64();
-
-		if (settle_wait_start_tick == 0)
-		{
-			settle_wait_start_tick = now;
-		}
-
-		if (now - settle_wait_start_tick >= HOTPLUG_SETTLE_MAX_WAIT_MS)
-		{
-			// Wait ceiling reached: run one scan with deferral disabled,
-			// announcing everything as-is so nothing stays unannounced
-			// forever. Announced devices are never deferred again, so
-			// this cannot loop.
-			KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
-			settle_wait_start_tick = 0;
-			InterlockedExchange(&defer_arrivals, 0);
-			windows_scan_for_hotplug_events(hwnd);
-			InterlockedExchange(&defer_arrivals, 1);
-		}
-		else
-		{
-			// The retry timer guarantees a re-examination even if the
-			// settling generates no further device tree broadcast
-			SetTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID, HOTPLUG_SETTLE_RETRY_MS, NULL);
-		}
-		return 0;
-	}
-
 	case WM_CLOSE:
 		KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
 		KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
 		first_debounce_tick = 0;
-		settle_wait_start_tick = 0;
 		if (!DestroyWindow(hwnd))
 		{
 			log_error("DestroyWindow");

--- a/libusb/os/windows_hotplug.c
+++ b/libusb/os/windows_hotplug.c
@@ -30,23 +30,36 @@
 #include <dbt.h>
 
 /* The Windows Hotplug system is a two steps process.
- * 1. We create a hidden window and listen for DBT_DEVNODES_CHANGED, which Windows
- *    broadcasts to all top-level windows whenever the device tree changes (no
- *    registration required). Multiple rapid events (e.g. a hub with many children)
- *    are coalesced via a short debounce timer so we only scan once the burst settles.
- *    A maximum delay ceiling guarantees a scan fires within a bounded time even
- *    during sustained bursts, preventing unbounded latency.
- * 2. Upon timer expiry, we snapshot the current device list, run a full re-enumeration
- *    via the Windows backend, then diff the result: newly found devices that have been
- *    successfully initialized generate DEVICE_ARRIVED events; devices that were not
- *    encountered by the re-enumeration (physically removed) generate DEVICE_LEFT events.
+ * 1. A hidden window listens for DBT_DEVNODES_CHANGED, which Windows
+ *    broadcasts to all top-level windows whenever the device tree changes.
+ *    Rapid bursts are coalesced by a short debounce timer, with a maximum
+ *    delay ceiling bounding the latency during sustained bursts.
+ * 2. Each expiry runs a full re-enumeration via the Windows backend, then
+ *    diffs the result: devices no longer present generate DEVICE_LEFT,
+ *    newly present devices generate DEVICE_ARRIVED - but only once a scan
+ *    has proven them usable, or proven that they never will be, because
+ *    Windows makes devices visible before their driver stack is up (see
+ *    windows_resolve_pending_announcements). A retry timer re-examines
+ *    still-pending devices, and after HOTPLUG_SETTLE_MAX_WAIT_MS one scan
+ *    runs with deferral disabled so nothing stays unannounced forever.
  */
 
 #define HOTPLUG_DEBOUNCE_TIMER_ID       1
 #define HOTPLUG_DEBOUNCE_MS             10
 #define HOTPLUG_DEBOUNCE_MAX_DELAY_MS   100
 
+#define HOTPLUG_SETTLE_TIMER_ID         2
+#define HOTPLUG_SETTLE_RETRY_MS         500
+#define HOTPLUG_SETTLE_MAX_WAIT_MS      5000
+
+// Posted to the notification window (possibly from another thread) when a
+// device stays announce-pending, so the event thread schedules a retry scan
+#define WM_LIBUSB_SETTLE_KICK           (WM_APP + 0)
+
 static ULONGLONG first_debounce_tick;
+static ULONGLONG settle_wait_start_tick;
+static volatile LONG scan_deferred_count;
+static volatile LONG defer_arrivals = 1;
 static HWND windows_event_hwnd;
 static HANDLE windows_event_thread_handle;
 static DWORD WINAPI windows_event_thread_main(LPVOID lpParam);
@@ -165,8 +178,56 @@ static int windows_get_device_list(struct libusb_context *ctx)
 	return ((struct windows_context_priv *)usbi_get_context_priv(ctx))->backend->get_device_list(ctx, NULL);
 }
 
+// Resolve withheld announcements once a scan has run all of its passes.
+// kick_if_pending schedules a retry scan for every device left pending: the
+// first of the two initial-scan resolves passes false, since it only exists
+// to record settled_observed for the immediately following second resolve.
+static void windows_resolve_pending_announcements(struct libusb_context *ctx, bool kick_if_pending)
+{
+	struct libusb_device *dev;
+
+	for_each_device(ctx, dev)
+	{
+		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
+
+		if (!priv->initialized || !priv->announce_pending)
+		{
+			continue;
+		}
+
+		if (!windows_hotplug_defer_arrivals() || windows_hotplug_device_usable(dev))
+		{
+			priv->announce_pending = false;
+		}
+		else if (priv->settled_observed)
+		{
+			// Was already settled before this scan and still yields nothing
+			// usable: nothing is coming, announce the device as-is
+			usbi_dbg(ctx, "device '%s' settled without becoming usable, announcing it as-is", priv->dev_id);
+			priv->announce_pending = false;
+		}
+		else
+		{
+			if (windows_hotplug_device_settled(dev))
+			{
+				// Settled per live PnP state, which the scan's device
+				// interface snapshot may predate: let one more scan, whose
+				// snapshot postdates this observation, decide usability
+				priv->settled_observed = true;
+			}
+			if (kick_if_pending)
+			{
+				usbi_dbg(ctx, "deferring arrival of device '%s' until its driver stack has settled", priv->dev_id);
+				windows_hotplug_arrival_deferred();
+			}
+		}
+	}
+}
+
 void windows_initial_scan_devices(struct libusb_context *ctx)
 {
+	struct libusb_device *dev;
+
 	usbi_mutex_static_lock(&active_contexts_lock);
 
 	const int ret =  windows_get_device_list(ctx);
@@ -174,6 +235,25 @@ void windows_initial_scan_devices(struct libusb_context *ctx)
 	{
 		usbi_err(ctx, "hotplug failed to retrieve initial list with error: %s", libusb_error_name(ret));
 	}
+
+	// Resolve twice: devices present at initialization have long been stable,
+	// so a settled-without-usable observation can be acted upon immediately.
+	// Only devices genuinely mid-bring-up stay pending.
+	windows_resolve_pending_announcements(ctx, false);
+	windows_resolve_pending_announcements(ctx, true);
+
+	// Devices present at initialization are delivered through
+	// LIBUSB_HOTPLUG_ENUMERATE: mark them announced so the first refresh
+	// does not re-announce them
+	for_each_device(ctx, dev)
+	{
+		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
+		if (priv->initialized && !priv->announce_pending)
+		{
+			priv->announced = true;
+		}
+	}
+
 	usbi_mutex_static_unlock(&active_contexts_lock);
 }
 
@@ -181,25 +261,26 @@ static void windows_refresh_device_list(struct libusb_context *ctx)
 {
 	struct libusb_device *dev, *next_dev;
 
-	// Step 1: clear seen_during_scan so the scan can mark which devices are still
-	// physically present, and set seen_before_scan so we can distinguish newly
-	// created devices (which start with seen_before_scan=false via calloc).
+	// Step 1: clear seen_during_scan so the scan can mark which devices are
+	// still physically present.
 	for_each_device_safe(ctx, dev, next_dev)
 	{
 		struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 		priv->seen_during_scan = false;
-		priv->seen_before_scan = true;
 	}
 
-	// Step 2: re-enumerate — winusb_get_device_list attaches newly-arrived devices
-	// and sets seen_during_scan=true for every device it physically encounters.
-	// seen_before_scan is untouched and will be left in default state (false) for newly created devices, allowing us to identify them in the next step.
+	// Step 2: re-enumerate — winusb_get_device_list attaches newly-arrived
+	// devices (announce-pending) and sets seen_during_scan=true for every
+	// device it physically encounters.
 	const int ret = windows_get_device_list(ctx);
 	if (ret != LIBUSB_SUCCESS)
 	{
 		usbi_err(ctx, "hotplug failed to retrieve current list with error: %s", libusb_error_name(ret));
 		return;
 	}
+
+	// Step 2.5: decide which withheld announcements can be released
+	windows_resolve_pending_announcements(ctx, true);
 
 	// Step 3: diff old vs new.
 	for_each_device_safe(ctx, dev, next_dev)
@@ -209,25 +290,22 @@ static void windows_refresh_device_list(struct libusb_context *ctx)
 		if (!priv->seen_during_scan)
 		{
 			// Not encountered by the scan: device was physically removed.
-			if (priv->initialized)
+			if (priv->announced)
 			{
 				usbi_disconnect_device(dev); // fires DEVICE_LEFT
 			}
 			else
 			{
+				// Never announced: no DEVICE_LEFT message will drop the
+				// initial ref, drop it here to avoid a leak
 				usbi_detach_device(dev);
-				// No DEVICE_LEFT message is posted for uninitialized
-				// devices, so no message handler will drop the initial
-				// ref. We must drop it here to avoid a leak.
 				libusb_unref_device(dev);
 			}
 		}
-		else if (!priv->seen_before_scan)
+		else if (priv->initialized && !priv->announce_pending && !priv->announced)
 		{
-			if (priv->initialized)
-			{
-				usbi_hotplug_notification(ctx, dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
-			}
+			priv->announced = true;
+			usbi_hotplug_notification(ctx, dev, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
 		}
 	}
 }
@@ -243,6 +321,41 @@ static void windows_refresh_device_list_for_all_ctx(void)
 	}
 
 	usbi_mutex_static_unlock(&active_contexts_lock);
+}
+
+bool windows_hotplug_defer_arrivals(void)
+{
+	return InterlockedCompareExchange(&defer_arrivals, 0, 0) != 0;
+}
+
+void windows_hotplug_arrival_deferred(void)
+{
+	InterlockedIncrement(&scan_deferred_count);
+
+	// The window exists by the time a scan can run; be defensive during
+	// monitor teardown, a missed kick only delays the re-examination
+	const HWND hwnd = windows_event_hwnd;
+	if (hwnd != NULL)
+	{
+		PostMessage(hwnd, WM_LIBUSB_SETTLE_KICK, 0, 0);
+	}
+}
+
+// Run a scan and maintain the settle-wait state accordingly. Event thread only.
+static void windows_scan_for_hotplug_events(HWND hwnd)
+{
+	InterlockedExchange(&scan_deferred_count, 0);
+
+	windows_refresh_device_list_for_all_ctx();
+
+	if (InterlockedCompareExchange(&scan_deferred_count, 0, 0) == 0)
+	{
+		// Nothing deferred: end the settle-wait window. Otherwise the
+		// posted WM_LIBUSB_SETTLE_KICK messages (re)arm the retry timer,
+		// or give up once the wait ceiling is reached.
+		KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
+		settle_wait_start_tick = 0;
+	}
 }
 
 #define WND_CLASS_NAME TEXT("libusb-1.0-windows-hotplug")
@@ -391,7 +504,7 @@ static LRESULT CALLBACK windows_proc_callback(
 				// are not invisible for the entire duration of a sustained burst.
 				KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
 				first_debounce_tick = 0;
-				windows_refresh_device_list_for_all_ctx();
+				windows_scan_for_hotplug_events(hwnd);
 			}
 			else
 			{
@@ -407,14 +520,52 @@ static LRESULT CALLBACK windows_proc_callback(
 		{
 			KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
 			first_debounce_tick = 0;
-			windows_refresh_device_list_for_all_ctx();
+			windows_scan_for_hotplug_events(hwnd);
+			return 0;
+		}
+		if (wParam == HOTPLUG_SETTLE_TIMER_ID)
+		{
+			KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
+			windows_scan_for_hotplug_events(hwnd);
 			return 0;
 		}
 		return DefWindowProc(hwnd, message, wParam, lParam);
 
+	case WM_LIBUSB_SETTLE_KICK:
+	{
+		const ULONGLONG now = GetTickCount64();
+
+		if (settle_wait_start_tick == 0)
+		{
+			settle_wait_start_tick = now;
+		}
+
+		if (now - settle_wait_start_tick >= HOTPLUG_SETTLE_MAX_WAIT_MS)
+		{
+			// Wait ceiling reached: run one scan with deferral disabled,
+			// announcing everything as-is so nothing stays unannounced
+			// forever. Announced devices are never deferred again, so
+			// this cannot loop.
+			KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
+			settle_wait_start_tick = 0;
+			InterlockedExchange(&defer_arrivals, 0);
+			windows_scan_for_hotplug_events(hwnd);
+			InterlockedExchange(&defer_arrivals, 1);
+		}
+		else
+		{
+			// The retry timer guarantees a re-examination even if the
+			// settling generates no further device tree broadcast
+			SetTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID, HOTPLUG_SETTLE_RETRY_MS, NULL);
+		}
+		return 0;
+	}
+
 	case WM_CLOSE:
 		KillTimer(hwnd, HOTPLUG_DEBOUNCE_TIMER_ID);
+		KillTimer(hwnd, HOTPLUG_SETTLE_TIMER_ID);
 		first_debounce_tick = 0;
+		settle_wait_start_tick = 0;
 		if (!DestroyWindow(hwnd))
 		{
 			log_error("DestroyWindow");

--- a/libusb/os/windows_hotplug.h
+++ b/libusb/os/windows_hotplug.h
@@ -28,14 +28,6 @@ int windows_stop_event_monitor(void);
 
 void windows_initial_scan_devices(struct libusb_context *ctx);
 
-// Whether announcements may be withheld; temporarily false while the scan
-// forced by the settle-retry ceiling runs, so no device is withheld forever
-bool windows_hotplug_defer_arrivals(void);
-
-// Called for each device left announce-pending: wakes the event thread so a
-// retry scan runs even without further device tree broadcasts
-void windows_hotplug_arrival_deferred(void);
-
 // Implemented by the WinUSB backend: whether the last scan materialized at
 // least one interface path for the device, and whether its driver stack is
 // fully settled per live PnP state

--- a/libusb/os/windows_hotplug.h
+++ b/libusb/os/windows_hotplug.h
@@ -28,4 +28,18 @@ int windows_stop_event_monitor(void);
 
 void windows_initial_scan_devices(struct libusb_context *ctx);
 
+// Whether announcements may be withheld; temporarily false while the scan
+// forced by the settle-retry ceiling runs, so no device is withheld forever
+bool windows_hotplug_defer_arrivals(void);
+
+// Called for each device left announce-pending: wakes the event thread so a
+// retry scan runs even without further device tree broadcasts
+void windows_hotplug_arrival_deferred(void);
+
+// Implemented by the WinUSB backend: whether the last scan materialized at
+// least one interface path for the device, and whether its driver stack is
+// fully settled per live PnP state
+bool windows_hotplug_device_usable(struct libusb_device *dev);
+bool windows_hotplug_device_settled(struct libusb_device *dev);
+
 #endif

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -37,6 +37,10 @@
 #include "libusbi.h"
 #include "windows_winusb.h"
 
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+#include "windows_hotplug.h"
+#endif
+
 #define HANDLE_VALID(h) (((h) != NULL) && ((h) != INVALID_HANDLE_VALUE))
 
 // The below macro is used in conjunction with safe loops.
@@ -191,6 +195,9 @@ static bool init_dlls(struct libusb_context *ctx)
 	DLL_GET_HANDLE(ctx, Cfgmgr32);
 	DLL_LOAD_FUNC(Cfgmgr32, CM_Get_Parent, true);
 	DLL_LOAD_FUNC(Cfgmgr32, CM_Get_Child, true);
+	DLL_LOAD_FUNC(Cfgmgr32, CM_Get_Sibling, true);
+	DLL_LOAD_FUNC(Cfgmgr32, CM_Get_DevNode_Status, true);
+	DLL_LOAD_FUNC(Cfgmgr32, CM_Get_DevNode_Registry_PropertyA, true);
 
 	// Prefixed to avoid conflict with header files
 	DLL_GET_HANDLE(ctx, AdvAPI32);
@@ -474,6 +481,99 @@ static struct libusb_device *get_ancestor(struct libusb_context *ctx,
 
 	return dev;
 }
+
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+/*
+ * Whether Windows has finished bringing up a devnode's driver stack.
+ *
+ * A devnode is final once started (DN_STARTED) or once Windows gave up on
+ * it (DN_HAS_PROBLEM): waiting longer cannot help then, so such a device
+ * gets announced as-is. usbccgp and HidUsb expose their functionality
+ * through child devnodes they create asynchronously after starting, so the
+ * walk recurses through those, and only those: a hub's children are
+ * independent devices with their own lifecycle.
+ */
+static bool windows_devnode_settled(struct libusb_context *ctx, struct winusb_device_priv *priv,
+	DEVINST devinst, unsigned int depth)
+{
+	ULONG status, problem;
+	char service[64];
+	ULONG size = sizeof(service);
+	ULONG reg_type;
+	DEVINST child_devinst;
+	CONFIGRET cr;
+	bool is_hidusb;
+
+	if (depth > 4)
+		return true; // Never seen on USB; do not let a cyclic tree hang us
+
+	cr = CM_Get_DevNode_Status(&status, &problem, devinst, 0);
+	if (cr != CR_SUCCESS) {
+		usbi_warn(ctx, "could not get devnode status for device '%s' (CR error %lu), assuming settled",
+			priv->dev_id, ULONG_CAST(cr));
+		return true;
+	}
+
+	if (status & DN_HAS_PROBLEM)
+		return true;
+
+	if (!(status & DN_STARTED))
+		return false;
+
+	if (CM_Get_DevNode_Registry_PropertyA(devinst, CM_DRP_SERVICE, &reg_type, service, &size, 0) != CR_SUCCESS)
+		return true;
+
+	is_hidusb = (_stricmp(service, "HidUsb") == 0);
+	if (!is_hidusb && (_stricmp(service, "usbccgp") != 0))
+		return true;
+
+	if (CM_Get_Child(&child_devinst, devinst, 0) != CR_SUCCESS)
+		return false; // the expected child devnodes have not been created yet
+
+	do {
+		if (!windows_devnode_settled(ctx, priv, child_devinst, depth + 1))
+			return false;
+	} while (CM_Get_Sibling(&child_devinst, child_devinst, 0) == CR_SUCCESS);
+
+	return true;
+}
+
+// The device's session id is its DEVINST (see the GEN pass)
+bool windows_hotplug_device_settled(struct libusb_device *dev)
+{
+	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
+
+	return windows_devnode_settled(DEVICE_CTX(dev), priv, (DEVINST)dev->session_data, 0);
+}
+
+// Judged from what the scans actually materialized (the same state
+// libusb_open will use), not from live PnP state, which can disagree with
+// the device interface snapshot a scan enumerates.
+bool windows_hotplug_device_usable(struct libusb_device *dev)
+{
+	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
+	int i;
+
+	if (priv->path == NULL)
+		return false;
+
+	switch (priv->apib->id) {
+	case USB_API_COMPOSITE:
+	case USB_API_HID:
+		for (i = 0; i < USB_MAXINTERFACES; i++) {
+			if (priv->usb_interface[i].path != NULL)
+				return true;
+		}
+		return false;
+	case USB_API_HUB:
+	case USB_API_UNSUPPORTED:
+		return false;
+	default:
+		// WinUSB-like APIs operate on the device path itself
+		return true;
+	}
+}
+#endif
 
 /*
  * Determine which interface the given endpoint address belongs to
@@ -2399,6 +2499,12 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 						usbi_warn(ctx, "could not retrieve port number for device '%s': %s", dev_id, windows_error_str(0));
 					r = init_device(dev, parent_dev, (uint8_t)port_nr, dev_info_data.DevInst);
 					usbi_mutex_unlock(&priv->interface_lock);
+#if defined(LIBUSB_WINDOWS_HOTPLUG)
+					// Withhold DEVICE_ARRIVED until the scan proves the
+					// device usable (windows_resolve_pending_announcements)
+					if (r == LIBUSB_SUCCESS)
+						priv->announce_pending = true;
+#endif
 				}
 				if (r == LIBUSB_SUCCESS) {
 					// Append device to the list of discovered devices

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -541,7 +541,7 @@ static bool windows_devnode_settled(struct libusb_context *ctx, struct winusb_de
 // The device's session id is its DEVINST (see the GEN pass)
 bool windows_hotplug_device_settled(struct libusb_device *dev)
 {
-	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
+	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 
 	return windows_devnode_settled(DEVICE_CTX(dev), priv, (DEVINST)dev->session_data, 0);
 }
@@ -551,7 +551,7 @@ bool windows_hotplug_device_settled(struct libusb_device *dev)
 // the device interface snapshot a scan enumerates.
 bool windows_hotplug_device_usable(struct libusb_device *dev)
 {
-	struct winusb_device_priv *priv = usbi_get_device_priv(dev);
+	struct winusb_device_priv *priv = (struct winusb_device_priv *)usbi_get_device_priv(dev);
 	int i;
 
 	if (priv->path == NULL)
@@ -2502,8 +2502,10 @@ static int winusb_get_device_list(struct libusb_context *ctx, struct discovered_
 #if defined(LIBUSB_WINDOWS_HOTPLUG)
 					// Withhold DEVICE_ARRIVED until the scan proves the
 					// device usable (windows_resolve_pending_announcements)
-					if (r == LIBUSB_SUCCESS)
+					if (r == LIBUSB_SUCCESS) {
 						priv->announce_pending = true;
+						priv->pending_since = GetTickCount64();
+					}
 #endif
 				}
 				if (r == LIBUSB_SUCCESS) {

--- a/libusb/os/windows_winusb.h
+++ b/libusb/os/windows_winusb.h
@@ -233,10 +233,20 @@ typedef RETURN_TYPE CONFIGRET;
 
 #define CR_SUCCESS	0x00000000
 
+/* Devnode status flags (from cfg.h) */
+#define DN_STARTED	0x00000008	// Is currently configured
+#define DN_HAS_PROBLEM	0x00000400	// Need device installer
+
+/* Devnode registry properties (from cfgmgr32.h) */
+#define CM_DRP_SERVICE	0x00000005
+
 /* Cfgmgr32 dependencies */
 DLL_DECLARE_HANDLE(Cfgmgr32);
 DLL_DECLARE_FUNC(WINAPI, CONFIGRET, CM_Get_Parent, (PDEVINST, DEVINST, ULONG));
 DLL_DECLARE_FUNC(WINAPI, CONFIGRET, CM_Get_Child, (PDEVINST, DEVINST, ULONG));
+DLL_DECLARE_FUNC(WINAPI, CONFIGRET, CM_Get_Sibling, (PDEVINST, DEVINST, ULONG));
+DLL_DECLARE_FUNC(WINAPI, CONFIGRET, CM_Get_DevNode_Status, (PULONG, PULONG, DEVINST, ULONG));
+DLL_DECLARE_FUNC(WINAPI, CONFIGRET, CM_Get_DevNode_Registry_PropertyA, (DEVINST, ULONG, PULONG, PVOID, PULONG, ULONG));
 
 /* AdvAPI32 dependencies */
 DLL_DECLARE_HANDLE(AdvAPI32);


### PR DESCRIPTION
Windows makes a device visible, such that libusb can fully initialize it, before its driver stack is up. For a composite device the gap is large: the function interface paths only exist once usbccgp has created and started a child devnode per function (for HID functions, one level further down via HidUsb): a DEVICE_ARRIVED fired during that gap announces a device that cannot be opened, and the application is never notified again once the interfaces appear later.

Fix: a newly initialized device is attached as before, but DEVICE_ARRIVED is withheld. Once all passes of a scan have run, the device is announced when:

- the scan produced at least one interface path for it, which is exactly what libusb_open needs,

or

- a previous scan found its driver stack fully settled, and the current scan, which started after that observation, still produced no interface path: at that point no usable interface is coming (e.g. all functions use in-box drivers), so the device is announced as-is. The settled check is a recursive devnode-status walk in which usbccgp and HidUsb nodes must have created their children.

Otherwise the device stays pending and is re-examined on each scan, driven by the broadcasts of the ongoing bring-up plus a retry timer, and released at the latest by a 5 s ceiling.

DEVICE_LEFT is only fired for announced devices.

Devices present at libusb_init are still delivered through LIBUSB_HOTPLUG_ENUMERATE.

Two design points that were easy to get wrong:

- the pending device must stay attached: if it is hidden, its function devnodes would themselves be enumerated as (bogus) devices, and the interface passes would then attach the interfaces to those instead of to the real parent.

- usability must be judged from what the scan actually produced, not from live PnP state: the scan enumerates device interfaces from a snapshot taken once at scan start, so when a device finishes its bring-up mid-scan, a live query says it is ready while its interfaces, registered after the snapshot, are invisible to that very scan.

Non-hotplug builds are unaffected.

References #1920 (Item 1)