### PR TITLE
io: fix transfer private pointer for C++ builds

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1343,7 +1343,7 @@ void API_EXPORTED libusb_free_transfer(struct libusb_transfer *transfer)
 	if (itransfer->dev)
 		libusb_unref_device(itransfer->dev);
 
-	unsigned char *ptr = usbi_transfer_to_transfer_priv(itransfer);
+	void *ptr = usbi_transfer_to_transfer_priv(itransfer);
 	assert(ptr == itransfer->priv);
 	free(ptr);
 }


### PR DESCRIPTION
## Summary

- Keep the transfer-private pointer as `void *`, which matches the helper return type.
- Restore building libusb's C sources as C++ on Linux, macOS, and Windows.
- Leave the primary C library build unchanged.

## Cause

PR #1729 changed `usbi_transfer_to_transfer_priv()` to return `void *`. Its caller still assigned the result to `unsigned char *`. C permits this implicit conversion. C++ requires an explicit conversion and stops the build.

The caller only compares and frees the pointer. It does not perform byte-pointer operations, so `void *` is the correct local type.

PR #1845 exposed the error in its Linux, macOS, and Windows C++ build jobs. The separate macOS `va_start` warning remains handled by #1904.

## Verification

- Linux C++20 build from #1845 passes with `g++`.
- Windows Release x64 build from #1845 passes with MSVC, `/TP`, `/W4`, and `/WX`: 0 warnings and 0 errors.
- Primary Linux C configure and build pass with `gcc`.
- Primary C `make check` passes.
- `git diff --check` passes.
- `libusb/libusb.h` is unchanged.

Related to #1729.
Related to #1845.
Related to #1904.

Assisted-by: codex:GPT-5.6-Sol
