### PR TITLE
build: link Emscripten examples and tests as C++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,13 @@ windows)
 	;;
 emscripten)
 	# Note: LT_LDFLAGS is not enough here because we need link flags for executable.
-	EM_LDFLAGS="--bind -s ASYNCIFY"
+	dnl The WebUSB backend (os/emscripten_webusb.cpp) is C++, so libusb-1.0
+	dnl pulls in the C++ runtime. Emscripten 6.0.6 disabled DEFAULT_TO_CXX,
+	dnl making em++ mandatory for C++ links; without it every C program that
+	dnl links libusb (the examples and tests here, and downstream users
+	dnl building with emcc) fails with undefined std:: symbols. Setting it
+	dnl back restores the pre-6.0.6 behaviour and is a no-op on older SDKs.
+	EM_LDFLAGS="--bind -s ASYNCIFY -s DEFAULT_TO_CXX"
 	AM_LDFLAGS="${AM_LDFLAGS} ${EM_LDFLAGS} -s ASSERTIONS -s ALLOW_MEMORY_GROWTH"
 	LIBS="${LIBS} ${EM_LDFLAGS}"
 	;;


### PR DESCRIPTION
## Problem

The `linux` workflow has been failing on `master` since 2026-08-07. The `emscripten`
step dies while linking the examples and tests:

```
wasm-ld: error: ../libusb/.libs/libusb-1.0.a(emscripten_webusb.o): undefined symbol: vtable for std::bad_optional_access
wasm-ld: error: ../libusb/.libs/libusb-1.0.a(emscripten_webusb.o): undefined symbol: std::__2::bad_function_call::~bad_function_call()
wasm-ld: error: ../libusb/.libs/libusb-1.0.a(emscripten_webusb.o): undefined symbol: std::logic_error::logic_error(char const*)
wasm-ld: error: ../libusb/.libs/libusb-1.0.a(emscripten_webusb.o): undefined symbol: __cxa_throw
emcc: warning: link failed with undefined C++ symbols. Try linking with 'em++' or passing '-sDEFAULT_TO_CXX'
```

Nothing in the tree caused it. The only libusb commit between the last green run
(2026-08-04) and the first red one is a documentation change. The trigger is the
toolchain: `emscripten-core/setup-emsdk` is not pinned, so CI moved from emsdk
6.0.5 to 6.0.6, whose changelog reads:

> `DEFAULT_TO_CXX` is now disabled by default. This means that `em++` is now
> required when linking C++ programs, matching the behavior of clang and gcc.

The WebUSB backend, `libusb/os/emscripten_webusb.cpp`, is C++, so `libusb-1.0.a`
carries C++ objects. As of 6.0.6 any `emcc` link that does not itself select C++
mode therefore fails — here the examples and tests, which are C programs that
automake links with `emcc` (`CCLD`).

## Fix

Add `-s DEFAULT_TO_CXX` to `EM_LDFLAGS`. `configure` already feeds `EM_LDFLAGS` into
both `AM_LDFLAGS` and `LIBS`, and both paths are needed: `examples/Makefile.am` clears
`LIBS`, while `tests/Makefile.am` overrides `AM_LDFLAGS`. Going through `LIBS` also
records the flag in `Libs.private` of `libusb-1.0.pc`, where downstream users who link
C programs against an Emscripten libusb with `emcc` pick it up from a static
pkg-config query.

`DEFAULT_TO_CXX` is not a diagnostic suppression: Emscripten maps both `em++` and this
setting onto the same internal C++ link mode, which is what pulls in libc++ and
libc++abi. The backend already requires Emscripten 3.1.48 or newer, and the setting
was on by default throughout that range until 6.0.6, so setting it explicitly is a
no-op on every older SDK libusb supports.

## Affected build context

This changes only the Emscripten/WebAssembly build. The edit is inside the
`emscripten)` branch of the backend `case` in `configure.ac`, so the primary C library
build is unaffected on every other backend.

## Verification

Reproduced and fixed locally against emsdk `latest`
(`emcc 6.0.6 (ce75e06884093bcefb86a6b8fd56a5d62a4cc245)`), the same version CI resolves,
running the CI command `emconfigure .private/ci-build.sh --build-dir build-emscripten -- --host=wasm32-unknown-emscripten`:

- **Before:** `make` fails; no example or test binary is produced.
- **After:** all 8 examples (`dpfp`, `dpfp_threaded`, `fxload`, `hotplugtest`, `listdevs`,
  `sam3u_benchmark`, `testlibusb`, `xusb`) and all 5 tests (`stress`, `stress_mt`,
  `set_option`, `init_context`, `testcore`) compile and link, and `make` exits 0.

In CI this also unblocks the four steps that had been skipped behind the failure since
2026-08-04 (`umockdev test`, the sanitized ASan/UBSan rebuild, the staged install, and
the BOS descriptor fuzzer smoke test); all of them pass.

Fixes: #1928

Assisted-by: claude-code:claude-opus-5
