### PR TITLE
ci: Do not trigger workflows on PR label events

### DIFF
--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -9,9 +9,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -19,22 +20,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/illumos.yml
+++ b/.github/workflows/illumos.yml
@@ -17,9 +17,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -27,22 +28,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   omnios:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -83,10 +74,6 @@ jobs:
             gmake check || { cat tests/test-suite.log; exit 1; }
 
   openindiana:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -123,10 +110,6 @@ jobs:
             gmake check || { cat tests/test-suite.log; exit 1; }
 
   solaris:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,9 +7,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -17,22 +18,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   c23:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     name: GCC 16 / C23
     runs-on: ubuntu-latest
     container: gcc:16
@@ -63,10 +54,6 @@ jobs:
           make -j"$(nproc)"
 
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,9 +9,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -19,14 +20,8 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # A workflow run is made up of one or more jobs that can run
@@ -34,10 +29,6 @@ concurrency:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: macos-latest
     timeout-minutes: 60
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -6,9 +6,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -16,22 +17,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64-aarch64.yml
+++ b/.github/workflows/msys2_clang64-aarch64.yml
@@ -6,9 +6,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -16,22 +17,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: windows-11-arm
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/msys2_clang64.yml
+++ b/.github/workflows/msys2_clang64.yml
@@ -6,9 +6,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -16,22 +17,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: windows-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -9,9 +9,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -19,22 +20,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -9,9 +9,10 @@ on:
     tags:
       - '**'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
-# Keep the long-running stress test on master unless a PR explicitly opts in.
+# Keep the long-running stress test on master unless a PR opts in with a
+# force_testcore or force_long_tests label. Labels are read from the event
+# payload, so a newly added label takes effect on the next push or reopen.
 env:
   TESTCORE_CONFIGURE_FLAG: >-
     ${{ (github.ref == 'refs/heads/master' ||
@@ -19,22 +20,12 @@ env:
          contains(github.event.pull_request.labels.*.name, 'force_long_tests'))
         && '--enable-testcore' || '' }}
 
-# Isolate unrelated label events from code and force-label CI runs.
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
-      github.event.action == 'labeled' &&
-      github.event.label.name != 'force_testcore' &&
-      github.event.label.name != 'force_long_tests' &&
-      github.run_id || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    if: >-
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'force_testcore' ||
-      github.event.label.name == 'force_long_tests'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary

Remove the `labeled` trigger from the nine CI workflows.

Each label added to a PR started all nine workflows that subscribe to the `labeled` event (added in #1913 for the `force_testcore` / `force_long_tests` opt-in). For all other labels, every job was skipped by the label guard. Each label change still created nine "skipped" workflow runs, and their skipped check runs replaced the green check results on the PR head commit. This is what made CI look skipped in #1945. No real CI run was lost.

Evidence:

- PR #1942: label `macOS` added 2026-08-23 02:29:41Z → nine skipped runs at 02:29:44Z.
- PR #1940: label `test` added 2026-08-21 01:14:54Z → nine skipped runs at 01:14:57Z.
- All 18 skipped runs in the last 200 runs map 1:1 to these two label events.
- Only the nine workflows with the `labeled` trigger show skipped runs; windows, android and CIFuzz never do.
- The concurrent-job limit theory does not match the data: quota pressure leaves runs queued, never "skipped", and these runs completed within about 1 second of creation.

## Changes

- Drop `types: [opened, synchronize, reopened, labeled]`. A bare `pull_request:` trigger has the same three default types, minus `labeled`.
- Restore the simple concurrency group, identical to windows.yml and android.yml.
- Remove the per-job label guards.

The `force_testcore` / `force_long_tests` labels still work. The workflows read the label state from the event payload, so a new label takes effect on the PR's next push or close/reopen. GitHub search shows no PR has carried either label so far, so no workflow use depends on the immediate label-triggered run.

Fixes: #1945

Assisted-by: claude-code:claude-fable-5
