### PR TITLE
docs: fix doxygen 1.18 documentation build errors

### DIFF
--- a/libusb/descriptor.c
+++ b/libusb/descriptor.c
@@ -1829,7 +1829,7 @@ int usbi_get_interface_string_index(libusb_device *dev,
  *   active one; otherwise \ref LIBUSB_ERROR_NOT_SUPPORTED is returned even
  *   though the requested configuration is valid.  In that case the string
  *   can still be read by opening the device and calling
- *   \ref libusb_get_string_descriptor() with the iConfiguration index.
+ *   \ref libusb_get_string_descriptor with the iConfiguration index.
  * - Backends that do not implement this function always return
  *   \ref LIBUSB_ERROR_NOT_SUPPORTED.
  */
@@ -1902,7 +1902,7 @@ int API_EXPORTED libusb_get_config_string(libusb_device *dev,
  *   index) with the current one; otherwise \ref LIBUSB_ERROR_NOT_SUPPORTED
  *   is returned even though the requested combination is valid.  In that
  *   case the string can still be read by opening the device and calling
- *   \ref libusb_get_string_descriptor() with the iInterface index.
+ *   \ref libusb_get_string_descriptor with the iInterface index.
  * - Backends that do not implement this function always return
  *   \ref LIBUSB_ERROR_NOT_SUPPORTED.
  */

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1731,11 +1731,12 @@ typedef void (LIBUSB_CALL *libusb_log_cb)(libusb_context *ctx,
 struct libusb_init_option {
 	/** Which option to set */
 	enum libusb_option option;
-	/** An integer value used by the option (if applicable). */
 	union {
+		/** An integer value used by the option. */
 		int ival;
+		/** A log callback used by the option. */
 		libusb_log_cb log_cbval;
-	} value;
+	} value; /**< The value used by the option (if applicable). */
 };
 
 int LIBUSB_CALL libusb_init(libusb_context **ctx);


### PR DESCRIPTION
Doxygen 1.18.0 (the current Homebrew formula) fails the documentation build with
five errors. Doxygen 1.9.8 (Ubuntu CI) and 1.14.0 do not report them, so only the
macOS job breaks. Both errors are behaviour changes in doxygen 1.18, not
platform differences, so pinning the macOS doxygen version would only postpone
them.

## Root cause 1: `\ref name()` no longer resolves to a `static` function

`libusb_get_string_descriptor()` is `static inline` in `libusb.h`. Doxygen 1.18
no longer matches the `name()` form of `\ref` to a file-scope function. Minimal
reproducer, independent of libusb:

```c
/* a.h */
/** \defgroup grp A group
 * @{ */
/** \ingroup grp
 * \param x an int
 * \returns int */
static inline int stat_fn(int x) { return x; }
/** \ingroup grp
 * \param x an int
 * \returns int */
int ext_fn(int x);
/** @} */

/* b.c */
#include "a.h"
/** \ingroup grp
 * R1 \ref stat_fn()
 * R2 \ref stat_fn
 * R3 \ref ext_fn()
 * R4 \ref ext_fn
 * \returns int */
int user_fn(void) { return stat_fn(1) + ext_fn(2); }
```

| doxygen | R1 `\ref stat_fn()` | R2 `\ref stat_fn` | R3 `\ref ext_fn()` | R4 `\ref ext_fn` |
| --- | --- | --- | --- | --- |
| 1.9.8  | link | link | link | link |
| 1.14.0 | link | link | link | link |
| 1.18.0 | **unresolved** | link | link | link |

The form without parentheses resolves on every version and still produces the
hyperlink, so the two references in `descriptor.c` drop the parentheses.

## Root cause 2: the anonymous union in `struct libusb_init_option` is undocumented

Doxygen 1.18 no longer shows the documentation of an anonymous union in place of
the documentation of the member (1.18.0 changelog, doxygen issue 12226). The
comment before `union {` therefore documents the union, which leaves `value`,
`ival` and `log_cbval` undocumented. Each member now carries its own comment.
The old text also said "An integer value" for a union that holds an int *or* a
log callback.

## Verification

`doc/doxygen.cfg` generated from the repository configuration
(`WARN_AS_ERROR = FAIL_ON_WARNINGS`, `GENERATE_MAN = YES`):

| doxygen | before | after |
| --- | --- | --- |
| 1.9.8  | pass | pass |
| 1.14.0 | pass | pass |
| 1.18.0 | 5 errors | pass |

The generated output keeps the `libusb_get_string_descriptor` hyperlinks and the
`libusb_init_option` field descriptions on all three versions.

The change is documentation comments only. The public API and ABI do not change.
`gcc -std=c99` and `g++ -std=c++11` still compile a translation unit that
includes `libusb.h` and uses `struct libusb_init_option`.

Fixes: #1946

Assisted-by: claude-code:claude-opus-5
