### PR TITLE
suppress some clang static analyzer false positives with asserts

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -492,16 +492,19 @@ enum usbi_event_flags {
 /* Macros for managing event handling state */
 static inline int usbi_handling_events(struct libusb_context *ctx)
 {
+	assert(ctx);
 	return usbi_tls_key_get(ctx->event_handling_key) != NULL;
 }
 
 static inline void usbi_start_event_handling(struct libusb_context *ctx)
 {
+	assert(ctx);
 	usbi_tls_key_set(ctx->event_handling_key, ctx);
 }
 
 static inline void usbi_end_event_handling(struct libusb_context *ctx)
 {
+	assert(ctx);
 	usbi_tls_key_set(ctx->event_handling_key, NULL);
 }
 

--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -111,6 +111,8 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 	int completed = 0;
 	int r;
 
+	assert(dev_handle);
+
 	if (usbi_handling_events(usbi_handle_ctx(dev_handle)))
 		return LIBUSB_ERROR_BUSY;
 
@@ -181,6 +183,8 @@ static int do_sync_bulk_transfer(struct libusb_device_handle *dev_handle,
 	struct libusb_transfer *transfer;
 	int completed = 0;
 	int r;
+
+	assert(dev_handle);
 
 	if (usbi_handling_events(usbi_handle_ctx(dev_handle)))
 		return LIBUSB_ERROR_BUSY;
@@ -339,6 +343,7 @@ int API_EXPORTED libusb_interrupt_transfer(libusb_device_handle *dev_handle,
 	unsigned char endpoint, unsigned char *data, int length,
 	int *transferred, unsigned int timeout)
 {
+	assert(dev_handle);
 	return do_sync_bulk_transfer(dev_handle, endpoint, data, length,
 		transferred, timeout, LIBUSB_TRANSFER_TYPE_INTERRUPT);
 }


### PR DESCRIPTION
The clang static analyzer warning of possible NULL deref, but in fact the API contract for these functions requires passing non-NULL.

Make that obvious to both the analyzer and human readers with asserts.