### PR TITLE
emscripten: fix transfer helpers and version warnings

### DIFF
--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -1657,13 +1657,13 @@ static inline bool usbi_is_xferout(const struct libusb_transfer *xfer)
 #define TRANSFER_CTX(transfer) \
 	usbi_transfer_ctx(transfer)
 #define IS_EPIN(ep) \
-	usbi_is_ep_in(ep)
+	usbi_is_epin(ep)
 #define IS_EPOUT(ep) \
-	usbi_is_ep_out(ep)
+	usbi_is_epout(ep)
 #define IS_XFERIN(xfer) \
-	usbi_is_xfer_in(xfer)
+	usbi_is_xferin(xfer)
 #define IS_XFEROUT(xfer) \
-	usbi_is_xfer_out(xfer)
+	usbi_is_xferout(xfer)
 
 
 #define for_each_context(c) \

--- a/libusb/os/emscripten_webusb.cpp
+++ b/libusb/os/emscripten_webusb.cpp
@@ -25,8 +25,19 @@
 
 #include <emscripten/version.h>
 
-static_assert((__EMSCRIPTEN_major__ * 100 * 100 + __EMSCRIPTEN_minor__ * 100 +
-			   __EMSCRIPTEN_tiny__) >= 30148,
+#if defined(__EMSCRIPTEN_MAJOR__)
+#define USBI_EMSCRIPTEN_MAJOR __EMSCRIPTEN_MAJOR__
+#define USBI_EMSCRIPTEN_MINOR __EMSCRIPTEN_MINOR__
+#define USBI_EMSCRIPTEN_TINY __EMSCRIPTEN_TINY__
+#else
+/* Emscripten 3.1.48 provides only the legacy mixed-case version macros. */
+#define USBI_EMSCRIPTEN_MAJOR __EMSCRIPTEN_major__
+#define USBI_EMSCRIPTEN_MINOR __EMSCRIPTEN_minor__
+#define USBI_EMSCRIPTEN_TINY __EMSCRIPTEN_tiny__
+#endif
+
+static_assert((USBI_EMSCRIPTEN_MAJOR * 100 * 100 + USBI_EMSCRIPTEN_MINOR * 100 +
+			   USBI_EMSCRIPTEN_TINY) >= 30148,
 			  "Emscripten 3.1.48 or newer is required.");
 
 #include <assert.h>
@@ -782,7 +793,7 @@ int em_submit_transfer(usbi_transfer* itransfer) REQUIRES(itransfer->lock) {
 				auto endpoint =
 					transfer->endpoint & LIBUSB_ENDPOINT_ADDRESS_MASK;
 
-				if (usbi_is_xfer_in(transfer)) {
+				if (usbi_is_xferin(transfer)) {
 					transfer_promise = web_usb_device.call<val>(
 						"transferIn", endpoint, transfer->length);
 				} else {


### PR DESCRIPTION
## Summary

- Fix the WebUSB backend call to the existing `usbi_is_xferin()` helper after the macro-to-inline-function conversion in #1729.
- Fix the internal compatibility aliases to call the existing endpoint and transfer direction helpers.
- Map current and legacy Emscripten version macros to project-local `USBI_EMSCRIPTEN_*` aliases and use one minimum-version assertion.

## Context and compatibility

The WebUSB backend builds `emscripten_webusb.cpp` as C++. Emscripten 6.0.6 deprecates the mixed-case version macros. Emscripten 3.1.48 provides only those mixed-case forms, so the project-local aliases preserve the existing minimum SDK requirement without defining implementation-reserved identifiers. The aliases remain in this implementation translation unit.

This change does not modify the public API or ABI. The primary C library build is unaffected.

The hosted link steps still emit the pre-existing `-Wpthreads-mem-growth` performance notice. WebUSB requires `-pthread`, and this build intentionally permits memory growth. Changing either setting would change runtime behavior, so that notice is outside this PR.

## Validation

- [Hosted Linux PR run 31888182222](https://github.com/libusb/libusb/actions/runs/31888182222) passed. Its Emscripten step passed, and its log contains none of the reported mixed-case macro warnings or the invalid `usbi_is_xfer_in` call.
- Emscripten 3.1.48: configure, compile, and link passed through the legacy version-macro path.
- Current and legacy version-alias paths: C++20 syntax checks with `-Werror` passed; the minimum-version assertion accepts 3.1.48 and rejects 3.1.47.
- Primary C build: `.private/ci-build.sh --werror --build-dir build-local-primary-2 -- --enable-debug-log` passed.
- Internal compatibility aliases: GCC syntax check with `-Werror` passed.
- `git diff --check origin/master` passed.

Observed in [master Actions run 31880910116](https://github.com/libusb/libusb/actions/runs/31880910116).

Related to #1729

Assisted-by: Codex:GPT-5.6 Sol