### PR TITLE
windows: restore struct timeval in the public header

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -53,6 +53,15 @@ jobs:
           msystem: ${{ matrix.msystem }}
           update: true
           install: ${{ matrix.packages }}
+      # Syntax-only check of the public header's include contract; needs the
+      # source tree only. -Werror matters here: mingw-w64 reports a wrong
+      # winsock order with #warning, not an error.
+      - name: Check public header include order
+        run: >-
+          gcc -fsyntax-only -Wall -Wextra -Werror -Ilibusb
+          .private/win32-header-check.c &&
+          gcc -fsyntax-only -Wall -Wextra -Werror -DWIN32_LEAN_AND_MEAN -Ilibusb
+          .private/win32-header-check.c
       - name: bootstrap
         run: ./bootstrap.sh
       - name: Build, test and install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,6 +90,18 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v3
 
+      # Syntax-only, so this needs no build. WIN32_LEAN_AND_MEAN makes windows.h
+      # skip winsock.h, which is the case that regressed in 1.0.30.
+      - name: Check public header include order
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSDIR=%%i"
+          call "%VSDIR%\VC\Auxiliary\Build\vcvarsall.bat" x64
+          if errorlevel 1 exit /b 1
+          cl /nologo /W4 /WX /Zs /I libusb .private\win32-header-check.c
+          if errorlevel 1 exit /b 1
+          cl /nologo /W4 /WX /Zs /I libusb /D WIN32_LEAN_AND_MEAN .private\win32-header-check.c
+
       - name: Build ${{ matrix.configuration_family.first }}
         id: first_build
         continue-on-error: true

--- a/.private/win32-header-check.c
+++ b/.private/win32-header-check.c
@@ -1,0 +1,24 @@
+/*
+ * Compile-only check of the libusb.h include contract on Windows.
+ *
+ * CI compiles this file twice, with and without WIN32_LEAN_AND_MEAN. The
+ * define stops windows.h from pulling in winsock.h, which is how an
+ * application can end up with neither winsock version in scope.
+ *
+ * References #1937 and #1509.
+ */
+
+#include "libusb.h"
+
+/* #1937: struct timeval must be complete with libusb.h as the only include. */
+int win32_header_check_timeval(libusb_context *ctx);
+int win32_header_check_timeval(libusb_context *ctx)
+{
+	struct timeval tv = { 1, 0 };
+
+	return libusb_handle_events_timeout_completed(ctx, &tv, NULL);
+}
+
+/* #1509: deliberately included last. Winsock v2 after libusb.h must not
+ * collide with a winsock v1 that libusb.h let windows.h pull in. */
+#include <winsock2.h>

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -65,6 +65,12 @@ typedef SSIZE_T ssize_t;
  * As this can be problematic if you include windows.h after libusb.h
  * in your sources, we force windows.h to be included first. */
 #if defined(_WIN32) || defined(__CYGWIN__)
+#if !defined(__CYGWIN__) && !defined(_WINSOCKAPI_)
+/* struct timeval comes from winsock. Include Winsock v2 first, because
+ * windows.h would otherwise pull in the incompatible v1 winsock.h. Skipped
+ * when winsock is already included, to keep the includer's choice. */
+#include <winsock2.h>
+#endif
 #include <windows.h>
 #if defined(interface)
 #undef interface


### PR DESCRIPTION
`libusb.h` again gives applications a complete `struct timeval` on MSVC, and it
no longer forces Winsock 1 on them.

#1657 removed `#include <winsock.h>` from `libusb.h` for 1.0.30. On MSVC
`libusb.h` skips `<sys/time.h>` and `<time.h>` has no `struct timeval`, so the
only remaining source was the `winsock.h` that `windows.h` pulls in. An
application that defines `WIN32_LEAN_AND_MEAN` gets neither header, so it cannot
declare the `struct timeval` that `libusb_handle_events_timeout_completed()` and
the related functions take (#1937).

That same `winsock.h` also collides with a `winsock2.h` that the application
includes after `libusb.h`. #1509 reported this and was closed as fixed by #1657,
but it was not: `windows.h` still pulls in Winsock 1.

This change includes `<winsock2.h>` before `windows.h`, which is what #1509 first
proposed. The `_WINSOCKAPI_` guard skips the include when winsock is already in
scope. libusb's own Windows backends include `windows.h` first, so they are
unchanged, and every application include order that works today keeps working.
No public declaration changes.

Two effects on applications, both unavoidable if #1509 is to stay fixed:

- Code that includes `libusb.h` now gets Winsock 2 in place of Winsock 1. A call
  to a legacy name such as `inet_addr()` gets the C4996 deprecation warning,
  which is an error under `/WX`.
- Code that declared its own `struct timeval` to work around #1937 must remove
  that declaration, or `winsock2.h` reports C2011.

CI now compiles `.private/win32-header-check.c` twice, with and without
`WIN32_LEAN_AND_MEAN`, on MSVC and on MinGW. Both compiles fail on master.

Verified locally on Windows 11 with the Windows SDK 10.0.26100:

- MSVC (VS 2026, v145): full `msvc/libusb.sln` build, Debug x64, clean.
- MSVC, clang-cl, and mingw-w64 (x86_64 and i686): the new check fails on master
  and passes here, at `/W4 /WX` and `-Wall -Wextra -Werror`, as C and as C++20.
  MSVC also checked for x86, x64, and ARM64.
- Application include orders unchanged: `libusb.h` alone; `windows.h` first;
  `windows.h` first with `WIN32_LEAN_AND_MEAN`; `winsock2.h` first; `winsock.h`
  first; `windows.h` after `libusb.h`; `_WINSOCKAPI_` defined first.

Known limit: under a non-desktop `WINAPI_FAMILY`, an application that includes
`windows.h` before `libusb.h` still has no `struct timeval`, because the SDK
`winsock.h` sets `_WINSOCKAPI_` outside its desktop-only body. That case also
fails on master, and libusb does not support that target.

Fixes: #1937
Closes: #1509

Assisted-by: claude-code:claude-opus-5
