### PR TITLE
docs: update libusb_open event handling description

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1114,21 +1114,18 @@ printf("completed!\n");
  *    again. One of them will succeed; it will then re-obtain the list of poll
  *    descriptors, and USB I/O will then continue as normal.
  *
- * libusb_open() is similar, and is actually a more simplistic case. Upon a
- * call to libusb_open():
+ * libusb_open() is simpler. Upon a call to libusb_open():
  *
- * -# The device is opened and a file descriptor is added to the poll set.
- * -# libusb sends some dummy data on the event pipe, and records that it
- *    is trying to modify the poll descriptor set.
- * -# The event handler is interrupted, and the same behaviour change as for
- *    libusb_close() takes effect, causing all event handling threads to become
- *    event waiters.
- * -# The libusb_open() implementation takes its free ride to the events lock.
- * -# Happy that it has successfully paused the events handler, libusb_open()
- *    releases the events lock.
- * -# The event waiter threads are all woken up and compete to become event
- *    handlers again. The one that succeeds will obtain the list of poll
- *    descriptors again, which will include the addition of the new device.
+ * -# The backend opens the device and adds any new event source to the
+ *    context's event-source list.
+ * -# libusb records the event-source change while holding the event-data lock
+ *    and ensures that the event handler is notified.
+ * -# The event handler notices the change, rebuilds its event-source list, and
+ *    resumes polling with the new source.
+ *
+ * Unlike libusb_close(), this path does not acquire the events lock. Adding an
+ * event source only requires interrupting the current poll; it does not require
+ * pausing all event handlers.
  *
  * \subsection concl Closing remarks
  *


### PR DESCRIPTION
Fixes: #1938

Update the `libusb_open()` section of the multi-threaded I/O documentation to match the current implementation. Opening a device adds any backend event source to the context, records the source change under the event-data lock, notifies the event handler, and lets it rebuild the event-source list. Unlike `libusb_close()`, opening a device does not acquire the events lock.

The description was checked against `usbi_add_event_source()` and `handle_events()` in the current source, and the historical change that removed the events-lock acquisition (`7ede4b76`) was verified.

Validation:
- `git diff --check`
- Source-level cross-check of `libusb/io.c` and `libusb/core.c`
- The repository's C build tools are not installed in this Windows environment, so a full C build was not run.

This documentation change was prepared with Codex assistance.

Assisted-by: Codex:GPT-5.6 Sol