### PR TITLE
CI: Add clang-tidy review workflow

### DIFF
--- a/.github/scripts/prepare-clang-tidy-review.jq
+++ b/.github/scripts/prepare-clang-tidy-review.jq
@@ -1,0 +1,46 @@
+# Convert untrusted action output into a bounded advisory review.
+def positive_integer:
+  type == "number" and . >= 1 and . <= 2147483647 and floor == .;
+
+def safe_path:
+  type == "string" and
+  length > 0 and length <= 4096 and
+  (startswith("/") | not) and
+  (contains("\\") | not) and
+  (index("\u0000") == null) and
+  (split("/") | all(. != "" and . != "." and . != ".."));
+
+def valid_comment:
+  type == "object" and
+  ((.body | type) == "string") and
+  ((.body | length) > 0 and (.body | length) <= 65536) and
+  (.path | safe_path) and
+  (.line | positive_integer) and
+  ((has("start_line") | not) or
+   ((.start_line | positive_integer) and .start_line <= .line));
+
+def canonical_comment:
+  {body, path, line, side: "RIGHT"} +
+  (if has("start_line") then
+     {start_line, start_side: "RIGHT"}
+   else
+     {}
+   end);
+
+if . == null then
+  null
+elif type != "object" or (.comments | type) != "array" then
+  error("review must be null or contain a comments array")
+elif (.comments | length) == 0 then
+  null
+elif (.comments | length) > 1000 then
+  error("review contains more than 1000 comments")
+elif (all(.comments[]; valid_comment) | not) then
+  error("review contains an invalid comment")
+else
+  {
+    body: "clang-tidy made some suggestions",
+    event: "COMMENT",
+    comments: [.comments[] | canonical_comment]
+  }
+end

--- a/.github/scripts/prepare-clang-tidy-review.jq
+++ b/.github/scripts/prepare-clang-tidy-review.jq
@@ -10,22 +10,29 @@ def safe_path:
   (index("\u0000") == null) and
   (split("/") | all(. != "" and . != "." and . != ".."));
 
+def diagnostic_body:
+  split("\n")[0] | rtrimstr("\r");
+
 def valid_comment:
   type == "object" and
   ((.body | type) == "string") and
   ((.body | length) > 0 and (.body | length) <= 65536) and
+  ((.body | diagnostic_body | length) > 0 and
+   (.body | diagnostic_body | length) <= 4096) and
   (.path | safe_path) and
   (.line | positive_integer) and
   ((has("start_line") | not) or
    ((.start_line | positive_integer) and .start_line <= .line));
 
 def canonical_comment:
-  {body, path, line, side: "RIGHT"} +
-  (if has("start_line") then
-     {start_line, start_side: "RIGHT"}
-   else
-     {}
-   end);
+  # The action calculates fix text with character offsets, but clang-tidy
+  # reports byte offsets. Do not pass potentially corrupt fix blocks on.
+  {
+    body: (.body | diagnostic_body),
+    path,
+    line: (.start_line // .line),
+    side: "RIGHT"
+  };
 
 if . == null then
   null
@@ -39,7 +46,7 @@ elif (all(.comments[]; valid_comment) | not) then
   error("review contains an invalid comment")
 else
   {
-    body: "clang-tidy made some suggestions",
+    body: "clang-tidy reported warnings",
     event: "COMMENT",
     comments: [.comments[] | canonical_comment]
   }

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,54 +21,59 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: master
+
+      - name: find source pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # workflow_run.pull_requests can be empty, so use trusted head data.
+          pull_requests=$(gh api -X GET "repos/$GITHUB_REPOSITORY/pulls" \
+            -f state=open \
+            -f base=master \
+            -f head="$HEAD_OWNER:$HEAD_BRANCH" \
+            -f per_page=100)
+          number=$(jq -er \
+            --arg head_repository "$HEAD_REPOSITORY" \
+            --arg head_sha "$HEAD_SHA" '
+            [.[] |
+             select(.head.repo.full_name == $head_repository and
+                    .head.sha == $head_sha)] |
+            unique_by(.number) |
+            if length == 1 then .[0].number else empty end
+          ' <<< "$pull_requests")
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
       - name: download review data
         uses: actions/download-artifact@v8
         with:
           name: clang-tidy-review
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/clang-tidy-review
 
-      - name: validate review data
+      - name: prepare advisory review
         env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          ARTIFACT_DIR: ${{ runner.temp }}/clang-tidy-review
+          EXPECTED_PR: ${{ steps.pull-request.outputs.number }}
         run: |
-          pull_requests=$(gh api -X GET "repos/$GITHUB_REPOSITORY/pulls" \
-            -f state=open \
-            -f base=master \
-            -f head="$HEAD_OWNER:$HEAD_BRANCH")
-          expected_pr=$(jq -er --arg head_sha "$HEAD_SHA" '
-            [.[] | select(.head.sha == $head_sha)] |
-            unique_by(.number) |
-            if length == 1 then .[0].number else empty end
-          ' <<< "$pull_requests")
-          actual_pr=$(jq -er \
-            'select(keys == ["pr_number"]) | .pr_number | numbers' \
-            clang-tidy-review-metadata.json)
-          test "$actual_pr" = "$expected_pr"
-          jq -e '
-            . == null or
-            ((keys | sort) == ["body", "comments", "event"] and
-             (.body | type) == "string" and
-             .event == "COMMENT" and
-             (.comments | type) == "array" and
-             ((.comments | length) == 0 or
-              .body == "clang-tidy made some suggestions") and
-             all(.comments[];
-               ((keys - ["body", "line", "path", "side",
-                         "start_line", "start_side"]) | length) == 0 and
-               (.path | type) == "string" and
-               (.path | startswith("/") | not) and
-               (.path | contains("..") | not) and
-               (.body | type) == "string" and
-               .side == "RIGHT" and
-               (.line | type) == "number" and .line >= 1 and
-               ((has("start_side") | not) or .start_side == "RIGHT") and
-               ((has("start_line") | not) or
-                ((.start_line | type) == "number" and .start_line >= 1))))
-          ' clang-tidy-review-output.json
+          review_file="$ARTIFACT_DIR/clang-tidy-review-output.json"
+          test -f "$review_file"
+          test ! -L "$review_file"
+          test "$(stat -c %s "$review_file")" -le 1048576
+          # Rebuild control fields instead of trusting the fork artifact.
+          jq -f .github/scripts/prepare-clang-tidy-review.jq \
+            "$review_file" > clang-tidy-review-output.json
+          jq -n --argjson pr_number "$EXPECTED_PR" \
+            '{pr_number: $pr_number}' > clang-tidy-review-metadata.json
 
       - name: post review comments
         uses: ZedThree/clang-tidy-review/post@v0.21.0

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -1,0 +1,78 @@
+name: post clang-tidy review
+
+on:
+  workflow_run:
+    workflows:
+      - clang-tidy
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  post:
+    name: review comments
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: download review data
+        uses: actions/download-artifact@v8
+        with:
+          name: clang-tidy-review
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: validate review data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pull_requests=$(gh api -X GET "repos/$GITHUB_REPOSITORY/pulls" \
+            -f state=open \
+            -f base=master \
+            -f head="$HEAD_OWNER:$HEAD_BRANCH")
+          expected_pr=$(jq -er --arg head_sha "$HEAD_SHA" '
+            [.[] | select(.head.sha == $head_sha)] |
+            unique_by(.number) |
+            if length == 1 then .[0].number else empty end
+          ' <<< "$pull_requests")
+          actual_pr=$(jq -er \
+            'select(keys == ["pr_number"]) | .pr_number | numbers' \
+            clang-tidy-review-metadata.json)
+          test "$actual_pr" = "$expected_pr"
+          jq -e '
+            . == null or
+            ((keys | sort) == ["body", "comments", "event"] and
+             (.body | type) == "string" and
+             .event == "COMMENT" and
+             (.comments | type) == "array" and
+             ((.comments | length) == 0 or
+              .body == "clang-tidy made some suggestions") and
+             all(.comments[];
+               ((keys - ["body", "line", "path", "side",
+                         "start_line", "start_side"]) | length) == 0 and
+               (.path | type) == "string" and
+               (.path | startswith("/") | not) and
+               (.path | contains("..") | not) and
+               (.body | type) == "string" and
+               .side == "RIGHT" and
+               (.line | type) == "number" and .line >= 1 and
+               ((has("start_side") | not) or .start_side == "RIGHT") and
+               ((has("start_line") | not) or
+                ((.start_line | type) == "number" and .start_line >= 1))))
+          ' clang-tidy-review-output.json
+
+      - name: post review comments
+        uses: ZedThree/clang-tidy-review/post@v0.21.0
+        with:
+          lgtm_comment_body: ''
+          max_comments: '25'
+          num_comments_as_exitcode: 'false'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,182 @@
+name: clang-tidy
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  CLANG_TIDY_BUILD_DIR: build-clang-tidy
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  review:
+    name: changed lines
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            autoconf automake bear clang-18 jq libtool libudev-dev \
+            libumockdev-dev m4 pkg-config umockdev
+
+      - name: configure
+        run: |
+          ./bootstrap.sh
+          mkdir "$CLANG_TIDY_BUILD_DIR-udev" "$CLANG_TIDY_BUILD_DIR-netlink"
+          cd "$CLANG_TIDY_BUILD_DIR-udev"
+          CC=clang-18 CXX=clang++-18 ../configure \
+            --enable-examples-build \
+            --enable-tests-build \
+            --enable-udev
+          cd "../$CLANG_TIDY_BUILD_DIR-netlink"
+          CC=clang-18 CXX=clang++-18 ../configure \
+            --enable-examples-build \
+            --enable-tests-build \
+            --disable-udev
+
+      - name: generate compilation database
+        run: |
+          bear --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            make -C "$CLANG_TIDY_BUILD_DIR-udev" -j"$(nproc)"
+          bear --output "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" -- \
+            make -C "$CLANG_TIDY_BUILD_DIR-netlink" -j"$(nproc)"
+          bear --append \
+            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            clang-18 -std=c99 -D_GNU_SOURCE \
+              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
+              -I"$GITHUB_WORKSPACE/libusb" \
+              -c tests/fuzz/fuzz_bos_descriptor.c \
+              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_bos_descriptor.o"
+          bear --append \
+            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            clang-18 -std=c99 -D_GNU_SOURCE -Wno-macro-redefined \
+              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
+              -I"$GITHUB_WORKSPACE/libusb" \
+              -c tests/fuzz/fuzz_descriptor_parsers.c \
+              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_descriptor_parsers.o"
+          for build_dir in \
+            "$CLANG_TIDY_BUILD_DIR-udev" \
+            "$CLANG_TIDY_BUILD_DIR-netlink"; do
+            jq 'unique_by(.file)' "$build_dir/compile_commands.json" \
+              > "$build_dir/compile_commands.tmp"
+            mv "$build_dir/compile_commands.tmp" \
+              "$build_dir/compile_commands.json"
+          done
+          mkdir "$CLANG_TIDY_BUILD_DIR"
+          jq -s 'add | unique_by(.file)' \
+            "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" \
+            "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" \
+            > "$CLANG_TIDY_BUILD_DIR/compile_commands.json"
+
+      - name: review changed lines
+        uses: ZedThree/clang-tidy-review@v0.21.0
+        with:
+          build_dir: ${{ env.CLANG_TIDY_BUILD_DIR }}
+          clang_tidy_version: '18'
+          config_file: .clang-tidy
+          # Internal headers need translation-unit context. The full scan checks them.
+          include: '*.c,libusb/libusb.h'
+          exclude: 'android/*,msvc/*,tests/macos.c,libusb/os/darwin_*,libusb/os/emscripten_*,libusb/os/haiku_*,libusb/os/netbsd_*,libusb/os/null_*,libusb/os/openbsd_*,libusb/os/sunos_*,libusb/os/*windows*'
+          apt_packages: libudev-dev,libumockdev-dev,umockdev
+          parallel: '2'
+          split_workflow: true
+
+      - name: upload review data
+        uses: actions/upload-artifact@v7
+        with:
+          name: clang-tidy-review
+          path: |
+            clang-tidy-review-output.json
+            clang-tidy-review-metadata.json
+            clang_tidy_review.yaml
+          if-no-files-found: error
+          retention-days: 7
+
+  full:
+    name: full Linux source set
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: setup prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            autoconf automake bear clang-18 clang-tidy-18 jq \
+            libtool libudev-dev libumockdev-dev m4 pkg-config umockdev
+
+      - name: configure
+        run: |
+          ./bootstrap.sh
+          mkdir "$CLANG_TIDY_BUILD_DIR-udev" "$CLANG_TIDY_BUILD_DIR-netlink"
+          cd "$CLANG_TIDY_BUILD_DIR-udev"
+          CC=clang-18 CXX=clang++-18 ../configure \
+            --enable-examples-build \
+            --enable-tests-build \
+            --enable-udev
+          cd "../$CLANG_TIDY_BUILD_DIR-netlink"
+          CC=clang-18 CXX=clang++-18 ../configure \
+            --enable-examples-build \
+            --enable-tests-build \
+            --disable-udev
+
+      - name: generate compilation database
+        run: |
+          bear --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            make -C "$CLANG_TIDY_BUILD_DIR-udev" -j"$(nproc)"
+          bear --output "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" -- \
+            make -C "$CLANG_TIDY_BUILD_DIR-netlink" -j"$(nproc)"
+          bear --append \
+            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            clang-18 -std=c99 -D_GNU_SOURCE \
+              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
+              -I"$GITHUB_WORKSPACE/libusb" \
+              -c tests/fuzz/fuzz_bos_descriptor.c \
+              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_bos_descriptor.o"
+          bear --append \
+            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
+            clang-18 -std=c99 -D_GNU_SOURCE -Wno-macro-redefined \
+              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
+              -I"$GITHUB_WORKSPACE/libusb" \
+              -c tests/fuzz/fuzz_descriptor_parsers.c \
+              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_descriptor_parsers.o"
+
+      - name: check all compiled sources
+        run: |
+          status=0
+          run-clang-tidy-18 \
+            -p "$CLANG_TIDY_BUILD_DIR-udev" \
+            -j 2 \
+            -config-file="$GITHUB_WORKSPACE/.clang-tidy" \
+            -header-filter='^.*/(libusb|examples|tests)/.*' \
+            -warnings-as-errors='*' || status=$?
+          run-clang-tidy-18 \
+            -p "$CLANG_TIDY_BUILD_DIR-netlink" \
+            -j 2 \
+            -config-file="$GITHUB_WORKSPACE/.clang-tidy" \
+            -header-filter='^.*/(libusb|examples|tests)/.*' \
+            -warnings-as-errors='*' || status=$?
+          exit "$status"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -86,15 +86,27 @@ jobs:
             "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" \
             > "$CLANG_TIDY_BUILD_DIR/compile_commands.json"
 
+      - name: select compiled review sources
+        id: review-sources
+        run: |
+          sources=$(jq -er --arg root "$GITHUB_WORKSPACE/" '
+            [.[].file |
+             if startswith($root) then ltrimstr($root)
+             else error("source outside the workspace: \(.)")
+             end] |
+            unique |
+            if length > 0 then join(",") else empty end
+          ' "$CLANG_TIDY_BUILD_DIR/compile_commands.json")
+          # Internal headers need translation-unit context. The full scan checks them.
+          printf 'include=%s,libusb/libusb.h\n' "$sources" >> "$GITHUB_OUTPUT"
+
       - name: review changed lines
         uses: ZedThree/clang-tidy-review@v0.21.0
         with:
           build_dir: ${{ env.CLANG_TIDY_BUILD_DIR }}
           clang_tidy_version: '18'
           config_file: .clang-tidy
-          # Internal headers need translation-unit context. The full scan checks them.
-          include: '*.c,libusb/libusb.h'
-          exclude: 'android/*,msvc/*,tests/macos.c,libusb/os/darwin_*,libusb/os/emscripten_*,libusb/os/haiku_*,libusb/os/netbsd_*,libusb/os/null_*,libusb/os/openbsd_*,libusb/os/sunos_*,libusb/os/*windows*'
+          include: ${{ steps.review-sources.outputs.include }}
           apt_packages: libudev-dev,libumockdev-dev,umockdev
           parallel: '2'
           split_workflow: true
@@ -103,10 +115,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: clang-tidy-review
-          path: |
-            clang-tidy-review-output.json
-            clang-tidy-review-metadata.json
-            clang_tidy_review.yaml
+          path: clang-tidy-review-output.json
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,21 +20,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  review:
-    name: changed lines
-    if: github.event_name == 'pull_request'
+  check:
+    name: ${{ github.event_name == 'pull_request' && 'changed lines' || 'full Linux source set' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.ref || 'master' }}
 
       - name: setup prerequisites
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            autoconf automake bear clang-18 jq libtool libudev-dev \
+            autoconf automake bear clang-18 clang-tidy-18 jq libtool libudev-dev \
             libumockdev-dev m4 pkg-config umockdev
 
       - name: configure
@@ -52,7 +52,7 @@ jobs:
             --enable-tests-build \
             --disable-udev
 
-      - name: generate compilation database
+      - name: generate compilation databases
         run: |
           bear --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
             make -C "$CLANG_TIDY_BUILD_DIR-udev" -j"$(nproc)"
@@ -72,6 +72,10 @@ jobs:
               -I"$GITHUB_WORKSPACE/libusb" \
               -c tests/fuzz/fuzz_descriptor_parsers.c \
               -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_descriptor_parsers.o"
+
+      - name: prepare review compilation database
+        if: github.event_name == 'pull_request'
+        run: |
           for build_dir in \
             "$CLANG_TIDY_BUILD_DIR-udev" \
             "$CLANG_TIDY_BUILD_DIR-netlink"; do
@@ -87,6 +91,7 @@ jobs:
             > "$CLANG_TIDY_BUILD_DIR/compile_commands.json"
 
       - name: select compiled review sources
+        if: github.event_name == 'pull_request'
         id: review-sources
         run: |
           sources=$(jq -er --arg root "$GITHUB_WORKSPACE/" '
@@ -101,6 +106,7 @@ jobs:
           printf 'include=%s,libusb/libusb.h\n' "$sources" >> "$GITHUB_OUTPUT"
 
       - name: review changed lines
+        if: github.event_name == 'pull_request'
         uses: ZedThree/clang-tidy-review@v0.21.0
         with:
           build_dir: ${{ env.CLANG_TIDY_BUILD_DIR }}
@@ -112,6 +118,7 @@ jobs:
           split_workflow: true
 
       - name: upload review data
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: clang-tidy-review
@@ -119,61 +126,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  full:
-    name: full Linux source set
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: master
-
-      - name: setup prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            autoconf automake bear clang-18 clang-tidy-18 jq \
-            libtool libudev-dev libumockdev-dev m4 pkg-config umockdev
-
-      - name: configure
-        run: |
-          ./bootstrap.sh
-          mkdir "$CLANG_TIDY_BUILD_DIR-udev" "$CLANG_TIDY_BUILD_DIR-netlink"
-          cd "$CLANG_TIDY_BUILD_DIR-udev"
-          CC=clang-18 CXX=clang++-18 ../configure \
-            --enable-examples-build \
-            --enable-tests-build \
-            --enable-udev
-          cd "../$CLANG_TIDY_BUILD_DIR-netlink"
-          CC=clang-18 CXX=clang++-18 ../configure \
-            --enable-examples-build \
-            --enable-tests-build \
-            --disable-udev
-
-      - name: generate compilation database
-        run: |
-          bear --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            make -C "$CLANG_TIDY_BUILD_DIR-udev" -j"$(nproc)"
-          bear --output "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" -- \
-            make -C "$CLANG_TIDY_BUILD_DIR-netlink" -j"$(nproc)"
-          bear --append \
-            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            clang-18 -std=c99 -D_GNU_SOURCE \
-              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
-              -I"$GITHUB_WORKSPACE/libusb" \
-              -c tests/fuzz/fuzz_bos_descriptor.c \
-              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_bos_descriptor.o"
-          bear --append \
-            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            clang-18 -std=c99 -D_GNU_SOURCE -Wno-macro-redefined \
-              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
-              -I"$GITHUB_WORKSPACE/libusb" \
-              -c tests/fuzz/fuzz_descriptor_parsers.c \
-              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_descriptor_parsers.o"
-
       - name: check all compiled sources
+        if: github.event_name != 'pull_request'
         run: |
           status=0
           run-clang-tidy-18 \

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -37,73 +37,13 @@ jobs:
             autoconf automake bear clang-18 clang-tidy-18 jq libtool libudev-dev \
             libumockdev-dev m4 pkg-config umockdev
 
-      - name: configure
-        run: |
-          ./bootstrap.sh
-          mkdir "$CLANG_TIDY_BUILD_DIR-udev" "$CLANG_TIDY_BUILD_DIR-netlink"
-          cd "$CLANG_TIDY_BUILD_DIR-udev"
-          CC=clang-18 CXX=clang++-18 ../configure \
-            --enable-examples-build \
-            --enable-tests-build \
-            --enable-udev
-          cd "../$CLANG_TIDY_BUILD_DIR-netlink"
-          CC=clang-18 CXX=clang++-18 ../configure \
-            --enable-examples-build \
-            --enable-tests-build \
-            --disable-udev
-
-      - name: generate compilation databases
-        run: |
-          bear --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            make -C "$CLANG_TIDY_BUILD_DIR-udev" -j"$(nproc)"
-          bear --output "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" -- \
-            make -C "$CLANG_TIDY_BUILD_DIR-netlink" -j"$(nproc)"
-          bear --append \
-            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            clang-18 -std=c99 -D_GNU_SOURCE \
-              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
-              -I"$GITHUB_WORKSPACE/libusb" \
-              -c tests/fuzz/fuzz_bos_descriptor.c \
-              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_bos_descriptor.o"
-          bear --append \
-            --output "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" -- \
-            clang-18 -std=c99 -D_GNU_SOURCE -Wno-macro-redefined \
-              -I"$GITHUB_WORKSPACE/$CLANG_TIDY_BUILD_DIR-udev" \
-              -I"$GITHUB_WORKSPACE/libusb" \
-              -c tests/fuzz/fuzz_descriptor_parsers.c \
-              -o "$CLANG_TIDY_BUILD_DIR-udev/fuzz_descriptor_parsers.o"
+      - name: build compilation databases
+        run: .private/ci-clang-tidy.sh build
 
       - name: prepare review compilation database
         if: github.event_name == 'pull_request'
-        run: |
-          for build_dir in \
-            "$CLANG_TIDY_BUILD_DIR-udev" \
-            "$CLANG_TIDY_BUILD_DIR-netlink"; do
-            jq 'unique_by(.file)' "$build_dir/compile_commands.json" \
-              > "$build_dir/compile_commands.tmp"
-            mv "$build_dir/compile_commands.tmp" \
-              "$build_dir/compile_commands.json"
-          done
-          mkdir "$CLANG_TIDY_BUILD_DIR"
-          jq -s 'add | unique_by(.file)' \
-            "$CLANG_TIDY_BUILD_DIR-udev/compile_commands.json" \
-            "$CLANG_TIDY_BUILD_DIR-netlink/compile_commands.json" \
-            > "$CLANG_TIDY_BUILD_DIR/compile_commands.json"
-
-      - name: select compiled review sources
-        if: github.event_name == 'pull_request'
         id: review-sources
-        run: |
-          sources=$(jq -er --arg root "$GITHUB_WORKSPACE/" '
-            [.[].file |
-             if startswith($root) then ltrimstr($root)
-             else error("source outside the workspace: \(.)")
-             end] |
-            unique |
-            if length > 0 then join(",") else empty end
-          ' "$CLANG_TIDY_BUILD_DIR/compile_commands.json")
-          # Internal headers need translation-unit context. The full scan checks them.
-          printf 'include=%s,libusb/libusb.h\n' "$sources" >> "$GITHUB_OUTPUT"
+        run: .private/ci-clang-tidy.sh prepare-review --github-output "$GITHUB_OUTPUT"
 
       - name: review changed lines
         if: github.event_name == 'pull_request'
@@ -128,18 +68,4 @@ jobs:
 
       - name: check all compiled sources
         if: github.event_name != 'pull_request'
-        run: |
-          status=0
-          run-clang-tidy-18 \
-            -p "$CLANG_TIDY_BUILD_DIR-udev" \
-            -j 2 \
-            -config-file="$GITHUB_WORKSPACE/.clang-tidy" \
-            -header-filter='^.*/(libusb|examples|tests)/.*' \
-            -warnings-as-errors='*' || status=$?
-          run-clang-tidy-18 \
-            -p "$CLANG_TIDY_BUILD_DIR-netlink" \
-            -j 2 \
-            -config-file="$GITHUB_WORKSPACE/.clang-tidy" \
-            -header-filter='^.*/(libusb|examples|tests)/.*' \
-            -warnings-as-errors='*' || status=$?
-          exit "$status"
+        run: .private/ci-clang-tidy.sh check-full

--- a/.private/ci-clang-tidy.sh
+++ b/.private/ci-clang-tidy.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage()
+{
+	echo "Usage: $0 build" >&2
+	echo "       $0 prepare-review --github-output FILE" >&2
+	echo "       $0 check-full" >&2
+	exit 2
+}
+
+if [ $# -lt 1 ]; then
+	usage
+fi
+
+command=$1
+shift
+
+case "${command}" in
+build|check-full)
+	[ $# -eq 0 ] || usage
+	;;
+prepare-review)
+	if [ $# -ne 2 ] || [ "$1" != "--github-output" ]; then
+		usage
+	fi
+	github_output=$2
+	;;
+*)
+	usage
+	;;
+esac
+
+: "${CLANG_TIDY_BUILD_DIR:?CLANG_TIDY_BUILD_DIR must be set}"
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+project_dir=$(cd -- "${script_dir}/.." && pwd -P)
+case "${CLANG_TIDY_BUILD_DIR}" in
+/*)
+	build_dir=${CLANG_TIDY_BUILD_DIR}
+	;;
+*)
+	build_dir="${project_dir}/${CLANG_TIDY_BUILD_DIR}"
+	;;
+esac
+udev_build_dir="${build_dir}-udev"
+netlink_build_dir="${build_dir}-netlink"
+cc=${CC:-clang-18}
+cxx=${CXX:-clang++-18}
+run_clang_tidy=${RUN_CLANG_TIDY:-run-clang-tidy-18}
+
+build()
+{
+	cd "${project_dir}"
+	./bootstrap.sh
+	mkdir "${udev_build_dir}" "${netlink_build_dir}"
+	(
+		cd "${udev_build_dir}"
+		CC="${cc}" CXX="${cxx}" "${project_dir}/configure" \
+			--enable-examples-build \
+			--enable-tests-build \
+			--enable-udev
+	)
+	(
+		cd "${netlink_build_dir}"
+		CC="${cc}" CXX="${cxx}" "${project_dir}/configure" \
+			--enable-examples-build \
+			--enable-tests-build \
+			--disable-udev
+	)
+
+	bear --output "${udev_build_dir}/compile_commands.json" -- \
+		make -C "${udev_build_dir}" -j"$(nproc)"
+	bear --output "${netlink_build_dir}/compile_commands.json" -- \
+		make -C "${netlink_build_dir}" -j"$(nproc)"
+	bear --append --output "${udev_build_dir}/compile_commands.json" -- \
+		"${cc}" -std=c99 -D_GNU_SOURCE \
+			-I"${udev_build_dir}" \
+			-I"${project_dir}/libusb" \
+			-c tests/fuzz/fuzz_bos_descriptor.c \
+			-o "${udev_build_dir}/fuzz_bos_descriptor.o"
+	bear --append --output "${udev_build_dir}/compile_commands.json" -- \
+		"${cc}" -std=c99 -D_GNU_SOURCE -Wno-macro-redefined \
+			-I"${udev_build_dir}" \
+			-I"${project_dir}/libusb" \
+			-c tests/fuzz/fuzz_descriptor_parsers.c \
+			-o "${udev_build_dir}/fuzz_descriptor_parsers.o"
+}
+
+prepare_review()
+{
+	mkdir "${build_dir}"
+	jq -s 'add | unique_by(.file)' \
+		"${udev_build_dir}/compile_commands.json" \
+		"${netlink_build_dir}/compile_commands.json" \
+		> "${build_dir}/compile_commands.json"
+
+	sources=$(jq -er --arg root "${project_dir}/" '
+		[.[].file |
+		 if startswith($root) then ltrimstr($root)
+		 else error("source outside the workspace: \(.)")
+		 end] |
+		unique |
+		if length > 0 then join(",") else empty end
+	' "${build_dir}/compile_commands.json")
+	# Internal headers need translation-unit context. The full scan checks them.
+	printf 'include=%s,libusb/libusb.h\n' "${sources}" >> "${github_output}"
+}
+
+check_full()
+{
+	status=0
+	"${run_clang_tidy}" \
+		-p "${udev_build_dir}" \
+		-j 2 \
+		-config-file="${project_dir}/.clang-tidy" \
+		-header-filter='^.*/(libusb|examples|tests)/.*' \
+		-warnings-as-errors='*' || status=$?
+	"${run_clang_tidy}" \
+		-p "${netlink_build_dir}" \
+		-j 2 \
+		-config-file="${project_dir}/.clang-tidy" \
+		-header-filter='^.*/(libusb|examples|tests)/.*' \
+		-warnings-as-errors='*' || status=$?
+	return "${status}"
+}
+
+case "${command}" in
+build)
+	build
+	;;
+prepare-review)
+	prepare_review
+	;;
+check-full)
+	check_full
+	;;
+esac


### PR DESCRIPTION
## Summary

- Review added and modified compiled C lines with `clang-tidy-review` and post advisory inline warnings. The split workflow supports pull requests from forks without giving fork code write access.
- Validate and rebuild the untrusted review artifact in the trusted poster. Current action releases misread clang byte offsets after non-ASCII text, so the poster keeps the diagnostic and removes potentially corrupt fix blocks.
- Generate Autotools compilation databases with Bear for the udev and netlink configurations. Include umockdev tests and both fuzz targets.
- Run a full Linux source scan against `master` on manual dispatch and each Monday at 04:17 UTC. Full-scan findings fail that job.

The compilation database is still required. The action can generate one for CMake, but libusb uses Autotools.

`clang-tidy-review@v0.21.0` uses Ubuntu 24.04 and Clang 18. Later releases currently use the end-of-life Ubuntu 25.10 base image. The repository has no `v0.21` moving tag, so the workflow uses the specific release tag.

Internal headers need translation-unit context. Pull-request review checks changed C files and `libusb/libusb.h`; the full scan checks internal headers through the compiled translation units.

## Testing

- [Upstream changed-lines run](https://github.com/libusb/libusb/actions/runs/32994579165) on the current PR head
- Fork-safe duplicate-include test: [draft PR](https://github.com/Youw/libusb/pull/2), [analysis](https://github.com/Youw/libusb/actions/runs/32994746769), [trusted poster](https://github.com/Youw/libusb/actions/runs/32995060345), and [inline warning](https://github.com/Youw/libusb/pull/2#discussion_r3865213561)
- Fork-safe macro-parentheses test: [draft PR](https://github.com/Youw/libusb/pull/3), [analysis](https://github.com/Youw/libusb/actions/runs/32995187477), [trusted poster](https://github.com/Youw/libusb/actions/runs/32995472685), and [inline warning](https://github.com/Youw/libusb/pull/3#discussion_r3865244670)
- [Manual full-source run](https://github.com/Youw/libusb/actions/runs/32992667648) completed setup and compilation-database generation, then failed as configured on existing repository-wide findings
- `actionlint` 1.7.12
- Clean udev and netlink Autotools builds in WSL with Bear, umockdev, and both fuzz targets
- The trusted sanitizer was validated with both raw action artifacts

Related to https://github.com/Youw/libusb/pull/2
Related to https://github.com/Youw/libusb/pull/3
Closes: #1678

Assisted-by: Codex:GPT-5.6 Sol
